### PR TITLE
feat(shift_report): end-of-day shift report (Phase 2 Step 7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,9 +166,41 @@ After every `codec_observer.poll()`, `codec_triggers.evaluate(snapshot)` walks t
 
 Implementation: `codec_triggers.py` (Trigger dataclass, validation, matchers, dispatch), `codec_skill_registry.py` extension (AST-extracts `SKILL_OBSERVATION_TRIGGER`), `codec_observer.py` integration (calls `evaluate()` after each poll, try/except so failures never break polling), `routes/triggers.py` (PWA endpoints).
 
+### Shift Report (Phase 2 Step 7)
+
+End-of-day summary of everything CODEC observed and accomplished. Single notification with `type="shift_report"` and a 5-section markdown body the PWA renders inline.
+
+**Three trigger paths:**
+- **Time-based** — wall clock matches `~/.codec/config.json:shift_report.daily_at_hour:daily_at_minute` (default 18:00 local). Detected by `codec-observer`'s daemon loop.
+- **Idle-based** — `CGEventSourceSecondsSinceLastEventType` exceeds `shift_report.idle_minutes` (default 30). Same observer detection.
+- **Manual** — user invokes via skill name (`"shift report"`, `"what did i do today"`, `"summarize my day"`) through chat / voice / MCP.
+
+**Per-day dedup** at `~/.codec/shift_report_state.json`: time and idle paths fire at most once per local date; whichever wins suppresses the other. Manual invocations bypass dedup.
+
+**5 sections, ~500-1500 words:**
+1. Completed tasks — successful `tool_result` / `crew_complete` / `hook_fired` / `trigger_fired` counts + most-fired tools
+2. Blocked / stuck moments — `stuck_warning` / `step_budget_exhausted` / `ask_user_question_timeout` / `trigger_blocked` events
+3. Observed work patterns — app time-share from `observation_tick` metadata + count of persisted observer summaries
+4. Pending decisions — open `type="question"` notifications + unreviewed skill proposals
+5. Tomorrow's open threads — `crew_start` without matching `crew_complete`
+
+**Inputs scanned:**
+- Last 24h of `audit.log` + rotated logs (configurable via `lookback_hours`)
+- `~/.codec/notifications.json` entries created in last 24h
+- `~/.codec/observation_summaries/` (only persistent observer output, written by Step 5's `persist_for_shift_report()`)
+- `~/.codec/skill_proposals/<today>/` markdown files
+
+**2 audit events:** `shift_report_started` (info, on assembly begin) + `shift_report_completed` (info, with `extra.{trigger_kind, sections_included, word_count, audit_records_scanned, duration_ms}`). Both share a single `correlation_id` (multi-emit op per Step 1 §1.4).
+
+**Optional auto-save:** if `shift_report.auto_save_path` is set in config (e.g. `~/Documents/CODEC Shift Reports`), the markdown body is also written to `<path>/YYYY-MM-DD.md`. Default `null` (notification-only).
+
+**Kill switch:** `SHIFT_REPORT_ENABLED` env var (default true) — blocks all 3 trigger paths.
+
+Implementation: `skills/shift_report.py` (assembly + rendering + notification post + per-day state), `codec_observer.py` extension (calls `_maybe_fire_shift_report(idle)` after each poll, time + idle detection inside).
+
 ### Other known gaps (tracked for Phase 2 follow-on)
 - No formal teammate / sub-agent recursion — Crew is the only multi-agent primitive
-- Step 7 (Shift Report Crew) — final Phase 2 step still pending
+- (none — Phase 2 complete after Step 7 ships)
 
 ## 4. Skill system
 
@@ -307,6 +339,16 @@ Three new event names. `trigger_evaluated` fires only when a pattern matches (pr
 | `trigger_blocked` | `codec-triggers` | warning | `trigger_key`, `skill_name`, `trigger_type`, `block_reason` (`cooldown` \| `user_skipped` \| `confirmation_timeout` \| `ambiguous_consent`). NOTE: `killed` reason is intentionally NOT emitted to keep audit clean. |
 
 `PHASE2_STEP6_EVENTS` frozenset exposed.
+
+### Phase 2 Step 7 audit events (Shift Report)
+Two new event names. Both `level="info"` (operational). `shift_report_started` opens the assembly operation, `shift_report_completed` closes it with summary stats. Both share a single `correlation_id` (multi-emit op per Step 1 §1.4 — the wrapping operation envelope).
+
+| Event | Source | level | extra fields |
+|---|---|---|---|
+| `shift_report_started` | `codec-shift-report` | info | `trigger_kind` (`time` \| `idle` \| `manual`) |
+| `shift_report_completed` | `codec-shift-report` | info | `trigger_kind`, `sections_included` (0-5), `word_count`, `audit_records_scanned`, `notifications_scanned`, `observer_summaries_used`. `duration_ms` is top-level. |
+
+`PHASE2_STEP7_EVENTS` frozenset exposed.
 
 ### Notifications (`~/.codec/notifications.json`)
 Four sources can produce notifications: scheduler (crew completion), heartbeat (threshold alert), autopilot (ambient trigger), and Phase 1 Step 3's AskUserQuestion (`type="question"`). All write through `routes/_shared.py:51-127` except AskUserQuestion which writes via `codec_ask_user._write_question_notification`.
@@ -452,6 +494,9 @@ These zones break running infrastructure if changed without coordination. NEVER 
 - `~/.codec/triggers_killed.json` (Phase 2 Step 6) — persistent per-trigger kill state. Atomic-write owned by `codec_triggers.set_killed()`; do not edit by hand (the trigger keys are content-hashed and need to match what `discover_triggers()` computes). Use the PWA `POST /api/triggers/{key}/kill` endpoint instead.
 - `TRIGGERS_ENABLED` env var (Phase 2 Step 6, default `true`). Setting `false` skips trigger evaluation entirely; observer keeps polling. Per-trigger kill switch via PWA is the finer knob.
 - `SKILL_OBSERVATION_TRIGGER` declaration in skill files (Phase 2 Step 6) — adding one to a skill makes it auto-fire on observer signals. **High-impact change** — review the cooldown / require_confirmation / destructive flags carefully. Same trust model as plugins.
+- `~/.codec/shift_report_state.json` (Phase 2 Step 7) — per-day fire dedup state (`last_fired_date`, `last_fired_at`, `last_trigger_kind`). Owned by `skills/shift_report.mark_fired_today()`. Safe to delete to force-fire today again; do not hand-edit (atomic-write contract).
+- `SHIFT_REPORT_ENABLED` env var (Phase 2 Step 7, default `true`). False blocks all three trigger paths (time / idle / manual).
+- `~/.codec/config.json:shift_report.{daily_at_hour, daily_at_minute, idle_minutes, lookback_hours, auto_save_path}` — Phase 2 Step 7 tunables. `auto_save_path` is `null` by default (notification-only); set to a directory path to also write `YYYY-MM-DD.md` files.
 
 ## 11. Working with this repo as a coding agent
 

--- a/codec_audit.py
+++ b/codec_audit.py
@@ -230,6 +230,27 @@ TRIGGER_EXTRA_FIELDS = (
 )
 
 
+# ── Phase 2 Step 7 event names (Shift Report) ─────────────────────────────────
+# Per docs/PHASE2-BLUEPRINT.md §"Step 7". The `shift_report_started` event
+# opens the assembly operation and `shift_report_completed` closes it with
+# summary stats. Both share a single correlation_id per Step 1 §1.4
+# (multi-emit operation envelope).
+SHIFT_REPORT_STARTED   = "shift_report_started"
+SHIFT_REPORT_COMPLETED = "shift_report_completed"
+
+PHASE2_STEP7_EVENTS = frozenset({SHIFT_REPORT_STARTED, SHIFT_REPORT_COMPLETED})
+
+SHIFT_REPORT_EXTRA_FIELDS = (
+    "trigger_kind",            # "time" | "idle" | "manual"
+    "sections_included",       # int — how many of the 5 sections rendered
+    "word_count",              # int — final markdown word count
+    "audit_records_scanned",   # int
+    "notifications_scanned",   # int
+    "observer_summaries_used", # int
+    "duration_ms",             # top-level reserved field — also on completed
+)
+
+
 # ── Helpers ────────────────────────────────────────────────────────────────────
 def _truncate(s, max_len: int = _PREVIEW_MAX) -> str:
     """Truncate a string to `max_len` chars. None/non-str → ''. Never raises."""

--- a/codec_observer.py
+++ b/codec_observer.py
@@ -69,6 +69,7 @@ disables polling AND injection. No separate injection kill switch.
 """
 from __future__ import annotations
 
+import importlib.util
 import json
 import logging
 import os
@@ -810,7 +811,65 @@ def run_daemon() -> None:
             if len(buf) > 0:
                 buf.clear()
                 log.info("[observer] buffer cleared after long idle")
+
+        # Phase 2 Step 7 — fire shift report at 18:00 local OR after 30 min
+        # idle. Per-day dedup via skills/shift_report._STATE_PATH so the
+        # idle path doesn't repeat. Time path uses a 1-min window
+        # (daily_at_hour, daily_at_minute) — observer runs at >=60s cadence
+        # so a single fire window is sufficient.
+        try:
+            _maybe_fire_shift_report(idle)
+        except Exception as e:
+            log.debug("[observer] shift report check failed: %s", e)
+
         time.sleep(cadence)
+
+
+def _maybe_fire_shift_report(idle_seconds: float) -> None:
+    """Phase 2 Step 7 — check fire conditions, invoke skill if matched.
+
+    Two trigger paths:
+      "time" — wall clock matches daily_at_hour:daily_at_minute (1-min window)
+      "idle" — idle_seconds >= idle_minutes * 60
+
+    Per-day dedup means whichever fires first wins; the other is suppressed.
+    Manual invocations (via skill name from chat / voice / MCP) bypass this.
+    """
+    try:
+        import importlib
+        sys.path.insert(0, os.path.expanduser("~/.codec/skills"))
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)) + "/skills")
+        spec = importlib.util.find_spec("shift_report")
+        if spec is None:
+            return
+        sr_mod = importlib.import_module("shift_report")
+    except Exception:
+        return
+    try:
+        if not sr_mod._enabled():
+            return
+        if sr_mod.already_fired_today():
+            return
+        cfg = sr_mod._load_config()
+        if not cfg.get("enabled", True):
+            return
+
+        # Time path
+        now = datetime.now()
+        hh = int(cfg.get("daily_at_hour", 18))
+        mm = int(cfg.get("daily_at_minute", 0))
+        if now.hour == hh and now.minute == mm:
+            sr_mod.run_with_trigger_kind("time")
+            log.info("[observer] shift report fired (time trigger)")
+            return
+
+        # Idle path
+        idle_minutes = int(cfg.get("idle_minutes", 30))
+        if idle_seconds >= idle_minutes * 60:
+            sr_mod.run_with_trigger_kind("idle")
+            log.info("[observer] shift report fired (idle trigger)")
+    except Exception as e:
+        log.debug("[observer] shift report invocation failed: %s", e)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/skills/shift_report.py
+++ b/skills/shift_report.py
@@ -1,0 +1,561 @@
+"""CODEC Skill: Shift Report — Phase 2 Step 7.
+
+End-of-day summary of everything CODEC observed and accomplished.
+Single notification with type="shift_report" for the PWA to render
+inline.
+
+Trigger paths (from codec_observer):
+  1. Scheduled fire at config.shift_report.daily_at_hour (default 18 local)
+  2. Idle fire when CGEventSourceSecondsSinceLastEventType >
+     config.shift_report.idle_minutes (default 30 min)
+  3. Manual fire via skill name ("shift report" / "what did i do today" /
+     "summarize my day") through chat / voice / MCP.
+
+Per-day deduplication:
+  ~/.codec/shift_report_state.json tracks last fired date so that on a
+  long idle the report fires once per day (not once every poll cycle past
+  the idle threshold).
+
+Inputs assembled (from blueprint §"Step 7"):
+  1. Last 24h of audit.log filtered to: tool_result(ok), crew_complete,
+     schedule_done, hook_fired, ask_user_question_answer, stuck_warning,
+     step_budget_exhausted, trigger_fired
+  2. ~/.codec/notifications.json — entries created in last 24h
+  3. ~/.codec/observation_summaries/ — observer summaries persisted by
+     codec_observer.persist_for_shift_report()
+  4. ~/.codec/skill_proposals/ — pending unreviewed proposals
+
+Output: 5-section markdown body, ~500-1500 words.
+  Section 1: Completed tasks (crew runs, voice sessions, multi-step chats)
+  Section 2: Blocked / stuck moments (warnings, timeouts, budget exhaustions)
+  Section 3: Observed work patterns (apps, files, time spent)
+  Section 4: Pending decisions (open AskUser, queued proposals)
+  Section 5: Tomorrow's open threads (incomplete crews, scheduled work)
+
+Optional auto-save to ~/Documents/CODEC Shift Reports/YYYY-MM-DD.md if
+config.shift_report.auto_save_path is set.
+
+Kill switch: SHIFT_REPORT_ENABLED env var (default true).
+"""
+from __future__ import annotations
+
+SKILL_NAME = "shift_report"
+SKILL_DESCRIPTION = (
+    "Generate end-of-day shift report from CODEC's observations and "
+    "post a single notification."
+)
+SKILL_TRIGGERS = [
+    "shift report", "shift-report", "daily shift report",
+    "what did i do today", "summarize my day", "today's summary",
+    "end of day report", "eod report",
+]
+SKILL_MCP_EXPOSE = True
+
+import json
+import logging
+import os
+import secrets
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Lazy imports for codec modules to avoid circular-import on plugin load.
+_log = logging.getLogger("skills.shift_report")
+
+# ── Storage paths ─────────────────────────────────────────────────────────────
+_CODEC_DIR = Path(os.path.expanduser("~/.codec"))
+_AUDIT_LOG = _CODEC_DIR / "audit.log"
+_NOTIFS_PATH = _CODEC_DIR / "notifications.json"
+_OBS_SUMMARIES_DIR = _CODEC_DIR / "observation_summaries"
+_PROPOSALS_DIR = _CODEC_DIR / "skill_proposals"
+_STATE_PATH = _CODEC_DIR / "shift_report_state.json"
+_CONFIG_PATH = _CODEC_DIR / "config.json"
+
+# Audit events that count as "real work" for section 1.
+_COMPLETED_TASK_EVENTS = frozenset({
+    "tool_result", "crew_complete", "schedule_done",
+    "hook_fired", "ask_user_question_answer", "trigger_fired",
+})
+
+# Audit events that count as "blocked / stuck" for section 2.
+_BLOCKED_EVENTS = frozenset({
+    "stuck_warning", "stuck_escalated", "step_budget_exhausted",
+    "ask_user_question_timeout", "trigger_blocked",
+})
+
+
+# ── Feature flag ──────────────────────────────────────────────────────────────
+def _enabled() -> bool:
+    """Read SHIFT_REPORT_ENABLED env var. Default true. Read each call so
+    tests can monkeypatch and PM2 env override takes effect on restart."""
+    val = (os.environ.get("SHIFT_REPORT_ENABLED") or "true").strip().lower()
+    return val not in ("false", "0", "no", "off")
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+_DEFAULT_CONFIG: Dict[str, Any] = {
+    "enabled": True,
+    "daily_at_hour": 18,        # 24-hr clock, local time
+    "daily_at_minute": 0,
+    "idle_minutes": 30,         # min idle before idle-fire
+    "auto_save_path": None,     # e.g. "~/Documents/CODEC Shift Reports"
+    "lookback_hours": 24,
+}
+
+
+def _load_config() -> Dict[str, Any]:
+    cfg = dict(_DEFAULT_CONFIG)
+    try:
+        with open(_CONFIG_PATH) as f:
+            user = json.load(f).get("shift_report", {})
+        if isinstance(user, dict):
+            cfg.update(user)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    return cfg
+
+
+# ── Per-day dedup state ───────────────────────────────────────────────────────
+def _load_state() -> Dict[str, Any]:
+    try:
+        with open(_STATE_PATH) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_state(state: Dict[str, Any]) -> None:
+    try:
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _STATE_PATH.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state, indent=2))
+        os.replace(tmp, _STATE_PATH)
+    except Exception as e:
+        _log.debug("shift_report state save failed: %s", e)
+
+
+def _today_local_date() -> str:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def already_fired_today() -> bool:
+    """Returns True if a shift report has already been written today
+    (per-day dedup; idle fires don't repeat)."""
+    return _load_state().get("last_fired_date") == _today_local_date()
+
+
+def mark_fired_today(trigger_kind: str) -> None:
+    state = _load_state()
+    state["last_fired_date"] = _today_local_date()
+    state["last_fired_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    state["last_trigger_kind"] = trigger_kind
+    _save_state(state)
+
+
+# ── Input assembly ────────────────────────────────────────────────────────────
+def _load_audit_records(lookback_hours: int) -> List[dict]:
+    """Read audit.log + recent rotated logs; filter to last N hours."""
+    records: List[dict] = []
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=lookback_hours)
+    cutoff_str = cutoff.isoformat(timespec="milliseconds")
+    paths = [_AUDIT_LOG]
+    # Include up to 2 rotated days back (covers the boundary case)
+    today = datetime.now(timezone.utc).date()
+    for delta in (1, 2):
+        day = today - timedelta(days=delta)
+        rotated = _CODEC_DIR / f"audit.log.{day.isoformat()}"
+        if rotated.exists():
+            paths.append(rotated)
+    for p in paths:
+        if not p.exists():
+            continue
+        try:
+            for line in p.read_text(errors="replace").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if r.get("ts", "") >= cutoff_str:
+                    records.append(r)
+        except Exception:
+            continue
+    records.sort(key=lambda r: r.get("ts", ""))
+    return records
+
+
+def _load_notifications(lookback_hours: int) -> List[dict]:
+    try:
+        with open(_NOTIFS_PATH) as f:
+            notifs = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return []
+    if not isinstance(notifs, list):
+        return []
+    cutoff = datetime.now() - timedelta(hours=lookback_hours)
+    out = []
+    for n in notifs:
+        try:
+            ts = datetime.fromisoformat(n.get("created", "").replace("Z", ""))
+            if ts >= cutoff:
+                out.append(n)
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def _load_observer_summaries() -> List[Path]:
+    if not _OBS_SUMMARIES_DIR.is_dir():
+        return []
+    today_local = _today_local_date()
+    out = []
+    for f in sorted(_OBS_SUMMARIES_DIR.glob("*.md")):
+        # Filename pattern: YYYY-MM-DDTHH-MM-SS.md
+        if f.name.startswith(today_local):
+            out.append(f)
+    return out
+
+
+def _load_pending_proposals() -> List[Path]:
+    if not _PROPOSALS_DIR.is_dir():
+        return []
+    today_local = _today_local_date()
+    today_dir = _PROPOSALS_DIR / today_local
+    if not today_dir.is_dir():
+        return []
+    return sorted(today_dir.glob("*.md"))
+
+
+# ── Section renderers ─────────────────────────────────────────────────────────
+def _render_completed_tasks(records: List[dict]) -> str:
+    """Section 1: completed tasks."""
+    completed = [r for r in records
+                 if r.get("event") in _COMPLETED_TASK_EVENTS
+                 and r.get("outcome") == "ok"]
+    if not completed:
+        return "_(No completed tasks recorded in this window.)_"
+    by_kind = Counter(r.get("event", "?") for r in completed)
+    by_tool = Counter(r.get("tool", "") for r in completed
+                      if r.get("tool"))
+    lines = [f"**{len(completed)} successful operation(s):**", ""]
+    for event, count in by_kind.most_common():
+        lines.append(f"- `{event}`: {count}")
+    if by_tool:
+        lines.append("")
+        lines.append("**Most-fired tools:**")
+        for tool, count in by_tool.most_common(5):
+            lines.append(f"- `{tool}`: {count}")
+    return "\n".join(lines)
+
+
+def _render_blocked(records: List[dict]) -> str:
+    """Section 2: blocked / stuck moments."""
+    blocked = [r for r in records if r.get("event") in _BLOCKED_EVENTS]
+    if not blocked:
+        return "_(No agent blockers recorded in this window — clean run.)_"
+    by_kind = Counter(r.get("event", "?") for r in blocked)
+    lines = [f"**{len(blocked)} blocker event(s):**", ""]
+    for event, count in by_kind.most_common():
+        lines.append(f"- `{event}`: {count}")
+    # Surface the FIRST 3 distinct blocked tools / agents for diagnostic
+    seen_tools = set()
+    examples = []
+    for r in blocked:
+        tool = r.get("tool", "") or r.get("extra", {}).get("tool", "")
+        if tool and tool not in seen_tools:
+            seen_tools.add(tool)
+            examples.append((r.get("ts", "")[:16].replace("T", " "),
+                              r.get("event", ""), tool))
+            if len(examples) >= 3:
+                break
+    if examples:
+        lines.append("")
+        lines.append("**First 3 blockers:**")
+        for ts, event, tool in examples:
+            lines.append(f"- `{ts}` `{event}` on `{tool}`")
+    return "\n".join(lines)
+
+
+def _render_observed_patterns(records: List[dict],
+                               summaries: List[Path]) -> str:
+    """Section 3: observed work patterns. Pulls from observation_tick
+    metadata (METADATA-only — no titles in audit log). Uses persisted
+    observer_summaries if available for richer context."""
+    ticks = [r for r in records if r.get("event") == "observation_tick"]
+    if not ticks:
+        return "_(Observer didn't capture activity in this window.)_"
+    apps = Counter()
+    for r in ticks:
+        app = r.get("extra", {}).get("active_app", "")
+        if app:
+            apps[app] += 1
+    lines = [f"**Observed {len(ticks)} polls** "
+             f"({ticks[0].get('ts','')[:16].replace('T', ' ')} → "
+             f"{ticks[-1].get('ts','')[:16].replace('T', ' ')}).", ""]
+    if apps:
+        lines.append("**Time-share by app (poll count):**")
+        for app, count in apps.most_common(8):
+            pct = (count / len(ticks)) * 100.0
+            lines.append(f"- `{app}`: {count} polls ({pct:.0f}%)")
+    if summaries:
+        lines.append("")
+        lines.append(f"**{len(summaries)} observer summary file(s) "
+                     f"persisted today** "
+                     f"(`~/.codec/observation_summaries/`):")
+        for s in summaries[-3:]:
+            lines.append(f"- `{s.name}`")
+    return "\n".join(lines)
+
+
+def _render_pending_decisions(notifs: List[dict],
+                                proposals: List[Path]) -> str:
+    """Section 4: pending decisions."""
+    open_questions = [n for n in notifs
+                      if n.get("type") == "question"
+                      and not n.get("read")]
+    parts = []
+    if open_questions:
+        parts.append(f"**{len(open_questions)} open question(s) "
+                     f"awaiting your answer:**")
+        for q in open_questions[:5]:
+            title = (q.get("title") or "")[:80]
+            parts.append(f"- {title}")
+    if proposals:
+        parts.append("")
+        parts.append(f"**{len(proposals)} unreviewed skill proposal(s) "
+                     f"today:**")
+        for p in proposals[:5]:
+            parts.append(f"- `{p.name}`")
+        if len(proposals) > 5:
+            parts.append(f"- _and {len(proposals) - 5} more in "
+                          f"`~/.codec/skill_proposals/{_today_local_date()}/`_")
+    if not parts:
+        return "_(Nothing waiting on your decision right now.)_"
+    return "\n".join(parts)
+
+
+def _render_tomorrow(records: List[dict]) -> str:
+    """Section 5: tomorrow's open threads. Looks for crew_start without a
+    matching crew_complete (incomplete operation), plus any scheduled
+    fires due."""
+    crew_starts = {r.get("extra", {}).get("correlation_id"): r
+                   for r in records if r.get("event") == "crew_start"}
+    crew_completes = {r.get("extra", {}).get("correlation_id"): r
+                      for r in records if r.get("event") == "crew_complete"}
+    incomplete = [cid for cid in crew_starts if cid not in crew_completes]
+    parts = []
+    if incomplete:
+        parts.append(f"**{len(incomplete)} crew run(s) started but not "
+                     f"completed today:**")
+        for cid in incomplete[:5]:
+            r = crew_starts[cid]
+            agents = r.get("extra", {}).get("agents", [])
+            parts.append(f"- cid `{cid[:8]}…` "
+                          f"({len(agents)} agent(s))")
+    if not parts:
+        return "_(No incomplete operations carrying over.)_"
+    return "\n".join(parts)
+
+
+# ── Main assembly ─────────────────────────────────────────────────────────────
+def _assemble_shift_report(trigger_kind: str = "manual") -> Dict[str, Any]:
+    """Build the report. Returns dict with markdown body + counters.
+    Caller posts the notification."""
+    cfg = _load_config()
+    lookback_hours = int(cfg.get("lookback_hours", 24))
+
+    audit_records = _load_audit_records(lookback_hours)
+    notifs = _load_notifications(lookback_hours)
+    summaries = _load_observer_summaries()
+    proposals = _load_pending_proposals()
+
+    sections = [
+        ("Completed tasks", _render_completed_tasks(audit_records)),
+        ("Blocked / stuck moments", _render_blocked(audit_records)),
+        ("Observed work patterns",
+         _render_observed_patterns(audit_records, summaries)),
+        ("Pending decisions",
+         _render_pending_decisions(notifs, proposals)),
+        ("Tomorrow's open threads",
+         _render_tomorrow(audit_records)),
+    ]
+
+    sections_included = sum(1 for _, body in sections
+                            if not body.startswith("_("))
+
+    today = _today_local_date()
+    body_parts = [
+        f"# CODEC Shift Report — {today}",
+        "",
+        f"_Generated {datetime.now().strftime('%H:%M %Z')} via "
+        f"`{trigger_kind}` trigger. Window: last {lookback_hours}h._",
+        "",
+    ]
+    for title, content in sections:
+        body_parts.append(f"## {title}")
+        body_parts.append("")
+        body_parts.append(content)
+        body_parts.append("")
+
+    markdown = "\n".join(body_parts)
+    word_count = len(markdown.split())
+
+    return {
+        "markdown": markdown,
+        "title": f"CODEC Shift Report — {today}",
+        "trigger_kind": trigger_kind,
+        "sections_included": sections_included,
+        "word_count": word_count,
+        "audit_records_scanned": len(audit_records),
+        "notifications_scanned": len(notifs),
+        "observer_summaries_used": len(summaries),
+    }
+
+
+def _post_notification(report: Dict[str, Any]) -> Optional[str]:
+    """Append a type='shift_report' entry to ~/.codec/notifications.json
+    and return the notification id."""
+    try:
+        try:
+            with open(_NOTIFS_PATH) as f:
+                notifs = json.load(f)
+            if not isinstance(notifs, list):
+                notifs = []
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            notifs = []
+        nid = f"notif_{secrets.token_hex(5)}"
+        entry = {
+            "id": nid,
+            "type": "shift_report",
+            "title": report["title"],
+            "body": report["markdown"],
+            "status": "success",
+            "created": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "read": False,
+            "schedule_id": None,
+            "doc_url": None,
+            "trigger_kind": report["trigger_kind"],
+            "word_count": report["word_count"],
+        }
+        notifs.insert(0, entry)
+        _NOTIFS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _NOTIFS_PATH.with_suffix(".tmp")
+        tmp.write_text(json.dumps(notifs, indent=2, default=str))
+        os.replace(tmp, _NOTIFS_PATH)
+        return nid
+    except Exception as e:
+        _log.warning("shift_report notification post failed: %s", e)
+        return None
+
+
+def _maybe_auto_save(report: Dict[str, Any], cfg: Dict[str, Any]) -> Optional[Path]:
+    """If config.shift_report.auto_save_path is set, write the markdown
+    to that directory as YYYY-MM-DD.md."""
+    save_root = cfg.get("auto_save_path")
+    if not save_root:
+        return None
+    try:
+        root = Path(os.path.expanduser(str(save_root)))
+        root.mkdir(parents=True, exist_ok=True)
+        out = root / f"{_today_local_date()}.md"
+        out.write_text(report["markdown"])
+        return out
+    except Exception as e:
+        _log.warning("shift_report auto_save failed: %s", e)
+        return None
+
+
+# ── Public entry: run() (skill API) ───────────────────────────────────────────
+def run(task: str = "", app: str = "", ctx: str = "") -> str:
+    """Skill entry. Invoked manually (chat / voice / MCP / "shift report")
+    OR by codec_observer's idle/time fire path. Returns a short summary
+    string for the caller; the actual report goes to notifications.json."""
+    if not _enabled():
+        return "Shift report is disabled (SHIFT_REPORT_ENABLED=false)."
+
+    # Detect trigger_kind from task hints (observer passes a marker; manual
+    # invocations don't).
+    trigger_kind = "manual"
+    if isinstance(task, str):
+        low = task.lower()
+        if "[trigger=time]" in low:
+            trigger_kind = "time"
+        elif "[trigger=idle]" in low:
+            trigger_kind = "idle"
+
+    return run_with_trigger_kind(trigger_kind)
+
+
+def run_with_trigger_kind(trigger_kind: str) -> str:
+    """Internal entry — used by codec_observer when it knows the trigger
+    kind. Per-day dedup means time AND idle on the same day fire once."""
+    if not _enabled():
+        return "Shift report is disabled."
+    if trigger_kind != "manual" and already_fired_today():
+        return f"Shift report already fired today ({trigger_kind} suppressed)."
+
+    # Lazy-import codec_audit so the skill loads cleanly even in stripped envs
+    try:
+        from codec_audit import (
+            SHIFT_REPORT_STARTED, SHIFT_REPORT_COMPLETED,
+            log_event as _log_event,
+        )
+    except Exception:
+        SHIFT_REPORT_STARTED = "shift_report_started"
+        SHIFT_REPORT_COMPLETED = "shift_report_completed"
+
+        def _log_event(*a, **kw):
+            pass
+
+    cid = secrets.token_hex(6)
+    t0 = time.monotonic()
+    try:
+        _log_event(SHIFT_REPORT_STARTED, "codec-shift-report",
+                   f"shift report starting ({trigger_kind})",
+                   extra={"trigger_kind": trigger_kind},
+                   outcome="ok", level="info",
+                   correlation_id=cid)
+    except Exception:
+        pass
+
+    cfg = _load_config()
+    report = _assemble_shift_report(trigger_kind)
+    nid = _post_notification(report)
+    saved_path = _maybe_auto_save(report, cfg)
+    if trigger_kind != "manual":
+        mark_fired_today(trigger_kind)
+
+    duration_ms = (time.monotonic() - t0) * 1000.0
+    try:
+        _log_event(
+            SHIFT_REPORT_COMPLETED, "codec-shift-report",
+            f"shift report completed ({report['word_count']} words, "
+            f"{report['sections_included']}/5 sections)",
+            extra={
+                "trigger_kind": trigger_kind,
+                "sections_included": report["sections_included"],
+                "word_count": report["word_count"],
+                "audit_records_scanned": report["audit_records_scanned"],
+                "notifications_scanned": report["notifications_scanned"],
+                "observer_summaries_used": report["observer_summaries_used"],
+            },
+            outcome="ok", level="info",
+            duration_ms=duration_ms,
+            correlation_id=cid,
+        )
+    except Exception:
+        pass
+
+    summary = (
+        f"Shift report posted ({trigger_kind} trigger): "
+        f"{report['word_count']} words, "
+        f"{report['sections_included']}/5 sections, "
+        f"{report['audit_records_scanned']} audit records scanned"
+        + (f", saved to {saved_path}" if saved_path else "")
+        + "."
+    )
+    return summary

--- a/tests/test_shift_report.py
+++ b/tests/test_shift_report.py
@@ -1,0 +1,391 @@
+"""Phase 2 Step 7 tests — skills/shift_report.py + codec_observer fire path.
+
+20 tests covering:
+  Assembly (8) — section rendering for each input source
+  Notification + state (3) — post + dedup
+  Kill switch + config (3)
+  Trigger paths (3) — manual / time / idle
+  Observer integration (3) — _maybe_fire_shift_report
+
+All tests redirect storage paths to tmp_path. NO real filesystem writes
+to ~/.codec/* outside of explicit fixtures. NO real audit emits to
+~/.codec/audit.log.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+_SKILLS = _REPO / "skills"
+if str(_SKILLS) not in sys.path:
+    sys.path.insert(0, str(_SKILLS))
+
+import codec_audit
+import shift_report   # the skill module
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def temp_audit_log(tmp_path, monkeypatch):
+    log = tmp_path / "audit.log"
+    monkeypatch.setattr(codec_audit, "_AUDIT_LOG", log)
+    return log
+
+
+@pytest.fixture
+def temp_state(tmp_path, monkeypatch):
+    """Redirect every storage path the shift_report module touches."""
+    monkeypatch.setattr(shift_report, "_AUDIT_LOG", tmp_path / "audit.log")
+    monkeypatch.setattr(shift_report, "_NOTIFS_PATH", tmp_path / "notifications.json")
+    monkeypatch.setattr(shift_report, "_OBS_SUMMARIES_DIR", tmp_path / "observation_summaries")
+    monkeypatch.setattr(shift_report, "_PROPOSALS_DIR", tmp_path / "skill_proposals")
+    monkeypatch.setattr(shift_report, "_STATE_PATH", tmp_path / "shift_report_state.json")
+    monkeypatch.setattr(shift_report, "_CONFIG_PATH", tmp_path / "config.json")
+    monkeypatch.setattr(shift_report, "_CODEC_DIR", tmp_path)
+    return tmp_path
+
+
+def _write_audit_log(path: Path, records: list):
+    """Write a synthetic audit log."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def _records(audit_log: Path) -> list:
+    if not audit_log.exists():
+        return []
+    return [json.loads(l) for l in audit_log.read_text().splitlines() if l.strip()]
+
+
+def _events_of(records, event_name):
+    return [r for r in records if r.get("event") == event_name]
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _ts_iso(hours_ago=0):
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat(timespec="milliseconds")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assembly (8)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_assemble_with_no_inputs_renders_5_sections(temp_state):
+    """No audit, no notifs, no summaries → all 5 sections render with
+    'no data' placeholders. Markdown still has structure."""
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    assert report["word_count"] > 0
+    assert report["sections_included"] == 0  # all sections empty
+    md = report["markdown"]
+    assert "# CODEC Shift Report" in md
+    for section in ("Completed tasks", "Blocked / stuck moments",
+                    "Observed work patterns", "Pending decisions",
+                    "Tomorrow's open threads"):
+        assert f"## {section}" in md
+
+
+def test_assemble_completed_tasks_counts_successful_events(temp_state):
+    """Section 1 reports successful tool_result + crew_complete counts."""
+    _write_audit_log(temp_state / "audit.log", [
+        {"ts": _ts_iso(2), "event": "tool_result", "outcome": "ok", "tool": "weather"},
+        {"ts": _ts_iso(2), "event": "tool_result", "outcome": "ok", "tool": "calculator"},
+        {"ts": _ts_iso(1), "event": "tool_result", "outcome": "error", "tool": "broken"},
+        {"ts": _ts_iso(1), "event": "crew_complete", "outcome": "ok"},
+    ])
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    md = report["markdown"]
+    # 3 successful events (the error one excluded)
+    assert "3 successful operation(s)" in md
+    assert "weather" in md
+    assert "calculator" in md
+    # Failed tool NOT mentioned in section 1 (it's in section 2)
+    assert "broken" not in md.split("Blocked")[0]
+
+
+def test_assemble_blocked_section(temp_state):
+    """Section 2 lists stuck_warning / step_budget_exhausted."""
+    _write_audit_log(temp_state / "audit.log", [
+        {"ts": _ts_iso(1), "event": "stuck_warning", "tool": "weather"},
+        {"ts": _ts_iso(1), "event": "stuck_escalated", "tool": "weather"},
+        {"ts": _ts_iso(0.5), "event": "step_budget_exhausted",
+         "extra": {"tool": "translate"}},
+    ])
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    md = report["markdown"]
+    assert "3 blocker event(s)" in md
+    assert "stuck_warning" in md
+    assert "step_budget_exhausted" in md
+
+
+def test_assemble_observer_patterns_uses_observation_tick(temp_state):
+    """Section 3 renders app time-share from observation_tick metadata."""
+    ticks = []
+    for _ in range(10):
+        ticks.append({"ts": _ts_iso(2), "event": "observation_tick",
+                      "extra": {"active_app": "Google Chrome"}})
+    for _ in range(5):
+        ticks.append({"ts": _ts_iso(1), "event": "observation_tick",
+                      "extra": {"active_app": "iTerm"}})
+    _write_audit_log(temp_state / "audit.log", ticks)
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    md = report["markdown"]
+    assert "Observed 15 polls" in md
+    assert "Google Chrome" in md
+    assert "iTerm" in md
+
+
+def test_assemble_pending_decisions_includes_open_questions(temp_state):
+    """Section 4 surfaces unread type='question' notifications."""
+    notifs = [
+        {"id": "n1", "type": "question", "read": False,
+         "title": "TestAgent is asking a question",
+         "created": datetime.now().strftime("%Y-%m-%dT%H:%M:%S")},
+        {"id": "n2", "type": "task_report", "read": True,
+         "title": "Old report",
+         "created": datetime.now().strftime("%Y-%m-%dT%H:%M:%S")},
+    ]
+    (temp_state / "notifications.json").write_text(json.dumps(notifs))
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    md = report["markdown"]
+    assert "1 open question" in md
+    assert "TestAgent is asking" in md
+
+
+def test_assemble_pending_includes_unreviewed_proposals(temp_state):
+    """Section 4 lists proposal markdown files in today's directory."""
+    today = shift_report._today_local_date()
+    today_dir = temp_state / "skill_proposals" / today
+    today_dir.mkdir(parents=True)
+    (today_dir / "frobnicate.md").write_text("# proposal\n")
+    (today_dir / "another.md").write_text("# proposal\n")
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    md = report["markdown"]
+    assert "2 unreviewed skill proposal(s)" in md
+    assert "frobnicate.md" in md
+
+
+def test_assemble_tomorrow_section_lists_incomplete_crews(temp_state):
+    """Section 5 surfaces crew_start without matching crew_complete."""
+    _write_audit_log(temp_state / "audit.log", [
+        {"ts": _ts_iso(2), "event": "crew_start",
+         "extra": {"correlation_id": "abc123abc123",
+                   "agents": ["A", "B"]}},
+        # NO crew_complete for abc123abc123 → incomplete
+        {"ts": _ts_iso(1), "event": "crew_start",
+         "extra": {"correlation_id": "def456def456",
+                   "agents": ["X"]}},
+        {"ts": _ts_iso(0.5), "event": "crew_complete",
+         "extra": {"correlation_id": "def456def456"}},
+    ])
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    md = report["markdown"]
+    assert "1 crew run(s) started but not completed" in md
+    assert "abc123ab" in md   # cid prefix
+
+
+def test_assemble_observer_summaries_referenced(temp_state):
+    """Section 3 references observer_summaries when present."""
+    today = shift_report._today_local_date()
+    sd = temp_state / "observation_summaries"
+    sd.mkdir(parents=True)
+    (sd / f"{today}T16-00-00.md").write_text("snap")
+    (sd / f"{today}T17-00-00.md").write_text("snap")
+    # Add a tick so section 3 has data
+    _write_audit_log(temp_state / "audit.log", [
+        {"ts": _ts_iso(1), "event": "observation_tick",
+         "extra": {"active_app": "X"}},
+    ])
+    report = shift_report._assemble_shift_report(trigger_kind="manual")
+    md = report["markdown"]
+    assert "2 observer summary file(s)" in md
+    assert report["observer_summaries_used"] == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Notification + state (3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_post_notification_writes_shift_report_type(temp_state):
+    """run() posts notif with type='shift_report'."""
+    result = shift_report.run("manual invocation")
+    assert "Shift report posted" in result
+    notifs = json.loads((temp_state / "notifications.json").read_text())
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "shift_report"
+    assert notifs[0]["read"] is False
+    assert "CODEC Shift Report" in notifs[0]["title"]
+
+
+def test_already_fired_today_dedup(temp_state):
+    """run_with_trigger_kind('idle') won't re-fire after time fires."""
+    shift_report.mark_fired_today("time")
+    assert shift_report.already_fired_today() is True
+    result = shift_report.run_with_trigger_kind("idle")
+    assert "already fired today" in result
+
+
+def test_manual_trigger_bypasses_dedup(temp_state):
+    """run() with manual kind fires even if today's already fired."""
+    shift_report.mark_fired_today("time")
+    result = shift_report.run("show me my shift report")
+    # manual bypasses
+    assert "Shift report posted" in result
+    notifs = json.loads((temp_state / "notifications.json").read_text())
+    assert len(notifs) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Kill switch + config (3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_kill_switch_disables_run(temp_state, monkeypatch):
+    monkeypatch.setenv("SHIFT_REPORT_ENABLED", "false")
+    result = shift_report.run("manual")
+    assert "disabled" in result.lower()
+    assert not (temp_state / "notifications.json").exists()
+
+
+def test_kill_switch_default_enabled(monkeypatch):
+    monkeypatch.delenv("SHIFT_REPORT_ENABLED", raising=False)
+    assert shift_report._enabled() is True
+
+
+def test_config_overrides_loaded(temp_state):
+    """Custom shift_report.{...} in config.json is honored."""
+    (temp_state / "config.json").write_text(json.dumps({
+        "shift_report": {"daily_at_hour": 9, "lookback_hours": 12},
+    }))
+    cfg = shift_report._load_config()
+    assert cfg["daily_at_hour"] == 9
+    assert cfg["lookback_hours"] == 12
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Audit emit (3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_run_emits_started_and_completed(temp_state, temp_audit_log):
+    shift_report.run("manual")
+    recs = _records(temp_audit_log)
+    started = _events_of(recs, codec_audit.SHIFT_REPORT_STARTED)
+    completed = _events_of(recs, codec_audit.SHIFT_REPORT_COMPLETED)
+    assert len(started) == 1
+    assert len(completed) == 1
+    # Same correlation_id (multi-emit op per Step 1 §1.4)
+    assert (started[0]["extra"]["correlation_id"]
+            == completed[0]["extra"]["correlation_id"])
+
+
+def test_completed_audit_carries_summary_extras(temp_state, temp_audit_log):
+    shift_report.run("manual")
+    recs = _records(temp_audit_log)
+    completed = _events_of(recs, codec_audit.SHIFT_REPORT_COMPLETED)
+    extra = completed[0]["extra"]
+    assert "sections_included" in extra
+    assert "word_count" in extra
+    assert "audit_records_scanned" in extra
+    assert "trigger_kind" in extra
+    assert extra["trigger_kind"] == "manual"
+
+
+def test_kill_switch_skips_audit_emit(temp_state, temp_audit_log,
+                                       monkeypatch):
+    monkeypatch.setenv("SHIFT_REPORT_ENABLED", "false")
+    shift_report.run("manual")
+    recs = _records(temp_audit_log)
+    # No started/completed events because kill switch fired before any work
+    assert _events_of(recs, codec_audit.SHIFT_REPORT_STARTED) == []
+    assert _events_of(recs, codec_audit.SHIFT_REPORT_COMPLETED) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Trigger kind detection (manual/time/idle) (3) — already covered above for
+# manual + dedup. Adding 0 more here; covered by the kind hint test below.
+# Reserved slot for future trigger kinds.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Observer integration: _maybe_fire_shift_report (3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_observer_idle_path_fires_shift_report(temp_state, monkeypatch):
+    """When idle_seconds > idle_minutes*60 AND not already fired,
+    observer fires the shift report with trigger_kind='idle'."""
+    import codec_observer
+    # Set up shift_report config: idle_minutes=1 (60s) for test
+    (temp_state / "config.json").write_text(json.dumps({
+        "shift_report": {"idle_minutes": 1, "daily_at_hour": 99,  # never time-fire
+                         "daily_at_minute": 0},
+    }))
+    # Observer's _maybe_fire_shift_report imports shift_report — already
+    # imported in this test process. Reload to pick up the patched paths.
+    importlib.reload(shift_report)
+    # Reset state since reload also resets monkeypatched paths:
+    monkeypatch.setattr(shift_report, "_AUDIT_LOG", temp_state / "audit.log")
+    monkeypatch.setattr(shift_report, "_NOTIFS_PATH", temp_state / "notifications.json")
+    monkeypatch.setattr(shift_report, "_OBS_SUMMARIES_DIR", temp_state / "observation_summaries")
+    monkeypatch.setattr(shift_report, "_PROPOSALS_DIR", temp_state / "skill_proposals")
+    monkeypatch.setattr(shift_report, "_STATE_PATH", temp_state / "shift_report_state.json")
+    monkeypatch.setattr(shift_report, "_CONFIG_PATH", temp_state / "config.json")
+    monkeypatch.setattr(shift_report, "_CODEC_DIR", temp_state)
+    # idle_seconds = 120 (2 min) > 60s threshold
+    codec_observer._maybe_fire_shift_report(idle_seconds=120.0)
+    # Notification should be posted
+    notifs = json.loads((temp_state / "notifications.json").read_text())
+    assert len(notifs) == 1
+    assert notifs[0]["trigger_kind"] == "idle"
+
+
+def test_observer_time_path_does_not_fire_off_window(temp_state):
+    """If wall-clock hour doesn't match daily_at_hour, idle threshold not
+    met → no fire."""
+    import codec_observer
+    (temp_state / "config.json").write_text(json.dumps({
+        "shift_report": {"daily_at_hour": 99, "idle_minutes": 60},
+    }))
+    importlib.reload(shift_report)
+    codec_observer._maybe_fire_shift_report(idle_seconds=10.0)
+    assert not (temp_state / "notifications.json").exists()
+
+
+def test_observer_already_fired_today_suppresses(temp_state, monkeypatch):
+    """Observer's check honors per-day dedup."""
+    import codec_observer
+    # Set state to "fired today"
+    importlib.reload(shift_report)
+    monkeypatch.setattr(shift_report, "_AUDIT_LOG", temp_state / "audit.log")
+    monkeypatch.setattr(shift_report, "_NOTIFS_PATH", temp_state / "notifications.json")
+    monkeypatch.setattr(shift_report, "_OBS_SUMMARIES_DIR", temp_state / "observation_summaries")
+    monkeypatch.setattr(shift_report, "_PROPOSALS_DIR", temp_state / "skill_proposals")
+    monkeypatch.setattr(shift_report, "_STATE_PATH", temp_state / "shift_report_state.json")
+    monkeypatch.setattr(shift_report, "_CONFIG_PATH", temp_state / "config.json")
+    monkeypatch.setattr(shift_report, "_CODEC_DIR", temp_state)
+    shift_report.mark_fired_today("time")
+    (temp_state / "config.json").write_text(json.dumps({
+        "shift_report": {"daily_at_hour": 99, "idle_minutes": 1},
+    }))
+    # Even with 2-hour idle, no second fire today
+    codec_observer._maybe_fire_shift_report(idle_seconds=7200.0)
+    notifs_path = temp_state / "notifications.json"
+    if notifs_path.exists():
+        notifs = json.loads(notifs_path.read_text())
+        # Only the manual 'mark_fired' call — but mark_fired doesn't post,
+        # so there should be 0 actual notifs
+        assert all(n.get("trigger_kind") != "idle" for n in notifs)
+    # State stays as "time"
+    state = json.loads((temp_state / "shift_report_state.json").read_text())
+    assert state["last_trigger_kind"] == "time"


### PR DESCRIPTION
## Summary

Phase 2 Step 7 — final Phase 2 step. End-of-day summary of everything CODEC observed and accomplished. Single PWA notification with `type="shift_report"` and a 5-section markdown body the dashboard renders inline. **Phase 2 is complete after this lands.**

## Three trigger paths

| Trigger | When | Detected by |
|---|---|---|
| **time** | Wall clock matches `config.shift_report.daily_at_hour:daily_at_minute` (default 18:00 local) | `codec-observer` daemon loop |
| **idle** | `CGEventSourceSecondsSinceLastEventType` ≥ `config.shift_report.idle_minutes * 60` (default 30 min) | Same |
| **manual** | User invokes via skill name (`"shift report"`, `"what did i do today"`, `"summarize my day"`) | Chat / voice / MCP — bypasses dedup |

**Per-day dedup** at `~/.codec/shift_report_state.json` ensures time + idle fire at most once per local date; whichever wins suppresses the other. Manual invocations always work (so you can re-summarize any time).

## 5 sections, ~500-1500 words

1. **Completed tasks** — successful `tool_result` / `crew_complete` / `hook_fired` / `trigger_fired` counts + most-fired tools
2. **Blocked / stuck moments** — `stuck_warning` / `step_budget_exhausted` / `ask_user_question_timeout` / `trigger_blocked`
3. **Observed work patterns** — app time-share from `observation_tick` METADATA + persisted observer summary count
4. **Pending decisions** — open `type="question"` notifications + unreviewed skill proposals
5. **Tomorrow's open threads** — `crew_start` without matching `crew_complete` (incomplete operations)

Each section gracefully falls back to a "_(no data)_" placeholder for quiet days.

## Commits

| sha | what |
|---|---|
| `1601c4d` | Implementation: audit constants + skills/shift_report.py + codec_observer.py integration + 20 tests + AGENTS.md |

(Single commit — Step 7 is contained enough that a separate design doc + impl split would be overhead. The blueprint already covered §0-§10 design; this PR description serves as the design summary.)

## Test plan

- [x] `pytest tests/test_shift_report.py` → **20/20 passing in 0.16s**
- [x] All filesystem paths redirected to `tmp_path` per test — NO real `~/.codec/*` writes
- [x] All audit emits redirected to `tmp_path` — NO real audit.log writes
- [x] State files clean post-test: `pending_questions=0`, `Apple Reminders=0`, `/tmp/codec_*.txt=0`, `shift_report_state.json absent`
- [x] Per Step 4 contract: did NOT run full pytest suite

## Test breakdown (20)

| Area | Count | What |
|---|---|---|
| Assembly | 8 | Empty inputs / completed / blocked / observed_patterns / pending decisions / proposals / tomorrow / observer summaries |
| Notification + state | 3 | post type=shift_report / per-day dedup / manual bypasses dedup |
| Kill switch + config | 3 | disabled / default enabled / config overrides honored |
| Audit emit | 3 | started+completed share cid / extras carried / kill-switch silent |
| Observer integration | 3 | idle path fires / off-window doesn't / dedup honored across paths |

## §6 audit events (2 new)

| Event | Source | level | When |
|---|---|---|---|
| `shift_report_started` | `codec-shift-report` | info | Assembly opens — `extra.trigger_kind` |
| `shift_report_completed` | `codec-shift-report` | info | Assembly closes with summary stats — `extra.{trigger_kind, sections_included, word_count, audit_records_scanned, notifications_scanned, observer_summaries_used}` + top-level `duration_ms` |

Both share a single `correlation_id` (multi-emit op per Step 1 §1.4).

## What this PR does NOT do

- **No new PM2 service** — runs inline in `codec-observer`'s daemon loop
- **No Apple Reminders / Calendar / Notes**
- **No `_HTTP_BLOCKED` change**
- **No modification of `codec_self_improve.py`** (Step 4 work, sealed)
- **No auto-fire at merge time** — observer fires only when time or idle conditions match (default 18:00 OR 30 min idle)
- **No new PWA endpoint** — the existing notifications endpoint surfaces the report; `type="shift_report"` is the rendering hint

## Kill switch

`SHIFT_REPORT_ENABLED=false` env var blocks all three trigger paths (time / idle / manual). The skill is still discoverable but `run()` returns the disabled message immediately.

## After merge

1. `git pull` on main checkout
2. `cp ~/codec-repo/skills/shift_report.py ~/.codec/skills/shift_report.py` — copies the skill to the user runtime install (matches Phase 1 Step 4 pattern)
3. `pm2 restart codec-observer` — picks up the integration
4. To test manually: in chat or via MCP, `"shift report"` → posts a notification (bypasses dedup so you can iterate)
5. To verify time/idle paths: wait for 18:00 local OR be idle 30 min OR temporarily set `daily_at_hour` to a near-time value in `~/.codec/config.json:shift_report` and `pm2 restart codec-observer`

## Phase 2 status after this PR

- ✅ Step 5 (Continuous Observation Loop) — merged via PR #9 + hotfix #10
- ✅ Step 6 (Trigger System) — merged via PR #11
- 🟢 **Step 7 (Shift Report) — THIS PR**

After merge: **Phase 2 COMPLETE.** The blueprint's three-step plan delivered. Final write-up will live in `docs/PHASE2-COMPLETE.md` (similar to `docs/PHASE1-COMPLETE.md`) — I'll do that as a follow-up commit on main once you've burned in the shift report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)