### PR TITLE
fix(tests): skip destructive skills in test_mcp_all_tools + incident report

### DIFF
--- a/docs/INCIDENT-2026-05-01-spurious-skill-fires.md
+++ b/docs/INCIDENT-2026-05-01-spurious-skill-fires.md
@@ -1,0 +1,278 @@
+# Incident: spurious skill fires (reminders, notes, qr_generator, voice_note, terminal_note)
+
+**Date:** 2026-05-01
+**Reporter:** user
+**Investigator:** Claude Code (this session)
+**Status:** ROOT-CAUSED — see Conclusions
+**Severity:** LOW — no production code regression. Two issues, both pre-existing and pre-Step-1.
+
+---
+
+## TL;DR
+
+The 5 reminders fires in `~/.codec/audit.log` today at 07:57:22-26 UTC are **NOT spurious**. They are real Apple Reminders that **Claude Code (a previous session) intentionally created** to schedule the Phase 1 Step 2 post-merge monitoring checkpoints (T+4h, T+8h, T+12h, T+16h, T+20h). Same for yesterday's 5 fires at 07:27:24-29 UTC (Phase 1 Step 1 monitoring).
+
+**Step 1 and Step 2 did NOT cause this.** The fires happened ON BOTH days (Apr 30 + May 1), including BEFORE Step 1 was merged in production. The audit-log appearance changed because Step 1 unified the envelope schema (transport went from `stdio` → `local` because the stdio MCP variant doesn't set `CODEC_MCP_TRANSPORT=stdio` env var, and `_transport_for("codec")` defaults to `"local"`).
+
+There is **no rogue plugin, no auto-firing test, no recursive emit loop, no autopilot trigger**. All six initial hypotheses (H1–H6) are either ruled out or partially-true-but-not-the-cause.
+
+There IS a separate, lower-priority pre-existing issue: `tests/test_mcp_all_tools.py` has CANONICAL_PROMPTS with destructive prompts that DO have user-visible side effects when run against the OLD `~/.codec/skills/reminders.py` (no read-mode). This is a test-hygiene cleanup, not the incident.
+
+**Step 3 should NOT be reverted.** Step 3 introduces no new skill-firing code paths.
+
+---
+
+## Investigation evidence
+
+### (1) `~/.codec/plugins/` — does NOT exist
+```
+ls: /Users/mickaelfarina/.codec/plugins/: No such file or directory
+```
+**Hypothesis H2 (rogue plugin firing skills) — RULED OUT.**
+Step 2's hook system reads from `~/.codec/plugins/`. Empty dir = no plugins = `run_with_hooks` is a passthrough.
+
+### (2) `~/.codec/schedules.json` + `~/.codec/autopilot.json`
+- `schedules.json`: 2 entries — `daily_briefing` (disabled) + `deep_research` (enabled, last run Apr 27 Sun, day=[0]). Neither references reminders/notes/qr.
+- `autopilot.json`: `enabled=false`, `triggers=[]`.
+**Hypothesis H4 (a hidden schedule entry) — RULED OUT.**
+
+### (3) Pytest watcher / test daemon
+```
+ps aux | grep -E "pytest|python.*test" | grep -v grep   # → empty
+```
+**Hypothesis H3 (test watcher daemon) — RULED OUT.**
+
+### (4) Recent commits to `tests/**` `skills/**`
+```
+ef7305f docs(agents): AGENTS.md §3+§6+§7+§10 — Phase 1 Step 3 (l) [worktree only]
+49648b3 test(voice): tests/test_voice_ask_user.py [worktree only]
+... (Phase 1 Step 3 worktree commits, none merged)
+0061f2b test(hooks): 5 new test files
+05f9b80 test(audit): 5 new test files
+```
+None of these commits introduce a code path that calls reminders/notes/qr_generator/voice_note/terminal_note from production.
+
+### (5) `~/.codec/` files referencing `reminders`
+- `config.json`: lists `reminders` in the skills allowlist. Read-only configuration, doesn't fire anything.
+- `agents/test.json`, `agents/testagent.json`: include `reminders` in the tool allowlist for two test agent definitions. Just availability, no auto-run schedule.
+- `audit.log` + `audit.log.2026-04-30`: the 10 historical fires we're investigating.
+- `skills/reminders.py`: the skill itself (OLD version, no read-mode — see "secondary issue" below).
+
+### (6) Full audit-log entries at 07:57:22-26 UTC
+All 5 entries identical structure:
+```jsonc
+{
+  "ts": "2026-05-01T07:57:22.605+00:00",
+  "schema": 1,
+  "event": "tool_result",
+  "source": "codec",
+  "tool": "reminders",
+  "task_len": 176,        // varies 176-253 across the 5
+  "duration_ms": 923.83,  // varies 195-924 across the 5
+  "outcome": "ok",
+  "transport": "local",
+  "extra": { "correlation_id": "c97ee071a81c" }    // 5 distinct cids
+}
+```
+- 5 distinct correlation_ids → 5 separate operations, not nested.
+- `event=tool_result` with NO paired `tool_call`. The `tool_call` precursor would have been emitted but isn't there. **Reason:** `codec_mcp.py` only emits a `tool_result` envelope (no separate `tool_call`); the `task_len` / `duration_ms` are sufficient pairing context.
+- No `agent`, no `level`, no `message`, no `task_preview` — all consistent with `codec_mcp._audit(sname, event="tool_result", task_len=tlen, ...)` at `codec_mcp.py:263` (no extra payload beyond cid).
+
+### (7) Codebase grep — what emits `event=tool_result`?
+
+```
+codec_agents.py:553   _audit("tool_result", agent=self.name, ...) → source="codec-agents", transport="crew"
+codec_mcp.py:239,246,263,293,299,315,321   _audit(sname, event="tool_result", ...) → source defaults
+codec_voice.py        sets source="codec-voice"
+```
+
+`codec_mcp.py` is the ONLY production module that emits `event=tool_result` WITHOUT setting source. Per `codec_audit.py:194`:
+```python
+src = source or os.environ.get("CODEC_PROCESS", "codec")
+```
+Without `CODEC_PROCESS` env var, source = `"codec"`. ✓ Matches.
+
+Per `codec_audit.py` transport fallback:
+```python
+"transport": transport or os.environ.get("CODEC_MCP_TRANSPORT") or _transport_for(src),
+```
+Without `CODEC_MCP_TRANSPORT` env var, transport = `_transport_for("codec")` = `"local"` (default fallback in `_TRANSPORT_BY_SOURCE`). ✓ Matches.
+
+The PM2 ecosystem.config.js does NOT set `CODEC_PROCESS` for any process. The `codec-mcp-http` PM2 process explicitly sets `CODEC_MCP_TRANSPORT="http"` at module load (`codec_mcp_http.py:43`), so its emits would have `transport=http` — NOT `local`. **The stdio variant `codec_mcp.py` does not set this env var.**
+
+### (8) `~/.codec/` files modified in the last 24h
+Normal: memory.db, notifications.json, audit.log, skill_proposals/, qchat.db, etc. Nothing unexpected.
+
+The skill `.pyc` files in `~/.codec/skills/__pycache__/` were all touched at 13:02 today — that's pytest's import cache, not skill execution.
+
+### (9) Module-level `run()` invocations in `tests/` `skills/`
+```
+tests/test_skills.py — calculator/time_date/system_info only (NOT reminders)
+tests/test_skill_contracts.py — AST-only inspection, doesn't call run()
+tests/test_full_product_audit.py — checks "every skill has run()", doesn't call it
+tests/test_mcp_all_tools.py — DOES call mod.run(prompt) for every exposed skill ⚠
+```
+`test_mcp_all_tools.py` is a real concern — see "secondary issue" below.
+
+### (10) Cross-reference: PM2 + spawned processes
+
+```
+ps aux | grep codec_mcp:
+  codec-mcp-http      (PM2, online 3h, port 8091, CODEC_MCP_TRANSPORT=http)
+  codec_mcp.py × 3    (spawned by /Applications/Claude.app/Contents/Helpers/disclaimer)
+```
+
+**Claude.app desktop has CODEC's MCP server integrated as stdio.** It spawns multiple `codec_mcp.py` instances. These are the processes whose audit emits show source=codec, transport=local.
+
+---
+
+## What the 5 fires actually were
+
+Cross-referencing audit-log timestamps with Apple Reminders creation timestamps:
+
+| audit ts (UTC) | local ts (CEST) | Reminder name (truncated) |
+|---|---|---|
+| 2026-04-30T07:27:24.881 | 09:27:24 | "Remind me at 1:17 PM today to run the CODEC Phase 1 Step 1 T+4h audit sample…" |
+| 2026-04-30T07:27:26.024 | 09:27:25 | "Remind me at 5:17 PM today to run the CODEC Phase 1 Step 1 T+8h audit sample…" |
+| 2026-04-30T07:27:27.286 | 09:27:26 | "Remind me at 9:17 PM today to run the CODEC Phase 1 Step 1 T+12h audit sample…" |
+| 2026-04-30T07:27:28.447 | 09:27:28 | "Remind me at 1:17 AM tomorrow (May 1) to run the CODEC Phase 1 Step 1 T+16h audit sample…" |
+| 2026-04-30T07:27:29.734 | 09:27:29 | "Remind me at 5:17 AM tomorrow (May 1) to run the CODEC Phase 1 Step 1 T+20h audit sample…" |
+| 2026-05-01T07:57:22.605 | 09:57:22 | "Remind me at 1:55 PM today to capture CODEC Phase 1 Step 2 T+4h audit sample…" |
+| 2026-05-01T07:57:23.238 | 09:57:23 | "Remind me at 5:55 PM today to capture CODEC Phase 1 Step 2 T+8h audit sample…" |
+| 2026-05-01T07:57:23.772 | 09:57:23 | "Remind me at 9:55 PM today to capture CODEC Phase 1 Step 2 T+12h audit sample…" |
+| 2026-05-01T07:57:24.960 | 09:57:24 | "Remind me at 1:55 AM tomorrow (May 2) to capture CODEC Phase 1 Step 2 T+16h audit sample…" |
+| 2026-05-01T07:57:26.086 | 09:57:26 | "Remind me at 5:55 AM tomorrow (May 2) to capture CODEC Phase 1 Step 2 T+20h audit sample…" |
+
+`task_len` of 176-253 chars matches the reminder text length exactly. `duration_ms` of 195-924 is the typical Apple Reminders osascript subprocess time.
+
+**These reminders were created by Claude Code (an earlier session) executing CODEC's reminders skill via stdio MCP through Claude.app's MCP integration.** The Phase 1 Step 1 design doc and Step 2 design doc both mandate post-merge monitoring at T+0/T+4h/T+8h/T+12h/T+16h/T+20h — this was the scheduling step.
+
+Memory observation `2148 12:51p ✅ Apple Reminders scheduled for Phase 1 Step 2 24-hour monitoring checkpoints` confirms it.
+
+---
+
+## User-perceived "every few minutes for past hours"
+
+The audit-log evidence does NOT support "every few minutes":
+
+| Hour (UTC) | Records | Of which skill fires |
+|---|---|---|
+| 00 - 06 | ~5/hour | 0 (heartbeat_tick only) |
+| 07 | 12 | 5 reminders fires (the burst) |
+| 08 | 5 | 0 (heartbeat) |
+| 09 | 10 | 0 |
+| 10 | 52 | 0 (testing activity from this session) |
+| 11 | 125 | 0 (more testing — stuck_warning emits from Step 3 dev) |
+| 12 | 3 | 0 |
+
+**The user's perception of "every few minutes" is incorrect.** Likely sources of the perception:
+1. Seeing all 10 monitoring reminders accumulated in Reminders.app at once.
+2. Older test artifacts in Apple Notes (e.g., the two notes containing "test 123" — created Apr 14, 2026, NOT today).
+3. Claude.app autonomously calling CODEC tools during normal Claude conversations (this is by design — when the user uses Claude.app, the LLM may decide to use any available MCP tool). These would show up in the audit log if they happened today; they did not.
+
+---
+
+## Hypotheses ranking (per user's H1–H6)
+
+| # | Hypothesis | Verdict |
+|---|---|---|
+| H1 | Test fixture imported by production firing skills | **PARTIALLY TRUE — but NOT this incident.** `tests/test_mcp_all_tools.py` does fire real skills with destructive prompts. See secondary issue. The production audit-log entries are NOT from this path. |
+| H2 | Plugin in `~/.codec/plugins/` firing skills | **RULED OUT.** Dir does not exist. |
+| H3 | Test watcher daemon | **RULED OUT.** No pytest processes running. |
+| H4 | Hidden schedule entry | **RULED OUT.** schedules.json + autopilot.json reviewed; no entries reference the affected skills. |
+| H5 | Step 1/2 audit recursion firing skills as side-effect | **RULED OUT.** `log_event` and `audit` are file-write only, no skill invocation. `run_with_hooks` is passthrough with zero plugins. |
+| H6 | Test side-effect leaving production in test mode | **RULED OUT.** No monkeypatched function leaks observed. |
+
+**ACTUAL CAUSE:** Claude Code (an earlier session) intentionally created post-merge monitoring reminders via stdio MCP. User mistook them for spurious fires.
+
+---
+
+## Secondary issue (separate, pre-existing): test_mcp_all_tools.py side effects
+
+This is NOT the cause of the user's report, but it is a real test-hygiene problem worth fixing on the same hotfix branch.
+
+`tests/test_mcp_all_tools.py::CANONICAL_PROMPTS` has prompts that produce destructive side effects when run against the user's OLD `~/.codec/skills/reminders.py` (which has NO read mode):
+
+| Skill | Prompt | Side effect when run against OLD `~/.codec/skills/<skill>.py` |
+|---|---|---|
+| `reminders` | `"list reminders"` | Creates a real Apple Reminder named "list reminders" (the OLD version has no read-mode branch). Verified by direct call: `reminders.run("list reminders")` → returns `'Reminder added: list reminders'`. |
+| `tts_say` | `"say test"` | Speaks "say test" via macOS `say` (audible). |
+| `notes` | `"list notes"` | Opens Apple Notes briefly (read-mode hit — no creation). |
+| `qr_generator` | `"qr code for hello"` | The skill name in registry is `generate_qr_code`, not `qr_generator`. CANONICAL_PROMPTS lookup misses → falls back to `"ping"` prompt → tries to generate QR code (silently fails if `qrcode` lib missing in test env, otherwise creates `qr.png` in cwd). |
+
+When the test is run from the **worktree** or **main** repo (both of which have the FIXED `skills/reminders.py` with read-mode for "list reminders"), the reminders side effect does NOT trigger. **But** if anyone runs the test against the user's `~/.codec/skills/` directory (the runtime install), the OLD reminders.py creates real reminders.
+
+The `SKIP_SKILLS` set in test_mcp_all_tools.py was tightened in Phase 1 Step 3 to add `ask_user` and `stuck`, but reminders/notes/tts_say/qr_generator have always been side-effecting.
+
+---
+
+## Proposed fix
+
+**One PR on the `hotfix/incident-spurious-skill-fires` branch** (already created; based off main `b187b8d`).
+
+### Hotfix changes
+
+1. **`tests/test_mcp_all_tools.py`** — add the destructive-side-effect skills to `SKIP_SKILLS`:
+   ```python
+   SKIP_SKILLS = {
+       ...
+       # macOS UI side effects (writes to system apps)
+       "reminders",       # creates Apple Reminders
+       "notes",           # opens Apple Notes
+       "tts_say",         # actually speaks via macOS `say`
+       "generate_qr_code", # creates qr.png in cwd
+   }
+   ```
+   And remove the entries from `CANONICAL_PROMPTS` that map to them.
+
+2. **`docs/INCIDENT-2026-05-01-spurious-skill-fires.md`** — this document.
+
+3. **(Optional, lower-priority) `~/.codec/skills/reminders.py`** — copy the FIXED version from `skills/reminders.py` (already on main) to the user's runtime install. Since this is a user state file, prefer to instruct the user to run a one-line `cp` rather than touching it from the codebase.
+
+### Rationale for the test cleanup
+
+These skills have user-visible side effects on macOS apps. The existing `SKIP_SKILLS` set already excludes `imessage_send`, `mouse_control`, `chrome_*`, `philips_hue`, `volume_brightness`, etc. — the same hygiene reasoning applies to reminders/notes/tts_say/qr.
+
+### What's NOT in this hotfix
+
+- **No production code change.** No regression to fix.
+- **Step 1 and Step 2 stay as-is.** They are not the cause.
+- **Step 3 PR (#5) untouched.** Per the user's contract.
+- **No PM2 restart required.** Hotfix is test-only.
+- **No `_HTTP_BLOCKED` change.** Per the user's don't-touch-zone contract.
+
+---
+
+## Step 1 / Step 2 status
+
+**Both steps stay merged.** The audit-log appearance change is just the schema unification (transport went from `stdio` (legacy emit) → `local` (default fallback when CODEC_MCP_TRANSPORT is unset)). It is a cosmetic improvement for analyzability, not a regression.
+
+A minor follow-up could set `CODEC_MCP_TRANSPORT=stdio` for the stdio MCP variant (currently codec_mcp.py doesn't set it; only codec_mcp_http.py sets it to "http"). This would restore `transport=stdio` for the stdio path — purely a tagging cleanup, separable from the hotfix.
+
+---
+
+## Reproducibility for review
+
+Direct verification that today's reminders fires match the monitoring-reminders timestamps:
+```bash
+osascript -e 'tell application "Reminders" to get {name, creation date} of reminders'
+# Returns 10 reminders matching the 10 audit-log timestamps exactly.
+```
+
+Direct verification that the secondary test issue is real:
+```bash
+python3 -c "import sys; sys.path.insert(0, '$HOME/.codec/skills'); import reminders; print(reminders.run('list reminders'))"
+# Returns: 'Reminder added: list reminders'
+# Creates a real Apple Reminder. ⚠ DO NOT RUN unless willing to clean up.
+```
+
+(I created and immediately deleted one such test reminder during this investigation.)
+
+---
+
+## Sign-off recommendations
+
+- [ ] User acknowledges the 10 reminders are intentional monitoring-checkpoint reminders, not spurious.
+- [ ] User decides whether to keep the existing monitoring reminders or delete them (they're useful for the 24h watch).
+- [ ] User approves the test cleanup (`SKIP_SKILLS` additions to `tests/test_mcp_all_tools.py`).
+- [ ] Step 3 PR #5 may resume after sign-off.

--- a/tests/test_mcp_all_tools.py
+++ b/tests/test_mcp_all_tools.py
@@ -22,7 +22,6 @@ CANONICAL_PROMPTS = {
     "calculator": "2 + 2",
     "bitcoin_price": "bitcoin price",
     "password_generator": "generate password",
-    "qr_generator": "qr code for hello",
     "time": "what time is it",
     "time_date": "what time is it",
     "json_formatter": 'format json {"a":1}',
@@ -34,11 +33,8 @@ CANONICAL_PROMPTS = {
     "memory_search": "test",
     "memory_history": "list active facts",
     "memory_entities": "list entities",
-    "tts_say": "say test",  # will fallback to macOS say
     "google_tasks": "list tasks",  # read-only
     "google_calendar": "list today events",
-    "notes": "list notes",  # read intent, opens Notes
-    "reminders": "list reminders",
     "pomodoro": "pomodoro status",
     "file_search": "find file CLAUDE.md",
     "clipboard": "read clipboard",
@@ -62,6 +58,13 @@ SKIP_SKILLS = {
     "scheduler", "scheduler_skill", "ax_control", "file_ops",
     "python_exec", "terminal", "process_manager", "pm2_control",
     "app_switch", "timer",
+    # 2026-05-01 incident hotfix — macOS UI side effects.
+    # See docs/INCIDENT-2026-05-01-spurious-skill-fires.md.
+    # The user's `~/.codec/skills/reminders.py` may be the OLD version with
+    # no read-mode; "list reminders" → creates a real Apple Reminder named
+    # "list reminders". Tts_say literally speaks via macOS `say`. Notes
+    # opens the Notes app. Generate_qr_code writes qr.png to cwd.
+    "reminders", "tts_say", "notes", "generate_qr_code", "qr_generator",
 }
 
 


### PR DESCRIPTION
## Summary

Hotfix landing the test cleanup that came out of the 2026-05-01 incident investigation. **No production code change.**

- Adds `reminders`, `tts_say`, `notes`, `generate_qr_code`, `qr_generator` to `SKIP_SKILLS` in `tests/test_mcp_all_tools.py`. Removes their entries from `CANONICAL_PROMPTS`.
- Adds `docs/INCIDENT-2026-05-01-spurious-skill-fires.md` documenting the full root-cause investigation.

## Why

User reported "spurious skill fires" of reminders/notes/qr_generator/voice_note/terminal_note for ~24h, perceived as caused by Phase 1 Step 1 / Step 2 deployment.

**Investigation conclusion (full evidence in `docs/INCIDENT-2026-05-01-spurious-skill-fires.md`):**

1. **The 10 audit-log entries are NOT spurious** — they are real Apple Reminders that Claude Code intentionally created on Apr 30 + May 1 to schedule the Phase 1 Step 1 / Step 2 post-merge monitoring checkpoints (T+4h, T+8h, T+12h, T+16h, T+20h). Cross-referenced audit timestamps against `osascript` creation dates — they match to the second. `task_len` (176-253 chars) matches each reminder's text length exactly.

2. **Step 1 / Step 2 did NOT cause this.** Same 5-fire pattern on both Apr 30 and May 1. The audit-log `transport` field changed from `stdio` → `local` because Step 1 unified the envelope schema and the stdio MCP variant `codec_mcp.py` doesn't set `CODEC_MCP_TRANSPORT`, so it falls through to `_transport_for("codec") = "local"`. Cosmetic.

3. **The audit-emit shape (`source=codec, transport=local`) resolves to `codec_mcp.py` invoked via stdio by Claude.app's MCP integration.** `ps aux` shows 3 `codec_mcp.py` instances spawned by `/Applications/Claude.app/Contents/Helpers/disclaimer`. Without `CODEC_PROCESS` env var, `codec_audit.py:194` defaults source to `"codec"`.

4. **All 6 user-supplied hypotheses (H1–H6)** were investigated and either ruled out or confirmed-but-unrelated. Plugins dir doesn't exist. No pytest watcher. No autopilot trigger. Step 1/2 don't introduce code paths that fire skills.

## Secondary issue (fixed by this PR)

`tests/test_mcp_all_tools.py::CANONICAL_PROMPTS` had destructive prompts:

| Skill | Prompt | Side effect when run against user's runtime `~/.codec/skills/` |
|---|---|---|
| `reminders` | `"list reminders"` | Creates a real Apple Reminder named "list reminders" (the OLD `~/.codec/skills/reminders.py` has no read-mode) |
| `tts_say` | `"say test"` | Speaks "say test" via macOS `say` (audible) |
| `notes` | `"list notes"` | Opens Apple Notes |
| `qr_generator` / `generate_qr_code` | falls through to `"ping"` | Creates `qr.png` in cwd |

Verified by direct call: `python3 -c "import sys; sys.path.insert(0, '~/.codec/skills'); import reminders; print(reminders.run('list reminders'))"` → `'Reminder added: list reminders'`. Same hygiene reasoning as existing skips for `imessage_send`, `chrome_*`, `philips_hue`, etc.

After this PR: **36 skills skipped (was 31), 27 fired (was 32).** Each fired skill confirmed read-only / no user-visible side effect.

## Test plan

- [x] `pytest tests/test_mcp_all_tools.py -v`: passes (32.50s).
- [x] Verified post-test: 0 reminders created in last 60s (`osascript ... whose creation date > (current date) - 60`).
- [x] Verified post-test: no `qr.png` files created in worktree.

## Out of scope

- **No production code change.** This is test-hygiene only.
- **Step 1 + Step 2 stay merged.** They are not the cause.
- **Step 3 PR #5 untouched.** Will rebase onto the new main after this lands.
- **No PM2 restart needed.**
- **`_HTTP_BLOCKED` untouched.**
- **(Optional follow-up, separate PR)**: copy the FIXED `skills/reminders.py` (already on main) to user's `~/.codec/skills/reminders.py` runtime install. Currently their runtime install has the OLD version without read-mode.

## After merge

- Rebase Step 3 PR #5 onto new main.
- Re-run full Step 3 test suite — confirm baseline holds (711 passed / 20 failed / 73 skipped).
- Produce `docs/PHASE1-STEP3-PREMERGE-AUDIT.md` classifying the 20 failures relative to Step 3's modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)