### PR TITLE
hotfix: add shift_report to CHAT_SKILL_ALLOWLIST

### DIFF
--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -2138,6 +2138,8 @@ CHAT_SKILL_ALLOWLIST = {
     "ai_news_digest", "scheduler",
     # Skill creation & delegation
     "create_skill", "skill_forge", "ask_codec_to_build", "delegate",
+    # Phase 2 Step 7 — end-of-day shift report (read-only, no destructive side effects)
+    "shift_report",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shift_report.py
+++ b/tests/test_shift_report.py
@@ -1,11 +1,12 @@
 """Phase 2 Step 7 tests — skills/shift_report.py + codec_observer fire path.
 
-20 tests covering:
+21 tests covering:
   Assembly (8) — section rendering for each input source
   Notification + state (3) — post + dedup
   Kill switch + config (3)
   Trigger paths (3) — manual / time / idle
   Observer integration (3) — _maybe_fire_shift_report
+  Chat allowlist (1) — shift_report must be in CHAT_SKILL_ALLOWLIST
 
 All tests redirect storage paths to tmp_path. NO real filesystem writes
 to ~/.codec/* outside of explicit fixtures. NO real audit emits to
@@ -389,3 +390,24 @@ def test_observer_already_fired_today_suppresses(temp_state, monkeypatch):
     # State stays as "time"
     state = json.loads((temp_state / "shift_report_state.json").read_text())
     assert state["last_trigger_kind"] == "time"
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Chat allowlist regression test (1)
+# ────────────────────────────────────────────────────────────────────────
+
+def test_shift_report_in_chat_skill_allowlist():
+    """`shift_report` must be in `codec_dashboard.CHAT_SKILL_ALLOWLIST`.
+
+    Regression test for the post-PR-#12 deployment bug: chat path
+    `_try_skill` matched `shift_report` via SKILL_TRIGGERS, but the
+    allowlist gate then dropped it and the LLM fell through to
+    [SKILL:pm2_control:...]. The user typed 'shift report' and got a
+    PM2 service listing instead.
+    """
+    import codec_dashboard
+    assert "shift_report" in codec_dashboard.CHAT_SKILL_ALLOWLIST, (
+        "shift_report skill is not in CHAT_SKILL_ALLOWLIST — chat-path "
+        "dispatch will silently drop the match and fall through to LLM. "
+        "See: docs/known-issues.md → Phase 2 Step 7 sign-off."
+    )


### PR DESCRIPTION
## Summary

User typed `shift report` in PWA chat after PR #12 merged — got a PM2 service listing instead of the report. Root cause: `shift_report` was never added to `codec_dashboard.CHAT_SKILL_ALLOWLIST`, so `_try_skill` matched the skill via `SKILL_TRIGGERS` but the allowlist gate returned `(None, None)`. Chat fell through to the LLM, which heard "report" and emitted `[SKILL:pm2_control:pm2 list]`.

The voice path and MCP path don't use this allowlist, so direct Python invocation (the deployment fire test at `2026-05-02T18:49:40Z`, `cid=5f188e5485e5`) worked end-to-end — only the chat route was broken.

- One-line fix: add `"shift_report"` to `CHAT_SKILL_ALLOWLIST` (codec_dashboard.py +2/-1)
- Regression test: `tests/test_shift_report.py::test_shift_report_in_chat_skill_allowlist` asserts membership and fails loudly with a pointer to this PR if anyone removes it again

## Test plan
- [x] 🧪 RUNNING PYTEST NOW — `tests/test_shift_report.py` → 21 passed (was 20; +1 new regression test)
- [x] 🧪 Full suite — 824 passed / 20 failed / 73 skipped (same 20/73 baseline as main; +1 from regression test)
- [ ] After merge: `git pull && pm2 restart codec-dashboard`, type `shift report` in PWA chat, expect notification with `type=shift_report` and the markdown body inline (not the PM2 list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)