### PR TITLE
fix(tests + readme): audit-log test pollution + Phase 3 README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 </p>
 
 <p align="center">
-  <a href="FEATURES.md"><img src="https://img.shields.io/badge/features-238-blue?style=flat-square" alt="238 Features"/></a>
-  <img src="https://img.shields.io/badge/skills-60-orange?style=flat-square" alt="60 Skills"/>
-  <img src="https://img.shields.io/badge/tests-378-green?style=flat-square" alt="378 Tests"/>
-  <img src="https://img.shields.io/badge/lines-33.9K-purple?style=flat-square" alt="33,900 Lines"/>
+  <a href="FEATURES.md"><img src="https://img.shields.io/badge/features-260+-blue?style=flat-square" alt="260+ Features"/></a>
+  <img src="https://img.shields.io/badge/skills-73-orange?style=flat-square" alt="73 Skills"/>
+  <img src="https://img.shields.io/badge/tests-1023-green?style=flat-square" alt="1023 Tests"/>
+  <img src="https://img.shields.io/badge/lines-53.3K-purple?style=flat-square" alt="53,300 Lines"/>
   <img src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square" alt="MIT License"/>
-  <img src="https://img.shields.io/badge/engine-CODEC%20v2.1-E8711A?style=flat-square" alt="Engine: CODEC v2.1"/>
+  <img src="https://img.shields.io/badge/engine-CODEC%20v2.3-E8711A?style=flat-square" alt="Engine: CODEC v2.3"/>
 </p>
 
 ---
@@ -88,11 +88,15 @@ Native floating overlays: orange-bordered recording panel with pulsing red dot, 
 
 Select any text, anywhere. Right-click. Eight AI services system-wide: Proofread, Elevate, Explain, Translate, Reply (with `:tone` syntax), Prompt, Read Aloud, Save. Powered by the local LLM.
 
-### 4. CODEC Chat — 250K Context + 12 Agent Crews
+### 4. CODEC Chat — 250K Context + 12 Agent Crews + Drop-a-Project Autonomy
 
 Full conversational AI. Long context. File uploads (drag-and-drop). Image analysis via vision model. Web search. Persistent conversation history with sidebar. Edit and re-send messages. Regenerate responses.
 
 Voice input via continuous microphone with stop button. Streaming responses with typing and thinking indicators.
+
+**Four modes** in the chat composer: **Chat / Think / Agents / Project**.
+
+**Project mode (Phase 3 — drop-a-project autonomy).** Type a project description, hit send. CODEC drafts a structured plan via local Qwen-3.6 with an explicit permission manifest (skills, write paths, network domains, destructive ops). You approve once. `codec-agent-runner` (PM2 daemon) picks up the approved plan and executes it autonomously — Qwen ↔ skill loops, permission-gated, plan-hash tamper detection, resume-after-restart, multi-agent concurrency capped at 3. Status pills above the input show running/paused/blocked agents with inline approve/pause/resume/abort actions. Updates post back into the chat thread. Try: *"Build me a Telegram bot that monitors Marbella property listings under €500k"* or *"Watch EUR/USD intraday vol and ping me when 30-min realized vol crosses 0.4%"*.
 
 Plus 12 autonomous agent crews — not single prompts, full multi-step workflows. Say *"research the latest AI agent frameworks and write a report."* Minutes later there's a formatted Google Doc in Drive with sources, images, and recommendations.
 
@@ -114,6 +118,8 @@ Plus 12 autonomous agent crews — not single prompts, full multi-step workflows
 Schedule any crew: *"Run competitor analysis every Monday at 9am"*
 
 The multi-agent framework is under 800 lines. Zero dependencies. No CrewAI. No LangChain. 7 built-in tools including web search, file operations, Google Docs, image generation, and vision.
+
+**Phase 3 substrate** (autonomous agents) reuses Phase 1+2 components: unified audit envelope (Step 1), plugin lifecycle hooks (Step 2), AskUser + strict-consent + step budget (Step 3), continuous observation loop (Step 5), trigger system (Step 6), end-of-day shift report (Step 7). Per-agent state at `~/.codec/agents/<id>/`. Global allowlist tier at `~/.codec/agent_global_grants.json`. 17 new audit events. See `docs/PHASE3-COMPLETE.md` for the full sign-off.
 
 ### 5. CODEC Vibe — AI Coding IDE + Skill Forge
 
@@ -603,6 +609,16 @@ python3 setup_codec.py
 ---
 
 ## What's Coming
+
+**Phase 3.5 (in progress)** — UX + polish on top of the autonomous-agent substrate:
+
+- [ ] **Anchor example end-to-end run** — drop the Marbella property bot project, document the run from plan-draft to final notification (`docs/PHASE35-ANCHOR-EXAMPLE-RUN.md`)
+- [ ] **Proactive intelligence overlay** — observer-driven contextual nudges via Step 6 trigger system (*"You've been on this Notion doc 30 min, want a summary?"*) with strict not-invasive defaults (1 suggestion / hour max, easy dismiss, per-pattern kill switch)
+- [ ] **Dedicated `blocked_on_qwen` status** — daemon-driven auto-resume when Qwen recovers (cleaner UX than reusing `blocked_on_permission` for LLM outages — Step 9 review C2)
+- [ ] **Read-paths runtime enforcement** — `Action.reads_path` field + LLM prompt update to symmetric read/write gating (Step 9 review M4)
+- [ ] **Multi-channel notifications** — at agent-spawn time, optionally route updates to macOS banner / iMessage / Telegram alongside PWA
+
+**Beyond Phase 3:**
 
 - [ ] iMessage voice notes (TTS briefing delivered as audio attachment)
 - [ ] WhatsApp integration (third messaging channel)

--- a/tests/test_agent_messaging.py
+++ b/tests/test_agent_messaging.py
@@ -65,6 +65,13 @@ def temp_codec_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(cam, "_CODEC_DIR", tmp_path)
     monkeypatch.setattr(cam, "_AGENTS_DIR", tmp_path / "agents")
     monkeypatch.setattr(cam, "_NOTIFICATIONS_PATH", tmp_path / "notifications.json")
+    # Redirect codec_audit._AUDIT_LOG so post_message audit emits don't
+    # leak into the production ~/.codec/audit.log (test pollution fix).
+    try:
+        import codec_audit
+        monkeypatch.setattr(codec_audit, "_AUDIT_LOG", tmp_path / "audit.log")
+    except Exception:
+        pass
     # Also patch codec_agent_plan paths so _run_agent tests don't touch real ~/.codec
     try:
         import codec_agent_plan as cap

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -117,9 +117,13 @@ def test_plan_hash_changes_when_content_changes():
 @pytest.fixture
 def temp_codec_dir(tmp_path, monkeypatch):
     import codec_agent_plan as cap
+    import codec_audit
     monkeypatch.setattr(cap, "_CODEC_DIR", tmp_path)
     monkeypatch.setattr(cap, "_AGENTS_DIR", tmp_path / "agents")
     monkeypatch.setattr(cap, "_GLOBAL_GRANTS_PATH", tmp_path / "agent_global_grants.json")
+    # Test-pollution fix: redirect codec_audit._AUDIT_LOG so audit emits
+    # during plan creation/approval do NOT leak into production ~/.codec/audit.log.
+    monkeypatch.setattr(codec_audit, "_AUDIT_LOG", tmp_path / "audit.log")
     return tmp_path
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -245,11 +245,18 @@ def test_destructive_consent_timeout_overnight(monkeypatch):
 
 @pytest.fixture
 def temp_codec_dir(tmp_path, monkeypatch):
-    """Mirrors Step 8 fixture; redirects all codec_agent_plan paths to tmp."""
+    """Mirrors Step 8 fixture; redirects all codec_agent_plan paths to tmp.
+
+    Also redirects codec_audit._AUDIT_LOG so test runs do NOT pollute
+    the production ~/.codec/audit.log. Without this, _run_agent's audit
+    emits during tests leak into the live log (same pattern as the
+    2026-05-01 incident; same fix)."""
     import codec_agent_plan as cap
+    import codec_audit
     monkeypatch.setattr(cap, "_CODEC_DIR", tmp_path)
     monkeypatch.setattr(cap, "_AGENTS_DIR", tmp_path / "agents")
     monkeypatch.setattr(cap, "_GLOBAL_GRANTS_PATH", tmp_path / "agent_global_grants.json")
+    monkeypatch.setattr(codec_audit, "_AUDIT_LOG", tmp_path / "audit.log")
     return tmp_path
 
 


### PR DESCRIPTION
## Summary

Two things bundled — a real safety fix found via health check + a README refresh.

## 1. Test pollution fix (safety)

Live `~/.codec/audit.log` on the production machine showed `agent_started` / `agent_aborted` / `agent_blocked_on_permission` / `agent_message_sent` events with `agent_id="test_agent"` — proof that pytest runs were leaking into the real production log. Same pattern as the 2026-05-01 incident.

**Root cause:** the `temp_codec_dir` fixture in `tests/test_agent_plan.py` + `tests/test_agent_runner.py` + `tests/test_agent_messaging.py` monkeypatched `codec_agent_plan` paths but NOT `codec_audit._AUDIT_LOG`. So when `_run_agent` / `approve_plan` / `post_message` audit-emitted during tests, the events bypassed the redirect and hit the production log.

**Fix:** extend the 3 `temp_codec_dir` fixtures to also redirect `codec_audit._AUDIT_LOG` → `tmp_path / "audit.log"`. Verified clean — 91/91 Phase 3 tests still pass, full suite 930/20/73 baseline preserved.

## 2. README refresh

- **Badges updated:**
  - tests 378 → **1023**
  - skills 60 → **73**
  - lines 33.9K → **53.3K**
  - features 238 → **260+**
  - engine v2.1 → **v2.3**
- **§4 CODEC Chat** rewritten to mention Project mode + drop-a-project autonomy, with anchor examples (Marbella property bot, EUR/USD vol monitor)
- **§"What's Coming"** split into "Phase 3.5 (in progress)" and "Beyond Phase 3":
  - Anchor example end-to-end run
  - Proactive intelligence overlay
  - `blocked_on_qwen` dedicated status (Step 9 review C2)
  - Read-paths runtime enforcement (Step 9 review M4)
  - Multi-channel notifications

## Test plan

- [x] 🧪 Phase 3 tests (`test_agent_plan.py + test_agent_runner.py + test_agent_messaging.py + test_chat_escalation.py`) → 91/91 passed
- [x] 🧪 Full suite — 930 passed / 20 failed / 73 skipped (same 20/73 baseline as main)
- [x] Audit log will no longer accumulate `agent_id="test_agent"` events from pytest runs going forward
- [ ] Post-merge: no deploy needed — pure test/docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)