### PR TITLE
feat(phase3-step8): Plan + Permission Contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,9 +198,43 @@ End-of-day summary of everything CODEC observed and accomplished. Single notific
 
 Implementation: `skills/shift_report.py` (assembly + rendering + notification post + per-day state), `codec_observer.py` extension (calls `_maybe_fire_shift_report(idle)` after each poll, time + idle detection inside).
 
-### Other known gaps (tracked for Phase 2 follow-on)
+### Plan + Permission Contract (Phase 3 Step 8)
+
+Drop-a-project planning layer. User describes a project; Qwen-3.6 drafts a structured plan with explicit permission manifest (read paths, write paths, network domains, skills, destructive ops); user approves in PWA; grants persisted to `~/.codec/agents/<id>/grants.json` with `plan_hash` (sha256) for Step 9 tamper detection.
+
+**Storage:**
+- `~/.codec/agents/<id>/manifest.json` — id, title, status, plan_hash, timestamps
+- `~/.codec/agents/<id>/plan.json` — schema:1, goals, checkpoints, permission manifest
+- `~/.codec/agents/<id>/state.json` — current_checkpoint, retry_count
+- `~/.codec/agents/<id>/grants.json` — written at approval, includes `auto_approved` subset (items pre-allowed via global allowlist)
+- `~/.codec/agent_global_grants.json` — cross-agent allowlist (network domains / read paths / write paths / skills)
+
+**Status state machine** (Step 8 only — Step 9 will extend):
+`draft_pending → awaiting_approval → approved/rejected/revised → awaiting_approval (if revised)`. `plan_failed` is terminal-with-retry.
+
+**Public API (`codec_agent_plan`):**
+- `create_agent(title, description, registry=None)` → returns `agent_id`
+- `approve_plan(agent_id)` → returns grants dict (re-validates skills against registry, computes plan_hash)
+- `reject_plan(agent_id, reason="")`
+- `revise_plan(agent_id, edited_plan_dict, registry=None)` → returns Plan
+- `load_global_grants()` / `add_global_grant(kind, value)` / `remove_global_grant(kind, value)`
+
+**PWA endpoints (`routes/agents.py`):** `POST /api/agents` (create + draft), `GET /api/agents` (list), `GET /api/agents/{id}` (detail), `POST /api/agents/{id}/approve`, `/reject`, `/revise`, `GET/POST/DELETE /api/agent_global_grants`.
+
+**LLM:** local Qwen-3.6 only via `http://127.0.0.1:8090/v1/chat/completions` (per Q1 — no cloud fallback).
+
+**Vague-description handling (Q3):** if LLM detects scope is too thin, agent posts up to 3 rounds of clarifying questions via `codec_ask_user.ask` before drafting. After 3 rounds without convergence: status=`plan_failed`, reason=`description_too_vague`.
+
+**Kill switch:** `AGENT_PLANNING_ENABLED=false` blocks drafting (existing plans untouched).
+
+**6 audit events** (paired correlation_id per Step 1 §1.4 contract): `agent_plan_drafted`, `_approved`, `_rejected`, `_revised`, `agent_global_grant_added`, `_removed`.
+
+Implementation: `codec_agent_plan.py` (~640 LOC), `routes/agents.py` (~250 LOC of new endpoints).
+
+### Other known gaps (tracked for Phase 3 follow-on)
+- Step 8 ships planning ONLY — no execution (Step 9 picks that up)
 - No formal teammate / sub-agent recursion — Crew is the only multi-agent primitive
-- (none — Phase 2 complete after Step 7 ships)
+- (Phase 3 complete after Steps 9 + 10 ship)
 
 ## 4. Skill system
 
@@ -350,6 +384,21 @@ Two new event names. Both `level="info"` (operational). `shift_report_started` o
 
 `PHASE2_STEP7_EVENTS` frozenset exposed.
 
+#### Phase 3 Step 8 events — agent planning lifecycle
+
+Six event names. All `level="info"` except `_rejected` (warning). Each is a single-emit operation; the `_drafted → _approved` (or `_drafted → _rejected`) sequence shares no implicit correlation_id since they're independent user-driven transitions (each gets a fresh cid generated at emit time).
+
+| Event | Source | level | extra fields |
+|---|---|---|---|
+| `agent_plan_drafted` | `codec-agent-plan` | info | `agent_id`, `checkpoint_count`, `estimated_duration_minutes`, `skills_count`, `domains_count` |
+| `agent_plan_approved` | `codec-agent-plan` | info | `agent_id`, `plan_hash` (sha256 hex), `checkpoint_count`, `skills_count`, `domains_count` |
+| `agent_plan_rejected` | `codec-agent-plan` | warning | `agent_id`, `reason` (truncated to 200 chars) |
+| `agent_plan_revised` | `codec-agent-plan` | info | `agent_id`, `checkpoint_count` |
+| `agent_global_grant_added` | `codec-agent-plan` | info | `kind` (`network_domains` \| `read_paths` \| `write_paths` \| `skills`), `value` |
+| `agent_global_grant_removed` | `codec-agent-plan` | info | `kind`, `value` |
+
+`PHASE3_STEP8_EVENTS` frozenset exposed.
+
 ### Notifications (`~/.codec/notifications.json`)
 Four sources can produce notifications: scheduler (crew completion), heartbeat (threshold alert), autopilot (ambient trigger), and Phase 1 Step 3's AskUserQuestion (`type="question"`). All write through `routes/_shared.py:51-127` except AskUserQuestion which writes via `codec_ask_user._write_question_notification`.
 
@@ -497,6 +546,12 @@ These zones break running infrastructure if changed without coordination. NEVER 
 - `~/.codec/shift_report_state.json` (Phase 2 Step 7) — per-day fire dedup state (`last_fired_date`, `last_fired_at`, `last_trigger_kind`). Owned by `skills/shift_report.mark_fired_today()`. Safe to delete to force-fire today again; do not hand-edit (atomic-write contract).
 - `SHIFT_REPORT_ENABLED` env var (Phase 2 Step 7, default `true`). False blocks all three trigger paths (time / idle / manual).
 - `~/.codec/config.json:shift_report.{daily_at_hour, daily_at_minute, idle_minutes, lookback_hours, auto_save_path}` — Phase 2 Step 7 tunables. `auto_save_path` is `null` by default (notification-only); set to a directory path to also write `YYYY-MM-DD.md` files.
+- `codec_agent_plan.py` (Phase 3 Step 8) — Plan + Permission Contract module. Don't refactor without re-running the PHASE3-STEP8 design gate. The dataclasses (`Plan`, `Checkpoint`, `PermissionManifest`) and `plan_from_dict()` lock the on-disk schema; bumping `PLAN_SCHEMA_VERSION` requires migration logic.
+- `routes/agents.py` Phase 3 Step 8 endpoints (`/api/agents`, `/api/agent_global_grants`) — don't change endpoint shapes without bumping API version. PWA reads these directly.
+- `~/.codec/agents/<id>/` — per-agent runtime state. Modify only via the documented public API (`codec_agent_plan.create_agent`, `approve_plan`, `reject_plan`, `revise_plan`). Direct edits to `plan.json` after approval will fail Step 9's plan-hash tamper check.
+- `~/.codec/agent_global_grants.json` (Phase 3 Step 8) — cross-agent allowlist. Modify only via `add_global_grant()` / `remove_global_grant()` or the `/api/agent_global_grants` endpoints. Atomic-write contract.
+- `AGENT_PLANNING_ENABLED` env var (Phase 3 Step 8, default `true`). Setting `false` blocks plan drafting; existing approved plans are untouched.
+- `MAX_CLARIFYING_ROUNDS` constant in `codec_agent_plan.py` (default 3) — caps the vague-description clarifying loop. Tune up cautiously; users can get stuck in long Q&A loops if too high.
 
 ## 11. Working with this repo as a coding agent
 

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -413,3 +413,51 @@ def draft_plan_with_clarification(agent_id: str, description: str,
                 raise  # bubble other validation errors
 
     raise DescriptionTooVagueError(f"reached max_rounds={max_rounds} unexpectedly")
+
+
+# ── Global allowlist (Q4 — cross-agent permissions) ───────────────────────────
+_GLOBAL_GRANT_KINDS = frozenset({
+    "network_domains", "read_paths", "write_paths", "skills",
+})
+
+
+def _empty_global_grants() -> Dict[str, Any]:
+    return {
+        "schema": GLOBAL_GRANTS_SCHEMA_VERSION, "version": 0,
+        "network_domains": [], "read_paths": [], "write_paths": [], "skills": [],
+    }
+
+
+def load_global_grants() -> Dict[str, Any]:
+    """Read ~/.codec/agent_global_grants.json, returning empty struct if missing."""
+    return _read_json(_GLOBAL_GRANTS_PATH) or _empty_global_grants()
+
+
+def add_global_grant(kind: str, value: str) -> None:
+    """Add `value` to the global allowlist for `kind`. Idempotent.
+    Bumps version and writes atomically."""
+    if kind not in _GLOBAL_GRANT_KINDS:
+        raise ValueError(f"invalid grant kind: {kind!r}; expected one of {sorted(_GLOBAL_GRANT_KINDS)}")
+    g = load_global_grants()
+    if value not in g[kind]:
+        g[kind] = sorted(g[kind] + [value])
+    g["version"] = int(g.get("version", 0)) + 1
+    g["updated_at"] = _now_iso()
+    _atomic_write_json(_GLOBAL_GRANTS_PATH, g)
+
+
+def remove_global_grant(kind: str, value: str) -> None:
+    """Remove `value` from `kind`. Idempotent (no-op if absent)."""
+    if kind not in _GLOBAL_GRANT_KINDS:
+        raise ValueError(f"invalid grant kind: {kind!r}")
+    g = load_global_grants()
+    if value in g[kind]:
+        g[kind] = [v for v in g[kind] if v != value]
+    g["version"] = int(g.get("version", 0)) + 1
+    g["updated_at"] = _now_iso()
+    _atomic_write_json(_GLOBAL_GRANTS_PATH, g)
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -1,0 +1,104 @@
+"""CODEC Phase 3 Step 8 — Plan + Permission Contract.
+
+When user drops a project, this module:
+  1. Drafts a structured plan via Qwen-3.6 (local LLM).
+  2. Validates skills_needed against codec_skill_registry.
+  3. Auto-approves items already in the global allowlist.
+  4. Persists to ~/.codec/agents/<id>/ with atomic tmp+rename writes.
+  5. Surfaces the plan + permission manifest via the FastAPI router in
+     routes/agents.py so the PWA can show approve/edit/reject UI.
+
+Step 8 ships planning ONLY — no execution. Step 9 (codec_agent_runner.py)
+will pick up status=approved plans and run them.
+
+Reuses:
+  - codec_audit.audit() — Step 1 envelope, paired correlation_id
+  - codec_skill_registry.SkillRegistry — skill validation
+  - codec_ask_user.ask — clarifying questions for vague descriptions
+
+See docs/PHASE3-BLUEPRINT.md §2 for design rationale.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import secrets
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+log = logging.getLogger("codec_agent_plan")
+
+# ── Storage paths (overridable for tests) ─────────────────────────────────────
+_CODEC_DIR = Path(os.path.expanduser("~/.codec"))
+_AGENTS_DIR = _CODEC_DIR / "agents"
+_GLOBAL_GRANTS_PATH = _CODEC_DIR / "agent_global_grants.json"
+
+# ── Schema constants ──────────────────────────────────────────────────────────
+PLAN_SCHEMA_VERSION = 1
+GLOBAL_GRANTS_SCHEMA_VERSION = 1
+DEFAULT_STEP_BUDGET_PER_CHECKPOINT = 30
+MAX_CLARIFYING_ROUNDS = 3
+
+
+# ── Dataclasses ───────────────────────────────────────────────────────────────
+@dataclass
+class Checkpoint:
+    id: str
+    title: str
+    description: str
+    skills_needed: List[str]
+    expected_output: str
+    step_budget: int = DEFAULT_STEP_BUDGET_PER_CHECKPOINT
+
+
+@dataclass
+class PermissionManifest:
+    read_paths: List[str]
+    write_paths: List[str]
+    network_domains: List[str]
+    skills: List[str]
+    destructive_ops: List[str]
+
+
+@dataclass
+class Plan:
+    schema: int
+    agent_id: str
+    goals: List[str]
+    checkpoints: List[Checkpoint]
+    permission_manifest: PermissionManifest
+    estimated_duration_minutes: int
+    assumptions: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "agent_id": self.agent_id,
+            "goals": list(self.goals),
+            "checkpoints": [asdict(cp) for cp in self.checkpoints],
+            "permission_manifest": asdict(self.permission_manifest),
+            "estimated_duration_minutes": self.estimated_duration_minutes,
+            "assumptions": list(self.assumptions),
+        }
+
+
+def plan_from_dict(d: Dict[str, Any]) -> Plan:
+    """Inverse of Plan.to_dict; raises ValueError on bad schema."""
+    if d.get("schema") != PLAN_SCHEMA_VERSION:
+        raise ValueError(f"unsupported plan schema: {d.get('schema')!r}")
+    cps = [Checkpoint(**cp) for cp in d.get("checkpoints", [])]
+    pm = PermissionManifest(**d["permission_manifest"])
+    return Plan(
+        schema=int(d["schema"]),
+        agent_id=str(d["agent_id"]),
+        goals=list(d.get("goals", [])),
+        checkpoints=cps,
+        permission_manifest=pm,
+        estimated_duration_minutes=int(d.get("estimated_duration_minutes", 0)),
+        assumptions=list(d.get("assumptions", [])),
+    )

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -573,3 +573,87 @@ def create_agent(title: str, description: str,
            })
 
     return agent_id
+
+
+def approve_plan(agent_id: str) -> Dict[str, Any]:
+    """Transition awaiting_approval → approved. Computes plan_hash for
+    Step 9 tamper detection. Writes grants.json (= full manifest by
+    default — Step 8 doesn't yet support partial grants; approve == all)."""
+    plan = load_plan(agent_id)
+    if plan is None:
+        raise ValueError(f"no plan found for {agent_id!r}")
+
+    plan_hash = compute_plan_hash(plan)
+
+    grants = {
+        "schema": 1,
+        "agent_id": agent_id,
+        "approved_at": _now_iso(),
+        # Initial v1: grants == manifest (no partial grants yet)
+        **asdict(plan.permission_manifest),
+    }
+    save_grants(agent_id, grants)
+
+    # Update manifest with hash + transition status
+    manifest = load_manifest(agent_id)
+    manifest["plan_hash"] = plan_hash
+    manifest["approved_at"] = _now_iso()
+    save_manifest(agent_id, manifest)
+    set_status(agent_id, "approved")
+
+    cid = secrets.token_hex(6)
+    _audit("agent_plan_approved", "codec-agent-plan",
+           f"plan approved for {agent_id}",
+           correlation_id=cid,
+           extra={
+               "agent_id": agent_id, "plan_hash": plan_hash,
+               "checkpoint_count": len(plan.checkpoints),
+               "skills_count": len(plan.permission_manifest.skills),
+               "domains_count": len(plan.permission_manifest.network_domains),
+           })
+
+    return grants
+
+
+def reject_plan(agent_id: str, reason: str = "") -> None:
+    """Transition awaiting_approval → rejected. Plan dir kept for review/TTL."""
+    set_status(agent_id, "rejected", reason=reason or "no reason")
+
+    cid = secrets.token_hex(6)
+    _audit("agent_plan_rejected", "codec-agent-plan",
+           f"plan rejected for {agent_id}: {reason[:80]}",
+           correlation_id=cid, outcome="warning",
+           extra={"agent_id": agent_id, "reason": reason[:200]})
+
+
+def revise_plan(agent_id: str, edited_plan_dict: Dict[str, Any],
+                registry=None) -> Plan:
+    """User submitted an edited plan. Re-validate against registry.
+    On success: persist new plan, transition awaiting_approval → revised
+    → awaiting_approval (immediately) so user re-reviews."""
+    edited_plan_dict.setdefault("schema", PLAN_SCHEMA_VERSION)
+    edited_plan_dict.setdefault("agent_id", agent_id)
+
+    try:
+        plan = plan_from_dict(edited_plan_dict)
+    except (KeyError, ValueError, TypeError) as e:
+        raise PlanValidationError(f"edited plan schema invalid: {e}")
+
+    ok, missing = validate_plan_skills(plan, registry=registry)
+    if not ok:
+        raise PlanValidationError(f"edited plan references unknown skills: {missing}")
+
+    save_plan(plan)
+    # Transition: awaiting_approval → revised → back to awaiting_approval
+    set_status(agent_id, "revised")
+    set_status(agent_id, "awaiting_approval")
+
+    cid = secrets.token_hex(6)
+    _audit("agent_plan_revised", "codec-agent-plan",
+           f"plan revised for {agent_id}", correlation_id=cid,
+           extra={
+               "agent_id": agent_id,
+               "checkpoint_count": len(plan.checkpoints),
+           })
+
+    return plan

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -110,3 +110,90 @@ def compute_plan_hash(plan: Plan) -> str:
     means someone manually edited plan.json after approval."""
     canonical = json.dumps(plan.to_dict(), sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ── Atomic file I/O (tmp+rename pattern from Phase 2) ─────────────────────────
+def _atomic_write_json(path: Path, data: Any) -> None:
+    """Write JSON atomically: write to .tmp, fsync, rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=False)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, path)
+
+
+def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        log.warning("read_json failed for %s: %s", path, e)
+        return None
+
+
+def _agent_dir(agent_id: str) -> Path:
+    return _AGENTS_DIR / agent_id
+
+
+# ── Plan R/W ──────────────────────────────────────────────────────────────────
+def save_plan(plan: Plan) -> None:
+    _atomic_write_json(_agent_dir(plan.agent_id) / "plan.json", plan.to_dict())
+
+
+def load_plan(agent_id: str) -> Optional[Plan]:
+    d = _read_json(_agent_dir(agent_id) / "plan.json")
+    return plan_from_dict(d) if d else None
+
+
+# ── State R/W ─────────────────────────────────────────────────────────────────
+def save_state(agent_id: str, state: Dict[str, Any]) -> None:
+    _atomic_write_json(_agent_dir(agent_id) / "state.json", state)
+
+
+def load_state(agent_id: str) -> Dict[str, Any]:
+    return _read_json(_agent_dir(agent_id) / "state.json") or {}
+
+
+# ── Manifest R/W ──────────────────────────────────────────────────────────────
+def save_manifest(agent_id: str, manifest: Dict[str, Any]) -> None:
+    _atomic_write_json(_agent_dir(agent_id) / "manifest.json", manifest)
+
+
+def load_manifest(agent_id: str) -> Dict[str, Any]:
+    return _read_json(_agent_dir(agent_id) / "manifest.json") or {}
+
+
+# ── Grants R/W ────────────────────────────────────────────────────────────────
+def save_grants(agent_id: str, grants: Dict[str, Any]) -> None:
+    _atomic_write_json(_agent_dir(agent_id) / "grants.json", grants)
+
+
+def load_grants(agent_id: str) -> Dict[str, Any]:
+    return _read_json(_agent_dir(agent_id) / "grants.json") or {}
+
+
+# ── Skill-registry validation ─────────────────────────────────────────────────
+def validate_plan_skills(plan: Plan, registry=None) -> Tuple[bool, List[str]]:
+    """Walk every checkpoint's skills_needed; return (ok, missing_skills).
+    If `registry` is None, lazy-imports codec_skill_registry's default
+    instance (via codec_dispatch)."""
+    if registry is None:
+        try:
+            from codec_dispatch import registry as _reg
+            registry = _reg
+        except Exception:
+            log.warning("codec_dispatch unavailable; cannot validate skills")
+            return (False, ["__registry_unavailable__"])
+
+    known = set(registry.names() or [])
+    needed = set()
+    for cp in plan.checkpoints:
+        needed.update(cp.skills_needed)
+    needed.update(plan.permission_manifest.skills)
+
+    missing = sorted(needed - known)
+    return (len(missing) == 0, missing)

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -461,3 +461,39 @@ def remove_global_grant(kind: str, value: str) -> None:
 def _now_iso() -> str:
     from datetime import datetime, timezone
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+# ── Status transitions ────────────────────────────────────────────────────────
+class InvalidStatusTransition(ValueError):
+    """Disallowed status transition attempted."""
+
+
+# Step 8 only manages: draft_pending → awaiting_approval → approved/rejected/revised.
+# Step 9 introduces: approved → running → checkpoint_completed/blocked_*/aborted/completed.
+# This map will be EXTENDED in Step 9.
+_VALID_TRANSITIONS: Dict[str, frozenset] = {
+    "draft_pending":      frozenset({"awaiting_approval", "plan_failed"}),
+    "awaiting_approval":  frozenset({"approved", "rejected", "revised"}),
+    "revised":            frozenset({"awaiting_approval"}),
+    "approved":           frozenset({"rejected"}),  # Step 9 will add: running
+    "rejected":           frozenset(),
+    "plan_failed":        frozenset({"draft_pending"}),  # retry path
+}
+
+
+def set_status(agent_id: str, new_status: str, reason: Optional[str] = None) -> None:
+    """Atomically transition manifest.json's status. Raises
+    InvalidStatusTransition if the move violates the state machine."""
+    manifest = load_manifest(agent_id)
+    current = manifest.get("status", "draft_pending")
+    allowed = _VALID_TRANSITIONS.get(current, frozenset())
+    if new_status not in allowed:
+        raise InvalidStatusTransition(
+            f"cannot transition {current!r} → {new_status!r} "
+            f"(allowed: {sorted(allowed)})"
+        )
+    manifest["status"] = new_status
+    manifest["updated_at"] = _now_iso()
+    if reason:
+        manifest["status_reason"] = reason
+    save_manifest(agent_id, manifest)

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -583,6 +583,13 @@ def approve_plan(agent_id: str) -> Dict[str, Any]:
     if plan is None:
         raise ValueError(f"no plan found for {agent_id!r}")
 
+    # Re-validate skills against registry (skills may have been deleted between draft & approval)
+    ok, missing = validate_plan_skills(plan)
+    if not ok:
+        raise PlanValidationError(
+            f"plan references skills no longer in registry: {missing}"
+        )
+
     plan_hash = compute_plan_hash(plan)
 
     # Compute auto_approved subset for UI rendering

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -585,11 +585,21 @@ def approve_plan(agent_id: str) -> Dict[str, Any]:
 
     plan_hash = compute_plan_hash(plan)
 
+    # Compute auto_approved subset for UI rendering
+    global_grants = load_global_grants()
+    auto_approved: Dict[str, List[str]] = {}
+    for kind in ("network_domains", "read_paths", "write_paths", "skills"):
+        plan_items = getattr(plan.permission_manifest, kind)
+        global_items = set(global_grants.get(kind, []))
+        approved_via_global = [item for item in plan_items if item in global_items]
+        if approved_via_global:
+            auto_approved[kind] = approved_via_global
+
     grants = {
         "schema": 1,
         "agent_id": agent_id,
         "approved_at": _now_iso(),
-        # Initial v1: grants == manifest (no partial grants yet)
+        "auto_approved": auto_approved,
         **asdict(plan.permission_manifest),
     }
     save_grants(agent_id, grants)

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -319,6 +319,10 @@ def draft_plan(agent_id: str, description: str, registry=None,
     except json.JSONDecodeError as e:
         raise PlanValidationError(f"qwen3.6 returned non-JSON: {e}; raw={raw[:300]!r}")
 
+    # Detect "too_vague" sentinel from LLM
+    if d.get("too_vague"):
+        raise PlanValidationError("too_vague: description needs clarification")
+
     # Inject schema + agent_id (LLM doesn't need to know schema number)
     d.setdefault("schema", PLAN_SCHEMA_VERSION)
     d.setdefault("agent_id", agent_id)
@@ -346,3 +350,66 @@ def _stable_checkpoint_id(cp_dict: Dict[str, Any]) -> str:
     the same conceptual checkpoint."""
     seed = f"{cp_dict.get('title', '')}|{cp_dict.get('description', '')}"
     return hashlib.sha1(seed.encode("utf-8")).hexdigest()[:8]
+
+
+class DescriptionTooVagueError(ValueError):
+    """User's project description couldn't be scoped after MAX_CLARIFYING_ROUNDS."""
+
+
+def _ask_user(question: str, *, agent_id: str,
+              deadline_seconds: int = 600) -> Tuple[str, Any]:
+    """Lazy-loaded codec_ask_user.ask wrapper. Returns (status, answer).
+    status ∈ {"answered", "ambiguous_consent", "timeout"}."""
+    try:
+        from codec_ask_user import ask, TIMEOUT_SENTINEL
+    except Exception as e:
+        log.warning("codec_ask_user unavailable: %s", e)
+        return ("timeout", TIMEOUT_SENTINEL if 'TIMEOUT_SENTINEL' in dir() else None)
+    return ask(question, source=f"agent_plan:{agent_id}",
+               deadline_seconds=deadline_seconds)
+
+
+def draft_plan_with_clarification(agent_id: str, description: str,
+                                  registry=None,
+                                  max_rounds: int = MAX_CLARIFYING_ROUNDS) -> Plan:
+    """Wrap draft_plan with a clarifying-question loop. If LLM returns
+    {"too_vague": True, "clarifying_questions": [...]}, ask user via
+    codec_ask_user.ask, append answers to description, retry. After
+    max_rounds without convergence, raise DescriptionTooVagueError."""
+    enriched_description = description
+
+    for round_idx in range(max_rounds + 1):
+        try:
+            return draft_plan(agent_id, enriched_description, registry=registry)
+        except PlanValidationError as e:
+            # Check if this was a "too_vague" response (sentinel from LLM)
+            if "too_vague" in str(e).lower():
+                if round_idx >= max_rounds:
+                    raise DescriptionTooVagueError(
+                        f"description still too vague after {max_rounds} rounds"
+                    )
+                # Re-call qwen JUST to extract clarifying questions
+                raw = _qwen_chat(
+                    user_prompt=enriched_description,
+                    system_prompt="The previous attempt was too vague. Output ONLY a JSON object: "
+                                  "{\"clarifying_questions\": [<q1>, <q2>, <q3>]}",
+                )
+                try:
+                    qs = json.loads(raw).get("clarifying_questions", [])
+                except json.JSONDecodeError:
+                    qs = ["Can you describe what you want CODEC to build, in more concrete terms?"]
+                # Ask user; combine answer with description and retry
+                full_q = "I need clarification before drafting a plan:\n\n" + \
+                         "\n".join(f"  {i+1}. {q}" for i, q in enumerate(qs[:3]))
+                status, ans = _ask_user(full_q, agent_id=agent_id)
+                if status != "answered":
+                    raise DescriptionTooVagueError(
+                        f"clarification not answered (status={status})"
+                    )
+                enriched_description = (
+                    f"{enriched_description}\n\n[user clarification round {round_idx+1}]\n{ans}"
+                )
+            else:
+                raise  # bubble other validation errors
+
+    raise DescriptionTooVagueError(f"reached max_rounds={max_rounds} unexpectedly")

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -197,3 +197,152 @@ def validate_plan_skills(plan: Plan, registry=None) -> Tuple[bool, List[str]]:
 
     missing = sorted(needed - known)
     return (len(missing) == 0, missing)
+
+
+# ── Qwen-3.6 client ───────────────────────────────────────────────────────────
+QWEN_URL = "http://127.0.0.1:8090/v1/chat/completions"
+QWEN_MODEL = "qwen3.6"
+QWEN_TIMEOUT = 60  # seconds
+
+
+class QwenUnavailableError(RuntimeError):
+    """Qwen-3.6 service down or unreachable."""
+
+
+class PlanValidationError(ValueError):
+    """Plan failed schema or skill-registry validation."""
+
+
+def _qwen_chat(user_prompt: str, system_prompt: str = "",
+               max_tokens: int = 4000) -> str:
+    """Call local Qwen-3.6 OpenAI-compatible endpoint. Returns the
+    assistant's content string. Raises QwenUnavailableError on
+    network failure or non-2xx response."""
+    import requests  # lazy import — avoid forcing requests on test machines without it
+
+    payload = {
+        "model": QWEN_MODEL,
+        "messages": [
+            {"role": "system", "content": system_prompt or ""},
+            {"role": "user",   "content": user_prompt},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.2,
+    }
+    try:
+        r = requests.post(QWEN_URL, json=payload, timeout=QWEN_TIMEOUT)
+    except requests.exceptions.ConnectionError as e:
+        raise QwenUnavailableError(f"qwen3.6 unreachable: {e}")
+    except requests.exceptions.Timeout:
+        raise QwenUnavailableError("qwen3.6 request timed out")
+    if r.status_code != 200:
+        raise QwenUnavailableError(f"qwen3.6 returned {r.status_code}: {r.text[:200]}")
+    try:
+        data = r.json()
+        return data["choices"][0]["message"]["content"]
+    except (KeyError, json.JSONDecodeError) as e:
+        raise QwenUnavailableError(f"qwen3.6 returned malformed response: {e}")
+
+
+# ── Plan drafting ─────────────────────────────────────────────────────────────
+_PLAN_SYSTEM_PROMPT = """You are CODEC's plan generator. The user describes a project. \
+You return ONLY a JSON object matching this schema:
+
+{
+  "goals":         [<string>, ...],
+  "checkpoints": [
+    {
+      "title":           <string>,
+      "description":     <string>,
+      "skills_needed":   [<skill_name>, ...],
+      "expected_output": <string>,
+      "step_budget":     <int, default 30>
+    }
+  ],
+  "permission_manifest": {
+    "read_paths":      [<glob>, ...],
+    "write_paths":     [<glob — MUST be under ~/.codec/agents/{agent_id}/artifacts/ unless user grants more>, ...],
+    "network_domains": [<domain>, ...],
+    "skills":          [<union of all checkpoints.skills_needed>, ...],
+    "destructive_ops": [<op-id>, ...]
+  },
+  "estimated_duration_minutes": <int>,
+  "assumptions": [<string>, ...]
+}
+
+Rules:
+- Output ONLY valid JSON. No prose before or after.
+- skills_needed MUST be skill names from the user-supplied registry list. Never invent skill names.
+- write_paths default to ~/.codec/agents/{agent_id}/artifacts/** unless the project explicitly requires writing elsewhere.
+- destructive_ops list any irreversible operations (deletes, payments, sending emails on user's behalf). They will require additional consent at runtime.
+- estimated_duration_minutes is your best honest guess.
+"""
+
+
+def draft_plan(agent_id: str, description: str, registry=None,
+               available_skills: Optional[List[str]] = None) -> Plan:
+    """Call Qwen-3.6 with the project description, parse response into Plan,
+    validate against skill registry. Raises PlanValidationError on schema or
+    validation failure; QwenUnavailableError on LLM unavailability."""
+    if registry is None:
+        try:
+            from codec_dispatch import registry as _reg
+            registry = _reg
+        except Exception:
+            raise PlanValidationError("codec_dispatch unavailable; cannot validate skills")
+
+    if available_skills is None:
+        available_skills = sorted(registry.names() or [])
+
+    user_prompt = (
+        f"agent_id: {agent_id}\n\n"
+        f"Available skills (registry): {', '.join(available_skills)}\n\n"
+        f"Project description:\n{description}\n\n"
+        f"Generate the JSON plan now."
+    )
+
+    try:
+        raw = _qwen_chat(user_prompt, _PLAN_SYSTEM_PROMPT)
+    except QwenUnavailableError:
+        raise
+    except (ConnectionError, OSError, RuntimeError) as e:
+        raise QwenUnavailableError(f"qwen3.6 error: {e}")
+
+    # Strip code fences if Qwen wraps in ```json ... ```
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```(?:json)?\s*", "", raw)
+        raw = re.sub(r"\s*```\s*$", "", raw)
+
+    try:
+        d = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise PlanValidationError(f"qwen3.6 returned non-JSON: {e}; raw={raw[:300]!r}")
+
+    # Inject schema + agent_id (LLM doesn't need to know schema number)
+    d.setdefault("schema", PLAN_SCHEMA_VERSION)
+    d.setdefault("agent_id", agent_id)
+
+    # Compute checkpoint IDs deterministically
+    for cp in d.get("checkpoints", []):
+        cp.setdefault("id", _stable_checkpoint_id(cp))
+
+    try:
+        plan = plan_from_dict(d)
+    except (KeyError, ValueError, TypeError) as e:
+        raise PlanValidationError(f"plan schema invalid: {e}")
+
+    ok, missing = validate_plan_skills(plan, registry=registry)
+    if not ok:
+        raise PlanValidationError(
+            f"plan references unknown skills: {missing}"
+        )
+
+    return plan
+
+
+def _stable_checkpoint_id(cp_dict: Dict[str, Any]) -> str:
+    """SHA-1 first 8 of (title + description). Stable across re-drafts of
+    the same conceptual checkpoint."""
+    seed = f"{cp_dict.get('title', '')}|{cp_dict.get('description', '')}"
+    return hashlib.sha1(seed.encode("utf-8")).hexdigest()[:8]

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -102,3 +102,11 @@ def plan_from_dict(d: Dict[str, Any]) -> Plan:
         estimated_duration_minutes=int(d.get("estimated_duration_minutes", 0)),
         assumptions=list(d.get("assumptions", [])),
     )
+
+
+def compute_plan_hash(plan: Plan) -> str:
+    """SHA-256 of canonical JSON serialization. Stored in manifest at
+    approval time; daemon (Step 9) verifies on every tick. Mismatch
+    means someone manually edited plan.json after approval."""
+    canonical = json.dumps(plan.to_dict(), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -33,6 +33,28 @@ from typing import Any, Dict, List, Optional, Tuple
 
 log = logging.getLogger("codec_agent_plan")
 
+# Audit event names — mirror codec_audit constants (single source of truth).
+# Imported at module level so emit sites use the constants and any rename in
+# codec_audit will fail loudly here at import time rather than silently drift.
+try:
+    from codec_audit import (  # noqa: E402
+        AGENT_PLAN_DRAFTED,
+        AGENT_PLAN_APPROVED,
+        AGENT_PLAN_REJECTED,
+        AGENT_PLAN_REVISED,
+        AGENT_GLOBAL_GRANT_ADDED,
+        AGENT_GLOBAL_GRANT_REMOVED,
+    )
+except ImportError:
+    # codec_audit not on path during isolated test collection — fall back to
+    # the canonical strings so import doesn't break.
+    AGENT_PLAN_DRAFTED = "agent_plan_drafted"
+    AGENT_PLAN_APPROVED = "agent_plan_approved"
+    AGENT_PLAN_REJECTED = "agent_plan_rejected"
+    AGENT_PLAN_REVISED = "agent_plan_revised"
+    AGENT_GLOBAL_GRANT_ADDED = "agent_global_grant_added"
+    AGENT_GLOBAL_GRANT_REMOVED = "agent_global_grant_removed"
+
 # ── Storage paths (overridable for tests) ─────────────────────────────────────
 _CODEC_DIR = Path(os.path.expanduser("~/.codec"))
 _AGENTS_DIR = _CODEC_DIR / "agents"
@@ -361,10 +383,10 @@ def _ask_user(question: str, *, agent_id: str,
     """Lazy-loaded codec_ask_user.ask wrapper. Returns (status, answer).
     status ∈ {"answered", "ambiguous_consent", "timeout"}."""
     try:
-        from codec_ask_user import ask, TIMEOUT_SENTINEL
+        from codec_ask_user import ask
     except Exception as e:
         log.warning("codec_ask_user unavailable: %s", e)
-        return ("timeout", TIMEOUT_SENTINEL if 'TIMEOUT_SENTINEL' in dir() else None)
+        return ("timeout", None)
     return ask(question, source=f"agent_plan:{agent_id}",
                deadline_seconds=deadline_seconds)
 
@@ -545,14 +567,14 @@ def create_agent(title: str, description: str,
         plan = draft_plan_with_clarification(agent_id, description, registry=registry)
     except DescriptionTooVagueError as e:
         set_status(agent_id, "plan_failed", reason=f"too_vague: {e}")
-        _audit("agent_plan_rejected", "codec-agent-plan",
+        _audit(AGENT_PLAN_REJECTED, "codec-agent-plan",
                f"plan failed (vague): {e}", correlation_id=cid,
                outcome="warning", level="warning",
                extra={"agent_id": agent_id, "reason": "too_vague"})
         raise
     except (PlanValidationError, QwenUnavailableError) as e:
         set_status(agent_id, "plan_failed", reason=str(e))
-        _audit("agent_plan_rejected", "codec-agent-plan",
+        _audit(AGENT_PLAN_REJECTED, "codec-agent-plan",
                f"plan failed: {e}", correlation_id=cid,
                outcome="error", level="error",
                extra={"agent_id": agent_id, "reason": str(e)[:200]})
@@ -562,7 +584,7 @@ def create_agent(title: str, description: str,
     save_plan(plan)
     set_status(agent_id, "awaiting_approval")
 
-    _audit("agent_plan_drafted", "codec-agent-plan",
+    _audit(AGENT_PLAN_DRAFTED, "codec-agent-plan",
            f"plan drafted for {title[:60]}", correlation_id=cid,
            extra={
                "agent_id": agent_id,
@@ -619,7 +641,7 @@ def approve_plan(agent_id: str) -> Dict[str, Any]:
     set_status(agent_id, "approved")
 
     cid = secrets.token_hex(6)
-    _audit("agent_plan_approved", "codec-agent-plan",
+    _audit(AGENT_PLAN_APPROVED, "codec-agent-plan",
            f"plan approved for {agent_id}",
            correlation_id=cid,
            extra={
@@ -637,7 +659,7 @@ def reject_plan(agent_id: str, reason: str = "") -> None:
     set_status(agent_id, "rejected", reason=reason or "no reason")
 
     cid = secrets.token_hex(6)
-    _audit("agent_plan_rejected", "codec-agent-plan",
+    _audit(AGENT_PLAN_REJECTED, "codec-agent-plan",
            f"plan rejected for {agent_id}: {reason[:80]}",
            correlation_id=cid, outcome="warning",
            extra={"agent_id": agent_id, "reason": reason[:200]})
@@ -666,7 +688,7 @@ def revise_plan(agent_id: str, edited_plan_dict: Dict[str, Any],
     set_status(agent_id, "awaiting_approval")
 
     cid = secrets.token_hex(6)
-    _audit("agent_plan_revised", "codec-agent-plan",
+    _audit(AGENT_PLAN_REVISED, "codec-agent-plan",
            f"plan revised for {agent_id}", correlation_id=cid,
            extra={
                "agent_id": agent_id,

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -497,3 +497,79 @@ def set_status(agent_id: str, new_status: str, reason: Optional[str] = None) -> 
     if reason:
         manifest["status_reason"] = reason
     save_manifest(agent_id, manifest)
+
+
+# ── Audit helper ──────────────────────────────────────────────────────────────
+def _audit(event: str, source: str, message: str = "",
+           correlation_id: str = "", outcome: str = "ok",
+           level: str = "info", extra: Optional[Dict[str, Any]] = None) -> None:
+    """Lazy-imported codec_audit emit. Centralized so tests can monkeypatch."""
+    try:
+        from codec_audit import audit
+    except Exception as e:
+        log.debug("codec_audit unavailable for %s: %s", event, e)
+        return
+    audit(event=event, source=source, message=message,
+          correlation_id=correlation_id, outcome=outcome,
+          level=level, extra=dict(extra or {}))
+
+
+# ── Public orchestrator ───────────────────────────────────────────────────────
+def _new_agent_id() -> str:
+    return f"agent_{secrets.token_hex(6)}"
+
+
+def create_agent(title: str, description: str,
+                 registry=None,
+                 notification_channels: Optional[List[str]] = None) -> str:
+    """Top-level entry point. Drafts a plan, persists to disk, emits audit.
+    Returns the new agent_id. Status after this call: awaiting_approval
+    (or plan_failed on validation error)."""
+    agent_id = _new_agent_id()
+    cid = secrets.token_hex(6)
+
+    # Initial manifest
+    manifest = {
+        "agent_id": agent_id,
+        "title": title[:120],
+        "status": "draft_pending",
+        "created_at": _now_iso(),
+        "updated_at": _now_iso(),
+        "notification_channels": notification_channels or ["pwa"],
+    }
+    save_manifest(agent_id, manifest)
+    save_state(agent_id, {"current_checkpoint": 0})
+
+    # Draft plan (with clarification loop)
+    try:
+        plan = draft_plan_with_clarification(agent_id, description, registry=registry)
+    except DescriptionTooVagueError as e:
+        set_status(agent_id, "plan_failed", reason=f"too_vague: {e}")
+        _audit("agent_plan_rejected", "codec-agent-plan",
+               f"plan failed (vague): {e}", correlation_id=cid,
+               outcome="warning", level="warning",
+               extra={"agent_id": agent_id, "reason": "too_vague"})
+        raise
+    except (PlanValidationError, QwenUnavailableError) as e:
+        set_status(agent_id, "plan_failed", reason=str(e))
+        _audit("agent_plan_rejected", "codec-agent-plan",
+               f"plan failed: {e}", correlation_id=cid,
+               outcome="error", level="error",
+               extra={"agent_id": agent_id, "reason": str(e)[:200]})
+        raise
+
+    # Persist plan + transition status
+    save_plan(plan)
+    set_status(agent_id, "awaiting_approval")
+
+    _audit("agent_plan_drafted", "codec-agent-plan",
+           f"plan drafted for {title[:60]}", correlation_id=cid,
+           extra={
+               "agent_id": agent_id,
+               "checkpoint_count": len(plan.checkpoints),
+               "estimated_duration_minutes": plan.estimated_duration_minutes,
+               "skills_count": len(plan.permission_manifest.skills),
+               "domains_count": len(plan.permission_manifest.network_domains),
+           })
+
+    return agent_id

--- a/codec_audit.py
+++ b/codec_audit.py
@@ -240,6 +240,21 @@ SHIFT_REPORT_COMPLETED = "shift_report_completed"
 
 PHASE2_STEP7_EVENTS = frozenset({SHIFT_REPORT_STARTED, SHIFT_REPORT_COMPLETED})
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3 Step 8 — Plan + Permission Contract
+# ─────────────────────────────────────────────────────────────────────────────
+AGENT_PLAN_DRAFTED         = "agent_plan_drafted"
+AGENT_PLAN_APPROVED        = "agent_plan_approved"
+AGENT_PLAN_REJECTED        = "agent_plan_rejected"
+AGENT_PLAN_REVISED         = "agent_plan_revised"
+AGENT_GLOBAL_GRANT_ADDED   = "agent_global_grant_added"
+AGENT_GLOBAL_GRANT_REMOVED = "agent_global_grant_removed"
+
+PHASE3_STEP8_EVENTS = frozenset({
+    AGENT_PLAN_DRAFTED, AGENT_PLAN_APPROVED, AGENT_PLAN_REJECTED,
+    AGENT_PLAN_REVISED, AGENT_GLOBAL_GRANT_ADDED, AGENT_GLOBAL_GRANT_REMOVED,
+})
+
 SHIFT_REPORT_EXTRA_FIELDS = (
     "trigger_kind",            # "time" | "idle" | "manual"
     "sections_included",       # int — how many of the 5 sections rendered

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -363,8 +363,11 @@ def add_global_grant(body: GlobalGrantBody):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    _cap._audit("agent_global_grant_added", "codec-agent-plan",
+    import secrets as _secrets
+    cid = _secrets.token_hex(6)
+    _cap._audit(_cap.AGENT_GLOBAL_GRANT_ADDED, "codec-agent-plan",
                f"grant added: {body.kind}={body.value}",
+               correlation_id=cid,
                extra={"kind": body.kind, "value": body.value})
     return _cap.load_global_grants()
 
@@ -376,7 +379,10 @@ def delete_global_grant(body: GlobalGrantBody):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    _cap._audit("agent_global_grant_removed", "codec-agent-plan",
+    import secrets as _secrets
+    cid = _secrets.token_hex(6)
+    _cap._audit(_cap.AGENT_GLOBAL_GRANT_REMOVED, "codec-agent-plan",
                f"grant removed: {body.kind}={body.value}",
+               correlation_id=cid,
                extra={"kind": body.kind, "value": body.value})
     return _cap.load_global_grants()

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -223,3 +223,160 @@ async def list_pending_questions():
         return {"pending_questions": pending, "count": len(pending)}
     except Exception as e:
         return JSONResponse({"error": str(e)}, status_code=500)
+
+
+# ── Phase 3 Step 8 — Agent Plan + Permission Contract endpoints ───────────────
+import logging as _logging
+from typing import Any as _Any, Dict as _Dict, List as _List, Optional as _Optional
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+import codec_agent_plan as _cap
+
+_log = _logging.getLogger("routes.agents.plan")
+
+
+class CreateAgentBody(BaseModel):
+    title: str = Field(..., min_length=1, max_length=120)
+    description: str = Field(..., min_length=1)
+    notification_channels: _Optional[_List[str]] = Field(default=None)
+
+
+class RejectBody(BaseModel):
+    reason: str = Field(default="", max_length=500)
+
+
+class ReviseBody(BaseModel):
+    edited_plan: _Dict[str, _Any] = Field(...)
+
+
+class GlobalGrantBody(BaseModel):
+    kind: str = Field(...)
+    value: str = Field(..., min_length=1)
+
+
+@router.post("/api/agents")
+def create_agent(body: CreateAgentBody):
+    try:
+        agent_id = _cap.create_agent(
+            title=body.title,
+            description=body.description,
+            notification_channels=body.notification_channels,
+        )
+    except _cap.DescriptionTooVagueError as e:
+        raise HTTPException(status_code=400, detail=f"description too vague: {e}")
+    except _cap.PlanValidationError as e:
+        raise HTTPException(status_code=400, detail=f"plan invalid: {e}")
+    except _cap.QwenUnavailableError as e:
+        raise HTTPException(status_code=503, detail=f"Qwen-3.6 unavailable: {e}")
+
+    manifest = _cap.load_manifest(agent_id)
+    return {"agent_id": agent_id, "status": manifest.get("status", "unknown")}
+
+
+@router.get("/api/agents")
+def list_agents():
+    """List all agents (any status). Returns a thin manifest summary."""
+    out: _List[_Dict[str, _Any]] = []
+    if not _cap._AGENTS_DIR.exists():
+        return {"agents": []}
+    for d in sorted(_cap._AGENTS_DIR.iterdir()):
+        if not d.is_dir():
+            continue
+        m = _cap.load_manifest(d.name)
+        if m:
+            out.append({
+                "agent_id": m.get("agent_id", d.name),
+                "title":    m.get("title", "(untitled)"),
+                "status":   m.get("status", "unknown"),
+                "created_at": m.get("created_at"),
+                "updated_at": m.get("updated_at"),
+            })
+    return {"agents": out}
+
+
+@router.get("/api/agents/{agent_id}")
+def get_agent(agent_id: str):
+    manifest = _cap.load_manifest(agent_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"agent {agent_id} not found")
+    plan = _cap.load_plan(agent_id)
+    state = _cap.load_state(agent_id)
+    grants = _cap.load_grants(agent_id) or None
+    return {
+        "manifest": manifest,
+        "plan": plan.to_dict() if plan else None,
+        "state": state,
+        "grants": grants,
+    }
+
+
+@router.post("/api/agents/{agent_id}/approve")
+def approve_agent(agent_id: str):
+    manifest = _cap.load_manifest(agent_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"agent {agent_id} not found")
+    try:
+        grants = _cap.approve_plan(agent_id)
+    except _cap.InvalidStatusTransition as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {"agent_id": agent_id, "status": "approved", "grants": grants}
+
+
+@router.post("/api/agents/{agent_id}/reject")
+def reject_agent(agent_id: str, body: RejectBody):
+    manifest = _cap.load_manifest(agent_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"agent {agent_id} not found")
+    try:
+        _cap.reject_plan(agent_id, reason=body.reason)
+    except _cap.InvalidStatusTransition as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {"agent_id": agent_id, "status": "rejected"}
+
+
+@router.post("/api/agents/{agent_id}/revise")
+def revise_agent(agent_id: str, body: ReviseBody):
+    manifest = _cap.load_manifest(agent_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"agent {agent_id} not found")
+    try:
+        plan = _cap.revise_plan(agent_id, body.edited_plan)
+    except _cap.PlanValidationError as e:
+        raise HTTPException(status_code=400, detail=f"plan invalid: {e}")
+    except _cap.InvalidStatusTransition as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {"agent_id": agent_id, "status": "awaiting_approval",
+            "plan": plan.to_dict()}
+
+
+@router.get("/api/agent_global_grants")
+def get_global_grants():
+    return _cap.load_global_grants()
+
+
+@router.post("/api/agent_global_grants")
+def add_global_grant(body: GlobalGrantBody):
+    try:
+        _cap.add_global_grant(body.kind, body.value)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    _cap._audit("agent_global_grant_added", "codec-agent-plan",
+               f"grant added: {body.kind}={body.value}",
+               extra={"kind": body.kind, "value": body.value})
+    return _cap.load_global_grants()
+
+
+@router.delete("/api/agent_global_grants")
+def delete_global_grant(body: GlobalGrantBody):
+    try:
+        _cap.remove_global_grant(body.kind, body.value)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    _cap._audit("agent_global_grant_removed", "codec-agent-plan",
+               f"grant removed: {body.kind}={body.value}",
+               extra={"kind": body.kind, "value": body.value})
+    return _cap.load_global_grants()

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -470,6 +470,7 @@ def test_approve_writes_grants_and_plan_hash(monkeypatch, temp_codec_dir):
             "destructive_ops": []},
         "estimated_duration_minutes": 5, "assumptions": []}))
     fake_reg = MagicMock(); fake_reg.names.return_value = ["weather"]
+    monkeypatch.setattr("codec_dispatch.registry", fake_reg, raising=False)
 
     agent_id = cap.create_agent(title="t", description="d", registry=fake_reg)
     cap.approve_plan(agent_id)
@@ -698,3 +699,33 @@ def test_approve_marks_global_allowlist_items(monkeypatch, temp_codec_dir):
     # Auto-approved tracking (a metadata field, not a separate set)
     assert grants.get("auto_approved", {}).get("network_domains") == ["github.com"]
     assert grants.get("auto_approved", {}).get("skills") == ["web_fetch"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 16 — Pre-approval re-validation against registry (1 test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_approve_revalidates_skills_against_registry(monkeypatch, temp_codec_dir):
+    """If a skill was deleted between draft and approval, approval should fail."""
+    import codec_agent_plan as cap
+
+    # Initial plan drafted with weather + calculator
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"], "checkpoints": [{"title": "t", "description": "d",
+            "skills_needed": ["weather", "calculator"],
+            "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+            "network_domains": [], "skills": ["weather", "calculator"],
+            "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": []}))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["weather", "calculator"]
+    monkeypatch.setattr("codec_dispatch.registry", fake_reg, raising=False)
+
+    agent_id = cap.create_agent(title="X", description="d")
+
+    # Now simulate calculator was deleted
+    fake_reg.names.return_value = ["weather"]
+
+    with pytest.raises(cap.PlanValidationError) as exc:
+        cap.approve_plan(agent_id)
+    assert "calculator" in str(exc.value)

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -628,3 +628,39 @@ def test_post_api_agents_reject_sets_reason(monkeypatch, temp_codec_dir):
     r3 = client.get(f"/api/agents/{agent_id}")
     assert r3.json()["manifest"]["status"] == "rejected"
     assert r3.json()["manifest"]["status_reason"] == "not now"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 14 — Global grants endpoints (1 test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_global_grants_endpoints_full_flow(temp_codec_dir):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from routes.agents import router
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    # GET — initially empty
+    r1 = client.get("/api/agent_global_grants")
+    assert r1.status_code == 200
+    assert r1.json()["network_domains"] == []
+
+    # POST — add
+    r2 = client.post("/api/agent_global_grants",
+                      json={"kind": "network_domains", "value": "github.com"})
+    assert r2.status_code == 200
+    assert "github.com" in r2.json()["network_domains"]
+
+    # POST — invalid kind
+    r3 = client.post("/api/agent_global_grants",
+                      json={"kind": "evil_thing", "value": "x"})
+    assert r3.status_code == 400
+
+    # DELETE
+    r4 = client.request("DELETE", "/api/agent_global_grants",
+                         json={"kind": "network_domains", "value": "github.com"})
+    assert r4.status_code == 200
+    assert "github.com" not in r4.json()["network_domains"]

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -345,3 +345,37 @@ def test_vague_description_max_clarifying_rounds_exceeded(monkeypatch):
             agent_id="a", description="x",
             registry=fake_registry, max_rounds=cap.MAX_CLARIFYING_ROUNDS,
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 8 — Global allowlist (Q4) (3 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_global_grants_load_returns_empty_when_missing(temp_codec_dir):
+    from codec_agent_plan import load_global_grants
+    g = load_global_grants()
+    assert g == {"schema": 1, "version": 0,
+                 "network_domains": [], "read_paths": [],
+                 "write_paths": [], "skills": []}
+
+
+def test_add_global_grant_persists(temp_codec_dir):
+    from codec_agent_plan import add_global_grant, load_global_grants
+    add_global_grant("network_domains", "github.com")
+    add_global_grant("network_domains", "news.ycombinator.com")
+    add_global_grant("skills", "web_fetch")
+    g = load_global_grants()
+    assert "github.com" in g["network_domains"]
+    assert "news.ycombinator.com" in g["network_domains"]
+    assert "web_fetch" in g["skills"]
+    assert g["version"] == 3  # 3 successful adds
+
+
+def test_remove_global_grant(temp_codec_dir):
+    from codec_agent_plan import add_global_grant, remove_global_grant, load_global_grants
+    add_global_grant("network_domains", "github.com")
+    add_global_grant("network_domains", "example.com")
+    remove_global_grant("network_domains", "github.com")
+    g = load_global_grants()
+    assert "github.com" not in g["network_domains"]
+    assert "example.com" in g["network_domains"]

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -278,3 +278,70 @@ def test_draft_plan_handles_qwen_unavailable(monkeypatch):
             description="x",
             registry=MagicMock(),
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 7 — Vague-description clarifying loop (Q3) (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_vague_description_triggers_clarifying_questions(monkeypatch):
+    import codec_agent_plan as cap
+
+    # First Qwen call → "too vague" sentinel
+    # Second call → asks 3 clarifying questions
+    # Third call (after user answers) → returns valid plan
+    call_count = {"n": 0}
+
+    def fake_qwen(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return json.dumps({"too_vague": True,
+                               "clarifying_questions": ["What platform?", "What output?", "Who's the user?"]})
+        # Subsequent calls return a valid plan
+        return json.dumps({
+            "goals": ["g"],
+            "checkpoints": [{"title": "t", "description": "d",
+                             "skills_needed": ["weather"],
+                             "expected_output": "o", "step_budget": 10}],
+            "permission_manifest": {"read_paths": [], "write_paths": [],
+                                    "network_domains": [], "skills": ["weather"],
+                                    "destructive_ops": []},
+            "estimated_duration_minutes": 5, "assumptions": [],
+        })
+
+    monkeypatch.setattr(cap, "_qwen_chat", fake_qwen)
+
+    fake_ask = MagicMock()
+    fake_ask.return_value = ("answered", "telegram bot, JSON output, real estate buyers")
+    monkeypatch.setattr(cap, "_ask_user", fake_ask)
+
+    fake_registry = MagicMock()
+    fake_registry.names.return_value = ["weather"]
+
+    plan = cap.draft_plan_with_clarification(
+        agent_id="a", description="make codec better",
+        registry=fake_registry,
+    )
+    assert plan is not None
+    assert call_count["n"] >= 2  # at least one re-draft after clarification
+    fake_ask.assert_called()
+
+
+def test_vague_description_max_clarifying_rounds_exceeded(monkeypatch):
+    import codec_agent_plan as cap
+
+    monkeypatch.setattr(cap, "_qwen_chat",
+                        lambda *a, **k: json.dumps({
+                            "too_vague": True,
+                            "clarifying_questions": ["q1", "q2"],
+                        }))
+    monkeypatch.setattr(cap, "_ask_user", lambda *a, **k: ("answered", "still vague"))
+
+    fake_registry = MagicMock()
+    fake_registry.names.return_value = []
+
+    with pytest.raises(cap.DescriptionTooVagueError):
+        cap.draft_plan_with_clarification(
+            agent_id="a", description="x",
+            registry=fake_registry, max_rounds=cap.MAX_CLARIFYING_ROUNDS,
+        )

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -664,3 +664,37 @@ def test_global_grants_endpoints_full_flow(temp_codec_dir):
                          json={"kind": "network_domains", "value": "github.com"})
     assert r4.status_code == 200
     assert "github.com" not in r4.json()["network_domains"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 15 — Auto-approve via global allowlist (1 test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_approve_marks_global_allowlist_items(monkeypatch, temp_codec_dir):
+    """When a plan needs github.com and github.com is already in the
+    global allowlist, the approval grants.json should reflect it."""
+    import codec_agent_plan as cap
+
+    # Pre-populate global allowlist
+    cap.add_global_grant("network_domains", "github.com")
+    cap.add_global_grant("skills", "web_fetch")
+
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"], "checkpoints": [{"title": "t", "description": "d",
+            "skills_needed": ["web_fetch"], "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+            "network_domains": ["github.com", "example.com"],
+            "skills": ["web_fetch"], "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": []}))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["web_fetch"]
+    monkeypatch.setattr("codec_dispatch.registry", fake_reg, raising=False)
+
+    agent_id = cap.create_agent(title="X", description="d")
+    grants = cap.approve_plan(agent_id)
+
+    # All manifest items end up in grants
+    assert "github.com" in grants["network_domains"]
+    assert "example.com" in grants["network_domains"]
+    # Auto-approved tracking (a metadata field, not a separate set)
+    assert grants.get("auto_approved", {}).get("network_domains") == ["github.com"]
+    assert grants.get("auto_approved", {}).get("skills") == ["web_fetch"]

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -404,3 +404,53 @@ def test_state_transition_invalid_raises(temp_codec_dir):
     # Cannot jump from draft_pending → completed without going through approved
     with pytest.raises(cap.InvalidStatusTransition):
         cap.set_status("a1", "completed")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 10 — create_agent orchestrator (1 test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_create_agent_full_flow(monkeypatch, temp_codec_dir):
+    import codec_agent_plan as cap
+
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"],
+        "checkpoints": [{"title": "t", "description": "d",
+                         "skills_needed": ["weather"],
+                         "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+                                "network_domains": [], "skills": ["weather"],
+                                "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": [],
+    }))
+
+    fake_registry = MagicMock()
+    fake_registry.names.return_value = ["weather"]
+
+    audit_emits = []
+    def fake_audit(event, source, message, **kw):
+        audit_emits.append((event, kw.get("correlation_id")))
+    monkeypatch.setattr(cap, "_audit", fake_audit)
+
+    agent_id = cap.create_agent(
+        title="Property bot",
+        description="Build a property scraper",
+        registry=fake_registry,
+    )
+    assert agent_id.startswith("agent_")
+
+    # Verify all 3 files written
+    agent_dir = temp_codec_dir / "agents" / agent_id
+    assert (agent_dir / "manifest.json").exists()
+    assert (agent_dir / "plan.json").exists()
+    assert (agent_dir / "state.json").exists()
+
+    # Manifest has correct fields
+    m = cap.load_manifest(agent_id)
+    assert m["title"] == "Property bot"
+    assert m["status"] == "awaiting_approval"
+    assert "created_at" in m
+
+    # Audit emit happened with correlation_id
+    plan_drafted = [(e, c) for e, c in audit_emits if e == "agent_plan_drafted"]
+    assert len(plan_drafted) == 1

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -729,3 +729,60 @@ def test_approve_revalidates_skills_against_registry(monkeypatch, temp_codec_dir
     with pytest.raises(cap.PlanValidationError) as exc:
         cap.approve_plan(agent_id)
     assert "calculator" in str(exc.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 17 — End-to-end integration test (1 test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_e2e_full_lifecycle(monkeypatch, temp_codec_dir):
+    """End-to-end: drop project → draft → approve → grants written → audit emits paired."""
+    import codec_agent_plan as cap
+    from typing import List, Tuple
+
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["Build property bot"],
+        "checkpoints": [
+            {"title": "Scaffold project", "description": "Create dir + skeleton",
+             "skills_needed": ["file_ops"], "expected_output": "Project initialized",
+             "step_budget": 30},
+            {"title": "Implement scraper", "description": "Use chrome to scrape",
+             "skills_needed": ["chrome_open", "file_ops"],
+             "expected_output": "Listings JSON written", "step_budget": 60},
+        ],
+        "permission_manifest": {
+            "read_paths": [],
+            "write_paths": ["~/.codec/agents/{agent_id}/artifacts/**"],
+            "network_domains": ["idealista.com", "fotocasa.es"],
+            "skills": ["file_ops", "chrome_open"], "destructive_ops": [],
+        },
+        "estimated_duration_minutes": 90,
+        "assumptions": ["User has Chrome installed"],
+    }))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["file_ops", "chrome_open"]
+    monkeypatch.setattr("codec_dispatch.registry", fake_reg, raising=False)
+
+    audit_emits: List[Tuple[str, str]] = []
+    def fake_audit(event, source, message="", correlation_id="", **kw):
+        audit_emits.append((event, correlation_id))
+    monkeypatch.setattr(cap, "_audit", fake_audit)
+
+    # Drop the project
+    agent_id = cap.create_agent(
+        title="Marbella property bot",
+        description="Build a Telegram bot that scrapes Marbella property listings",
+    )
+
+    # Approve
+    grants = cap.approve_plan(agent_id)
+
+    # Verify final state
+    m = cap.load_manifest(agent_id)
+    assert m["status"] == "approved"
+    assert "plan_hash" in m
+    assert grants["network_domains"] == ["idealista.com", "fotocasa.es"]
+
+    # Verify both audit events were emitted (paired correlation_ids will differ — independent ops)
+    events = [e for e, _ in audit_emits]
+    assert "agent_plan_drafted" in events
+    assert "agent_plan_approved" in events

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -454,3 +454,48 @@ def test_create_agent_full_flow(monkeypatch, temp_codec_dir):
     # Audit emit happened with correlation_id
     plan_drafted = [(e, c) for e, c in audit_emits if e == "agent_plan_drafted"]
     assert len(plan_drafted) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 11 — approve / reject / revise (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_approve_writes_grants_and_plan_hash(monkeypatch, temp_codec_dir):
+    import codec_agent_plan as cap
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"], "checkpoints": [{"title": "t", "description": "d",
+            "skills_needed": ["weather"], "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+            "network_domains": ["example.com"], "skills": ["weather"],
+            "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": []}))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["weather"]
+
+    agent_id = cap.create_agent(title="t", description="d", registry=fake_reg)
+    cap.approve_plan(agent_id)
+
+    m = cap.load_manifest(agent_id)
+    assert m["status"] == "approved"
+    assert "plan_hash" in m
+    assert len(m["plan_hash"]) == 64  # sha256 hex
+
+    grants = cap.load_grants(agent_id)
+    assert "example.com" in grants["network_domains"]
+    assert "weather" in grants["skills"]
+
+
+def test_reject_sets_status_with_reason(monkeypatch, temp_codec_dir):
+    import codec_agent_plan as cap
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"], "checkpoints": [{"title": "t", "description": "d",
+            "skills_needed": ["weather"], "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+            "network_domains": [], "skills": ["weather"], "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": []}))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["weather"]
+
+    agent_id = cap.create_agent(title="t", description="d", registry=fake_reg)
+    cap.reject_plan(agent_id, reason="don't need this")
+    m = cap.load_manifest(agent_id)
+    assert m["status"] == "rejected"
+    assert m["status_reason"] == "don't need this"

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -499,3 +499,64 @@ def test_reject_sets_status_with_reason(monkeypatch, temp_codec_dir):
     m = cap.load_manifest(agent_id)
     assert m["status"] == "rejected"
     assert m["status_reason"] == "don't need this"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 12 — PWA endpoints (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_post_api_agents_creates_drafts(monkeypatch, temp_codec_dir, tmp_path):
+    """POST /api/agents creates an agent and drafts the plan."""
+    from fastapi.testclient import TestClient
+    import codec_agent_plan as cap
+
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"], "checkpoints": [{"title": "t", "description": "d",
+            "skills_needed": ["weather"], "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+            "network_domains": [], "skills": ["weather"], "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": []}))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["weather"]
+    monkeypatch.setattr("codec_agent_plan.draft_plan_with_clarification",
+                        lambda agent_id, desc, registry=None, max_rounds=3:
+                            cap.draft_plan(agent_id, desc, registry=fake_reg))
+
+    from routes.agents import router
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    r = client.post("/api/agents", json={
+        "title": "Property bot",
+        "description": "Build a property scraper",
+        "notification_channels": ["pwa"],
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["agent_id"].startswith("agent_")
+    assert body["status"] == "awaiting_approval"
+
+
+def test_get_api_agents_lists_all(temp_codec_dir):
+    """GET /api/agents returns all agents."""
+    from fastapi.testclient import TestClient
+    import codec_agent_plan as cap
+
+    # Create 2 agents directly via R/W (bypass LLM)
+    cap.save_manifest("agent_a", {"agent_id": "agent_a", "title": "A",
+                                   "status": "awaiting_approval", "created_at": "..."})
+    cap.save_manifest("agent_b", {"agent_id": "agent_b", "title": "B",
+                                   "status": "approved", "created_at": "..."})
+
+    from routes.agents import router
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    r = client.get("/api/agents")
+    assert r.status_code == 200
+    body = r.json()
+    ids = {a["agent_id"] for a in body["agents"]}
+    assert ids == {"agent_a", "agent_b"}

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -560,3 +560,71 @@ def test_get_api_agents_lists_all(temp_codec_dir):
     body = r.json()
     ids = {a["agent_id"] for a in body["agents"]}
     assert ids == {"agent_a", "agent_b"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 13 — Approve/reject integration tests via FastAPI TestClient (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_post_api_agents_approve_full_flow(monkeypatch, temp_codec_dir):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    import codec_agent_plan as cap
+
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"], "checkpoints": [{"title": "t", "description": "d",
+            "skills_needed": ["weather"], "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+            "network_domains": [], "skills": ["weather"], "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": []}))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["weather"]
+    # Patch the lazy-import path used inside draft_plan
+    monkeypatch.setattr("codec_dispatch.registry", fake_reg, raising=False)
+
+    from routes.agents import router
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    r1 = client.post("/api/agents", json={
+        "title": "X", "description": "build x"})
+    agent_id = r1.json()["agent_id"]
+
+    r2 = client.post(f"/api/agents/{agent_id}/approve")
+    assert r2.status_code == 200
+    assert r2.json()["status"] == "approved"
+
+    # Manifest now has plan_hash
+    r3 = client.get(f"/api/agents/{agent_id}")
+    assert r3.status_code == 200
+    assert "plan_hash" in r3.json()["manifest"]
+    assert r3.json()["grants"] is not None
+
+
+def test_post_api_agents_reject_sets_reason(monkeypatch, temp_codec_dir):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    import codec_agent_plan as cap
+
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: json.dumps({
+        "goals": ["g"], "checkpoints": [{"title": "t", "description": "d",
+            "skills_needed": ["weather"], "expected_output": "o", "step_budget": 10}],
+        "permission_manifest": {"read_paths": [], "write_paths": [],
+            "network_domains": [], "skills": ["weather"], "destructive_ops": []},
+        "estimated_duration_minutes": 5, "assumptions": []}))
+    fake_reg = MagicMock(); fake_reg.names.return_value = ["weather"]
+    monkeypatch.setattr("codec_dispatch.registry", fake_reg, raising=False)
+
+    from routes.agents import router
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    r1 = client.post("/api/agents", json={"title": "X", "description": "build x"})
+    agent_id = r1.json()["agent_id"]
+
+    r2 = client.post(f"/api/agents/{agent_id}/reject", json={"reason": "not now"})
+    assert r2.status_code == 200
+    r3 = client.get(f"/api/agents/{agent_id}")
+    assert r3.json()["manifest"]["status"] == "rejected"
+    assert r3.json()["manifest"]["status_reason"] == "not now"

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -78,3 +78,33 @@ def test_plan_from_dict_rejects_bad_schema():
     from codec_agent_plan import plan_from_dict
     with pytest.raises(ValueError, match="unsupported plan schema"):
         plan_from_dict({"schema": 99, "agent_id": "x"})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 3 — Plan-hash for tamper detection (Q13) (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_plan_hash_stable_for_identical_content():
+    from codec_agent_plan import Plan, Checkpoint, PermissionManifest, compute_plan_hash
+    cp = Checkpoint(id="x", title="t", description="d", skills_needed=["s"],
+                    expected_output="o", step_budget=10)
+    pm = PermissionManifest(read_paths=[], write_paths=[], network_domains=[],
+                            skills=["s"], destructive_ops=[])
+    plan_a = Plan(schema=1, agent_id="a1", goals=["g"], checkpoints=[cp],
+                  permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+    plan_b = Plan(schema=1, agent_id="a1", goals=["g"], checkpoints=[cp],
+                  permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+    assert compute_plan_hash(plan_a) == compute_plan_hash(plan_b)
+
+
+def test_plan_hash_changes_when_content_changes():
+    from codec_agent_plan import Plan, Checkpoint, PermissionManifest, compute_plan_hash
+    cp = Checkpoint(id="x", title="t", description="d", skills_needed=["s"],
+                    expected_output="o", step_budget=10)
+    pm = PermissionManifest(read_paths=[], write_paths=[], network_domains=[],
+                            skills=["s"], destructive_ops=[])
+    plan_a = Plan(schema=1, agent_id="a1", goals=["g"], checkpoints=[cp],
+                  permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+    plan_b = Plan(schema=1, agent_id="a1", goals=["g_modified"], checkpoints=[cp],
+                  permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+    assert compute_plan_hash(plan_a) != compute_plan_hash(plan_b)

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -189,3 +189,92 @@ def test_validate_plan_against_registry_rejects_unknown_skill():
     ok, missing = validate_plan_skills(plan, registry=fake_registry)
     assert ok is False
     assert "nonexistent_skill" in missing
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 6 — LLM plan drafter (Qwen-3.6, local-only) (3 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_draft_plan_via_qwen_returns_valid_plan(monkeypatch):
+    import codec_agent_plan as cap
+
+    fake_qwen_response = json.dumps({
+        "goals": ["Build property monitor bot"],
+        "checkpoints": [
+            {"title": "Set up bot scaffold", "description": "...",
+             "skills_needed": ["file_ops"], "expected_output": "Bot project dir created",
+             "step_budget": 30},
+            {"title": "Implement scraper", "description": "...",
+             "skills_needed": ["chrome_open", "file_ops"],
+             "expected_output": "Listings JSON written", "step_budget": 60},
+        ],
+        "permission_manifest": {
+            "read_paths": [], "write_paths": ["~/.codec/agents/{agent_id}/artifacts/**"],
+            "network_domains": ["idealista.com", "fotocasa.es"],
+            "skills": ["file_ops", "chrome_open"], "destructive_ops": [],
+        },
+        "estimated_duration_minutes": 90,
+        "assumptions": ["User has Chrome installed"],
+    })
+
+    def fake_qwen_chat(prompt, system_prompt=None, max_tokens=4000, **kw):
+        return fake_qwen_response
+
+    monkeypatch.setattr(cap, "_qwen_chat", fake_qwen_chat)
+
+    fake_registry = MagicMock()
+    fake_registry.names.return_value = ["file_ops", "chrome_open"]
+
+    plan = cap.draft_plan(
+        agent_id="test_agent",
+        description="Build a Telegram bot that scrapes Marbella property listings",
+        registry=fake_registry,
+    )
+    assert plan.agent_id == "test_agent"
+    assert len(plan.checkpoints) == 2
+    assert "idealista.com" in plan.permission_manifest.network_domains
+
+
+def test_draft_plan_rejects_unknown_skill(monkeypatch):
+    import codec_agent_plan as cap
+
+    fake_response = json.dumps({
+        "goals": ["x"], "checkpoints": [
+            {"title": "t", "description": "d",
+             "skills_needed": ["nonexistent_skill_xyz"],
+             "expected_output": "o", "step_budget": 10}
+        ],
+        "permission_manifest": {
+            "read_paths": [], "write_paths": [], "network_domains": [],
+            "skills": ["nonexistent_skill_xyz"], "destructive_ops": [],
+        },
+        "estimated_duration_minutes": 5, "assumptions": [],
+    })
+    monkeypatch.setattr(cap, "_qwen_chat", lambda *a, **k: fake_response)
+
+    fake_registry = MagicMock()
+    fake_registry.names.return_value = ["weather"]  # nonexistent_skill_xyz NOT in registry
+
+    with pytest.raises(cap.PlanValidationError) as exc_info:
+        cap.draft_plan(
+            agent_id="test_agent",
+            description="some project",
+            registry=fake_registry,
+        )
+    assert "nonexistent_skill_xyz" in str(exc_info.value)
+
+
+def test_draft_plan_handles_qwen_unavailable(monkeypatch):
+    import codec_agent_plan as cap
+
+    def raise_connection(*a, **k):
+        raise ConnectionError("qwen3.6 down")
+
+    monkeypatch.setattr(cap, "_qwen_chat", raise_connection)
+
+    with pytest.raises(cap.QwenUnavailableError):
+        cap.draft_plan(
+            agent_id="test_agent",
+            description="x",
+            registry=MagicMock(),
+        )

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -108,3 +108,84 @@ def test_plan_hash_changes_when_content_changes():
     plan_b = Plan(schema=1, agent_id="a1", goals=["g_modified"], checkpoints=[cp],
                   permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
     assert compute_plan_hash(plan_a) != compute_plan_hash(plan_b)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 4 — Atomic R/W (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def temp_codec_dir(tmp_path, monkeypatch):
+    import codec_agent_plan as cap
+    monkeypatch.setattr(cap, "_CODEC_DIR", tmp_path)
+    monkeypatch.setattr(cap, "_AGENTS_DIR", tmp_path / "agents")
+    monkeypatch.setattr(cap, "_GLOBAL_GRANTS_PATH", tmp_path / "agent_global_grants.json")
+    return tmp_path
+
+
+def test_save_and_load_plan_roundtrip(temp_codec_dir):
+    from codec_agent_plan import (
+        Plan, Checkpoint, PermissionManifest, save_plan, load_plan,
+    )
+    cp = Checkpoint(id="x", title="t", description="d", skills_needed=["s"],
+                    expected_output="o", step_budget=10)
+    pm = PermissionManifest(read_paths=[], write_paths=[], network_domains=[],
+                            skills=["s"], destructive_ops=[])
+    plan = Plan(schema=1, agent_id="agent_test", goals=["g"], checkpoints=[cp],
+                permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+    save_plan(plan)
+    loaded = load_plan("agent_test")
+    assert loaded.agent_id == "agent_test"
+    assert loaded.checkpoints[0].title == "t"
+
+
+def test_save_state_atomic(temp_codec_dir):
+    from codec_agent_plan import save_state, load_state
+    save_state("agent_x", {"current_checkpoint": 0, "status": "draft_pending"})
+    state = load_state("agent_x")
+    assert state["current_checkpoint"] == 0
+    assert state["status"] == "draft_pending"
+    # Verify atomic: tmp file is gone after save
+    agent_dir = temp_codec_dir / "agents" / "agent_x"
+    assert not (agent_dir / "state.json.tmp").exists()
+    assert (agent_dir / "state.json").exists()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 5 — Skill-registry validation (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_validate_plan_against_registry_ok():
+    from codec_agent_plan import (
+        Plan, Checkpoint, PermissionManifest, validate_plan_skills,
+    )
+    cp = Checkpoint(id="x", title="t", description="d",
+                    skills_needed=["weather"], expected_output="o", step_budget=10)
+    pm = PermissionManifest(read_paths=[], write_paths=[], network_domains=[],
+                            skills=["weather"], destructive_ops=[])
+    plan = Plan(schema=1, agent_id="a", goals=["g"], checkpoints=[cp],
+                permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+
+    fake_registry = MagicMock()
+    fake_registry.names.return_value = ["weather", "calculator"]
+    ok, missing = validate_plan_skills(plan, registry=fake_registry)
+    assert ok is True
+    assert missing == []
+
+
+def test_validate_plan_against_registry_rejects_unknown_skill():
+    from codec_agent_plan import (
+        Plan, Checkpoint, PermissionManifest, validate_plan_skills,
+    )
+    cp = Checkpoint(id="x", title="t", description="d",
+                    skills_needed=["nonexistent_skill"], expected_output="o", step_budget=10)
+    pm = PermissionManifest(read_paths=[], write_paths=[], network_domains=[],
+                            skills=["nonexistent_skill"], destructive_ops=[])
+    plan = Plan(schema=1, agent_id="a", goals=["g"], checkpoints=[cp],
+                permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+
+    fake_registry = MagicMock()
+    fake_registry.names.return_value = ["weather", "calculator"]
+    ok, missing = validate_plan_skills(plan, registry=fake_registry)
+    assert ok is False
+    assert "nonexistent_skill" in missing

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -1,0 +1,34 @@
+"""Phase 3 Step 8 tests — codec_agent_plan + routes/agents.py.
+
+25 tests covering: audit constants, dataclasses, atomic R/W, validation,
+plan-hash, LLM drafter, clarifying loop, global allowlist, state machine,
+PWA endpoints, and end-to-end integration.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+def test_audit_constants_present():
+    """Phase 3 Step 8 adds 6 named events + 1 frozenset."""
+    import codec_audit
+    assert codec_audit.AGENT_PLAN_DRAFTED == "agent_plan_drafted"
+    assert codec_audit.AGENT_PLAN_APPROVED == "agent_plan_approved"
+    assert codec_audit.AGENT_PLAN_REJECTED == "agent_plan_rejected"
+    assert codec_audit.AGENT_PLAN_REVISED == "agent_plan_revised"
+    assert codec_audit.AGENT_GLOBAL_GRANT_ADDED == "agent_global_grant_added"
+    assert codec_audit.AGENT_GLOBAL_GRANT_REMOVED == "agent_global_grant_removed"
+    assert codec_audit.PHASE3_STEP8_EVENTS == frozenset({
+        "agent_plan_drafted", "agent_plan_approved", "agent_plan_rejected",
+        "agent_plan_revised", "agent_global_grant_added", "agent_global_grant_removed",
+    })

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -379,3 +379,28 @@ def test_remove_global_grant(temp_codec_dir):
     g = load_global_grants()
     assert "github.com" not in g["network_domains"]
     assert "example.com" in g["network_domains"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 9 — State machine (2 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_state_transition_valid(temp_codec_dir):
+    from codec_agent_plan import set_status, load_state, save_manifest
+    save_manifest("a1", {"agent_id": "a1", "title": "t",
+                         "status": "draft_pending", "created_at": "2026-05-03"})
+    set_status("a1", "awaiting_approval")
+    state = load_state("a1")
+    # Status mirrored in state.json AND manifest.json
+    from codec_agent_plan import load_manifest
+    m = load_manifest("a1")
+    assert m["status"] == "awaiting_approval"
+
+
+def test_state_transition_invalid_raises(temp_codec_dir):
+    import codec_agent_plan as cap
+    cap.save_manifest("a1", {"agent_id": "a1", "status": "draft_pending"})
+
+    # Cannot jump from draft_pending → completed without going through approved
+    with pytest.raises(cap.InvalidStatusTransition):
+        cap.set_status("a1", "completed")

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -32,3 +32,49 @@ def test_audit_constants_present():
         "agent_plan_drafted", "agent_plan_approved", "agent_plan_rejected",
         "agent_plan_revised", "agent_global_grant_added", "agent_global_grant_removed",
     })
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 2 — Plan/Checkpoint/PermissionManifest dataclasses (3 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_plan_dataclass_basic():
+    from codec_agent_plan import Plan, Checkpoint, PermissionManifest
+    cp = Checkpoint(
+        id="abc123ab", title="Scrape listings", description="...",
+        skills_needed=["chrome_open"], expected_output="JSON of listings",
+        step_budget=30,
+    )
+    pm = PermissionManifest(
+        read_paths=["~/Documents/**"], write_paths=["~/.codec/agents/test/artifacts/**"],
+        network_domains=["example.com"], skills=["chrome_open"], destructive_ops=[],
+    )
+    plan = Plan(
+        schema=1, agent_id="test_agent",
+        goals=["Scrape data"], checkpoints=[cp], permission_manifest=pm,
+        estimated_duration_minutes=15, assumptions=[],
+    )
+    assert plan.schema == 1
+    assert plan.checkpoints[0].title == "Scrape listings"
+    assert plan.permission_manifest.skills == ["chrome_open"]
+
+
+def test_plan_dataclass_to_dict_roundtrip():
+    from codec_agent_plan import Plan, Checkpoint, PermissionManifest, plan_from_dict
+    cp = Checkpoint(id="x", title="t", description="d",
+                    skills_needed=["s"], expected_output="o", step_budget=10)
+    pm = PermissionManifest(read_paths=[], write_paths=[], network_domains=[],
+                            skills=["s"], destructive_ops=[])
+    plan = Plan(schema=1, agent_id="a1", goals=["g"], checkpoints=[cp],
+                permission_manifest=pm, estimated_duration_minutes=5, assumptions=[])
+    d = plan.to_dict()
+    plan2 = plan_from_dict(d)
+    assert plan2.agent_id == plan.agent_id
+    assert plan2.checkpoints[0].id == plan.checkpoints[0].id
+    assert plan2.permission_manifest.skills == plan.permission_manifest.skills
+
+
+def test_plan_from_dict_rejects_bad_schema():
+    from codec_agent_plan import plan_from_dict
+    with pytest.raises(ValueError, match="unsupported plan schema"):
+        plan_from_dict({"schema": 99, "agent_id": "x"})


### PR DESCRIPTION
## Summary

Phase 3 Step 8 — Plan + Permission Contract. Drop-a-project planning layer.

User describes a project → Qwen-3.6 drafts structured plan with permission manifest → user approves in PWA → grants persisted to `~/.codec/agents/<id>/grants.json` with `plan_hash` for Step 9 tamper detection.

**No execution yet** — Step 9 picks that up. Step 8 alone is shippable: drafted plans sit in `awaiting_approval`, approved plans sit in `approved` waiting for the runner.

## Reference

- **Blueprint:** `docs/PHASE3-BLUEPRINT.md` §2 (approved 2026-05-03)
- **TDD plan:** `docs/PHASE3-STEP8-PLAN.md` (19 tasks, 89 atomic steps)
- **Resolved Q&A** (blueprint §8): Q1 Qwen-3.6 only, Q2 inline edit, Q3 clarifying loop, Q4 global allowlist tier, Q13 plan-hash tamper detection

## What ships

| Component | Lines | Tests |
|---|---|---|
| `codec_agent_plan.py` (NEW) | ~640 | — |
| `routes/agents.py` (extended) | +250 | — |
| `tests/test_agent_plan.py` (NEW) | ~700 | 31 tests |
| `codec_audit.py` (modified) | +18 | constants + frozenset |
| `codec_dashboard.py` (modified) | router mount | — |
| `AGENTS.md` (modified) | +57 | docs |

## Audit envelope

6 new schema:1 events, all paired correlation_ids per Step 1 §1.4 contract:
- `agent_plan_drafted` (info) — agent_id, checkpoint_count, estimated_duration_minutes, skills_count, domains_count
- `agent_plan_approved` (info) — agent_id, plan_hash (sha256), checkpoint_count, skills_count, domains_count
- `agent_plan_rejected` (warning) — agent_id, reason
- `agent_plan_revised` (info) — agent_id, checkpoint_count
- `agent_global_grant_added` (info) — kind, value
- `agent_global_grant_removed` (info) — kind, value

`PHASE3_STEP8_EVENTS` frozenset exposed.

## Permission model (Q4 — plan-and-grant + global allowlist)

**Per-agent grants** (extracted from plan): valid for that agent's lifetime, written to `~/.codec/agents/<id>/grants.json` at approval. Plan-hash (sha256) computed at approval; Step 9 will verify on every daemon tick (Q13 tamper detection).

**Global allowlist** (`~/.codec/agent_global_grants.json`): cross-agent permissions. Items already in global → marked `auto_approved` in per-agent grants. User manages via `/api/agent_global_grants` GET/POST/DELETE. 4 grant kinds: `network_domains`, `read_paths`, `write_paths`, `skills`.

## Vague-description handling (Q3)

Up to 3 rounds of `codec_ask_user.ask` clarifying questions before drafting. After 3 rounds without convergence: status=`plan_failed`, reason=`description_too_vague`. Tunable via `MAX_CLARIFYING_ROUNDS` constant (default 3).

## State machine

```
draft_pending → awaiting_approval → approved | rejected | revised
                                       ↓
                                  awaiting_approval (if revised)

plan_failed (terminal-with-retry from draft_pending)
```

Step 9 will extend with: approved → running → checkpoint_completed / blocked_* / aborted / completed.

## Kill switches

- `AGENT_PLANNING_ENABLED=false` — drafting disabled (existing plans untouched)
- Plan validation hard-rejects unknown skills (no silent degradation)

## Test plan

- [x] 🧪 `tests/test_agent_plan.py` → 31 passed
- [x] 🧪 Full suite — 870 passed / 20 failed / 73 skipped (same 20/73 baseline as main, +27 new tests)
- [x] AST extraction validates skill names against `codec_skill_registry`
- [x] All Phase 3 Step 8 audit events emit with paired correlation_ids
- [ ] Post-merge: `pm2 restart codec-dashboard` (no skill install needed; module is in repo root)
- [ ] PWA test: `POST /api/agents` with a project description, verify drafted plan appears, `POST /api/agents/{id}/approve`, verify `grants.json` + `plan_hash` written

## Out of scope (Step 9 + 10)

- `codec_agent_runner.py` daemon (Step 9)
- Plan execution loop + permission gate enforcement (Step 9)
- Resume after PM2 restart (Step 9)
- Strict-consent gate integration for destructive ops (Step 9)
- Project mode UI / mode dropdown / status pills (Step 10)
- Proactive messaging from agent to user (Step 10)
- Auto-escalation from chat mode (Step 10)

## Implementation note

Plan + Implementation Plan documents (`docs/PHASE3-BLUEPRINT.md` + `docs/PHASE3-STEP8-PLAN.md`) approved by user 2026-05-03 via the `superpowers:brainstorming` + `superpowers:writing-plans` skill flow. Implementation followed TDD strictly: every commit has a failing test → implementation → passing test cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)