### PR TITLE
fix(agents): Phase 3.5 review C2 + M4 — blocked_on_qwen + read_paths runtime gating

### DIFF
--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -540,10 +540,15 @@ _VALID_TRANSITIONS: Dict[str, frozenset] = {
     "running":               frozenset({"completed", "aborted", "paused",
                                         "blocked_on_permission",
                                         "blocked_on_destructive",
+                                        "blocked_on_qwen",
                                         "crashed_resumed"}),
     "paused":                frozenset({"running", "aborted"}),
     "blocked_on_permission": frozenset({"running", "aborted"}),
     "blocked_on_destructive": frozenset({"running", "aborted"}),
+    # Phase 3.5 review fix C2: dedicated status for Qwen-3.6 unavailability.
+    # Distinct from blocked_on_permission (no permission to grant — service
+    # is just down). Daemon auto-resumes on next tick when Qwen comes back.
+    "blocked_on_qwen":       frozenset({"running", "aborted"}),
     "crashed_resumed":       frozenset({"running", "aborted"}),
     "completed":             frozenset(),
     "aborted":               frozenset(),

--- a/codec_agent_runner.py
+++ b/codec_agent_runner.py
@@ -59,7 +59,10 @@ DESTRUCTIVE_CONSENT_TIMEOUT_S = 600  # Step 3 §1.7 default — overnight = bloc
 class Action:
     """One proposed step in a checkpoint loop. Returned by
     Qwen-3.6's next-action driver, evaluated by permission_gate,
-    executed via codec_dispatch.run_skill."""
+    executed via codec_dispatch.run_skill.
+
+    Phase 3.5 review M4: `reads_path` + `read_path` added for symmetric
+    read/write gating. `touches_path`/`path` is the write side."""
     skill: str
     task: str
     is_destructive: bool = False
@@ -67,6 +70,8 @@ class Action:
     network_domain: str = ""
     touches_path: bool = False
     path: str = ""
+    reads_path: bool = False        # Phase 3.5 review M4: read enforcement
+    read_path: str = ""             # Phase 3.5 review M4
     kind: str = "skill_call"   # "skill_call" | "checkpoint_done"
 
 
@@ -97,20 +102,30 @@ def permission_gate(action: Action, agent_grants: Dict[str, Any],
     if action.skill not in skills:
         raise PermissionViolation("skill_not_authorized", action.skill)
 
-    # Asymmetry: only write_paths is enforced here. PermissionManifest.read_paths
-    # is declared at approval time for user transparency ("this agent will read X")
-    # but not gated at runtime — Action's grammar has no read/write distinction
-    # (only `touches_path`, treated as a write), and skill-internal reads bypass
-    # the runner anyway. Runtime read enforcement would need a new Action field
-    # + LLM prompt update — out of scope for Step 9.
+    # Phase 3.5 review M4: symmetric read/write gating now active.
+    # `touches_path` = write; `reads_path` = read. Both checked against
+    # respective manifest entries. Note: skill-internal reads (where the
+    # skill itself opens files without going through Action) still bypass
+    # the runner — that's a fundamental limitation of the dispatch model.
     if action.touches_path:
         write_paths = (set(agent_grants.get("write_paths", [])) |
                        set(global_grants.get("write_paths", [])))
-        # fnmatch supports glob patterns the LLM puts in manifest
-        ok = any(fnmatch.fnmatch(action.path, os.path.expanduser(p))
+        # fnmatch supports glob patterns the LLM puts in manifest.
+        # Expand ~ on both sides so "~/Documents/x" matches "~/Documents/**".
+        action_path_abs = os.path.expanduser(action.path)
+        ok = any(fnmatch.fnmatch(action_path_abs, os.path.expanduser(p))
                  for p in write_paths)
         if not ok:
             raise PermissionViolation("path_not_authorized", action.path)
+
+    if action.reads_path and action.read_path:
+        read_paths = (set(agent_grants.get("read_paths", [])) |
+                      set(global_grants.get("read_paths", [])))
+        action_read_abs = os.path.expanduser(action.read_path)
+        ok = any(fnmatch.fnmatch(action_read_abs, os.path.expanduser(p))
+                 for p in read_paths)
+        if not ok:
+            raise PermissionViolation("read_path_not_authorized", action.read_path)
 
     if action.network_call:
         domains = (set(agent_grants.get("network_domains", [])) |
@@ -141,8 +156,10 @@ For a skill call:
   "is_destructive": <bool — true for irreversible ops: file delete, payments, send-on-behalf>,
   "network_call": <bool — true if the skill will make HTTP requests>,
   "network_domain": "<domain if network_call=true, else empty>",
-  "touches_path": <bool — true if the skill writes to a filesystem path>,
-  "path": "<path if touches_path=true, else empty>"
+  "touches_path": <bool — true if the skill WRITES to a filesystem path>,
+  "path": "<path if touches_path=true, else empty>",
+  "reads_path": <bool — true if the skill READS a filesystem path>,
+  "read_path": "<path if reads_path=true, else empty>"
 }
 
 For checkpoint completion:
@@ -151,6 +168,7 @@ For checkpoint completion:
 Rules:
 - skill MUST be in plan.permission_manifest.skills.
 - If you need a skill that's NOT in the manifest, return is_destructive=false and pick the closest available; the runtime will block via permission_gate, escalate to user, and re-call you with the same context.
+- read_path is checked against permission_manifest.read_paths; write path against write_paths. They are independent — a single action can both read and write (e.g. read template.md, write output.md).
 - Output ONLY the JSON. No prose.
 """
 
@@ -225,6 +243,8 @@ def _qwen_next_action(plan_dict: Dict[str, Any], checkpoint: Dict[str, Any],
         network_domain=str(d.get("network_domain", "")),
         touches_path=bool(d.get("touches_path", False)),
         path=str(d.get("path", "")),
+        reads_path=bool(d.get("reads_path", False)),    # Phase 3.5 review M4
+        read_path=str(d.get("read_path", "")),          # Phase 3.5 review M4
         kind="skill_call",
     )
 
@@ -586,23 +606,21 @@ def _run_agent(agent_id: str, cid: Optional[str] = None) -> None:
                      correlation_id=cid)
 
     except QwenUnavailableError as e:
-        # Review fix C2: Qwen-3.6 unavailable is not strictly a permission
-        # problem, but we route through `blocked_on_permission` for v1
-        # because:
-        #   (a) it's a recoverable block (agent can resume once Qwen is back)
-        #   (b) adding `blocked_on_qwen` requires a new state-machine entry
-        #       + UI changes that should ship together in Step 10
-        # The reason="qwen_unavailable" makes the cause unambiguous in audit,
-        # and the daemon will retry on next tick once Qwen returns.
-        # TODO Step 10 / Phase 3.5: introduce dedicated `blocked_on_qwen`
-        # status with daemon-driven auto-resume on Qwen recovery.
+        # Phase 3.5 review fix C2: dedicated `blocked_on_qwen` status.
+        # Distinct from blocked_on_permission — no permission to grant; the
+        # LLM service is just down. The daemon auto-resumes on next tick
+        # when Qwen comes back online (see _daemon_one_tick blocked_on_qwen
+        # branch). Audit emit still uses AGENT_BLOCKED_ON_PERMISSION with
+        # reason="qwen_unavailable" since we don't add a new audit constant
+        # for this — the status is enough to disambiguate.
         log.warning("[%s] qwen unavailable: %s", agent_id, e)
-        _atomic_set_status(agent_id, "blocked_on_permission",
+        _atomic_set_status(agent_id, "blocked_on_qwen",
                            reason=f"qwen_unavailable:{e}")
         _audit(AGENT_BLOCKED_ON_PERMISSION,
                message=f"qwen unavailable: {e}",
                correlation_id=cid, outcome="warning", level="warning",
-               extra={"agent_id": agent_id, "reason": "qwen_unavailable"})
+               extra={"agent_id": agent_id, "reason": "qwen_unavailable",
+                      "status": "blocked_on_qwen"})
     except Exception as e:
         log.exception("[%s] unhandled exception in _run_agent", agent_id)
         _atomic_set_status(agent_id, "aborted",
@@ -710,6 +728,32 @@ def _daemon_one_tick() -> None:
                 _atomic_set_status(agent_id, "running")
                 t = threading.Thread(target=_run_agent, args=(agent_id,),
                                       kwargs={"cid": recovery_cid}, daemon=True,
+                                      name=f"agent-{agent_id}")
+                t.start()
+                with _threads_lock:
+                    _active_threads[agent_id] = t
+                occupied += 1
+
+        elif status == "blocked_on_qwen":
+            # Phase 3.5 review C2: auto-resume when Qwen returns. We probe
+            # Qwen liveness with a tiny request; if the call succeeds, the
+            # agent transitions back to running and the daemon respawns it
+            # next iteration. No user interaction needed for this block —
+            # unlike blocked_on_permission, the user has nothing to grant.
+            if occupied >= MAX_CONCURRENT:
+                continue
+            try:
+                # Probe Qwen with a trivial call; if it succeeds, unblock
+                _qwen_chat("ping", system_prompt="", max_tokens=1)
+                qwen_alive = True
+            except QwenUnavailableError:
+                qwen_alive = False
+            except Exception as e:
+                log.debug("[%s] qwen probe error: %s", agent_id, e)
+                qwen_alive = False
+            if qwen_alive:
+                _atomic_set_status(agent_id, "running")
+                t = threading.Thread(target=_run_agent, args=(agent_id,), daemon=True,
                                       name=f"agent-{agent_id}")
                 t.start()
                 with _threads_lock:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -865,3 +865,83 @@ def test_extend_budget_endpoint_409_when_not_paused_on_budget(temp_codec_dir):
     r = client.post("/api/agents/a1/extend_budget",
                      json={"additional_steps": 10})
     assert r.status_code == 409
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3.5 review C2 — blocked_on_qwen dedicated status (3 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_blocked_on_qwen_in_state_machine():
+    """blocked_on_qwen is a valid status with proper transitions."""
+    from codec_agent_plan import _VALID_TRANSITIONS
+    assert "blocked_on_qwen" in _VALID_TRANSITIONS["running"]
+    assert {"running", "aborted"} <= _VALID_TRANSITIONS["blocked_on_qwen"]
+
+
+def test_run_agent_qwen_failure_uses_blocked_on_qwen(monkeypatch, temp_codec_dir):
+    """When Qwen is unavailable mid-run, status transitions to blocked_on_qwen
+    (NOT blocked_on_permission)."""
+    import codec_agent_runner as car
+    import codec_agent_plan as cap
+    _setup_approved_agent(temp_codec_dir, monkeypatch, num_checkpoints=1)
+
+    def raise_qwen(*a, **k):
+        raise car.QwenUnavailableError("simulated outage")
+    monkeypatch.setattr(car, "_qwen_next_action", raise_qwen)
+
+    car._run_agent("test_agent")
+
+    m = cap.load_manifest("test_agent")
+    assert m["status"] == "blocked_on_qwen"
+    assert "qwen_unavailable" in (m.get("status_reason", "") or "")
+
+
+def test_daemon_resumes_blocked_on_qwen_when_qwen_alive(monkeypatch, temp_codec_dir):
+    """When daemon ticks and an agent is blocked_on_qwen, if Qwen is alive
+    (probe succeeds), the daemon transitions back to running and respawns."""
+    import codec_agent_runner as car
+    import codec_agent_plan as cap
+
+    cap.save_manifest("a1", {"agent_id": "a1", "status": "blocked_on_qwen",
+                              "title": "x"})
+    monkeypatch.setattr(car, "_qwen_chat", lambda *a, **k: "ok")  # Qwen alive
+    spawned = []
+    monkeypatch.setattr(car, "_run_agent", lambda agent_id, **kw: spawned.append(agent_id))
+    monkeypatch.setattr(car, "MAX_CONCURRENT", 3)
+
+    car._daemon_one_tick()
+    time.sleep(0.3)
+    assert "a1" in spawned
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3.5 review M4 — read_paths runtime enforcement (3 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_action_dataclass_supports_reads_path():
+    """Action accepts reads_path + read_path fields."""
+    from codec_agent_runner import Action
+    a = Action(skill="file_ops", task="read template",
+               reads_path=True, read_path="~/Documents/template.md")
+    assert a.reads_path is True
+    assert a.read_path == "~/Documents/template.md"
+
+
+def test_permission_gate_blocks_read_path_outside_grants(basic_grants, empty_global_grants):
+    """Action with reads_path=True and read_path NOT in read_paths → blocked."""
+    from codec_agent_runner import permission_gate, Action, PermissionViolation
+    action = Action(skill="weather", task="read",
+                    reads_path=True, read_path="/etc/passwd")
+    with pytest.raises(PermissionViolation) as exc:
+        permission_gate(action, basic_grants, empty_global_grants)
+    assert exc.value.reason == "read_path_not_authorized"
+    assert exc.value.needed == "/etc/passwd"
+
+
+def test_permission_gate_allows_read_path_in_grants(basic_grants, empty_global_grants):
+    """Action reading a path inside ~/Documents/** (granted) → allowed."""
+    from codec_agent_runner import permission_gate, Action
+    # basic_grants fixture has read_paths=["~/Documents/**"]
+    action = Action(skill="weather", task="read",
+                    reads_path=True, read_path="~/Documents/research/notes.md")
+    permission_gate(action, basic_grants, empty_global_grants)  # no exception


### PR DESCRIPTION
## Summary

Resolves the two Phase 3 Step 9 review deferrals (C2 + M4). Both are small backend cleanups; together ~150 LOC + 6 tests.

## C2 — dedicated `blocked_on_qwen` status

**Before:** Qwen-3.6 unavailability mapped to `blocked_on_permission`. Semantic mismatch — no permission to grant; service is just down. User would see a "grant permission" prompt with nothing to grant.

**After:**
- New status `blocked_on_qwen` in state machine (`running → blocked_on_qwen → running | aborted`)
- `_run_agent` Qwen exception handler uses the new status
- Daemon's `_daemon_one_tick` adds a branch: when an agent is `blocked_on_qwen`, probe Qwen with a tiny call. If alive → auto-resume to `running`. No user click required.

When Qwen flickers (PM2 restart, OOM, network blip), agents auto-recover within one daemon tick (5 s). Before this fix, you'd have to manually `/resume`.

## M4 — read_paths runtime enforcement

**Before:** `PermissionManifest.read_paths` was declared at approval time for transparency but never enforced. An agent could ask Qwen for a skill that reads `/etc/passwd` and `permission_gate` wouldn't catch it (only `touches_path` = write was checked).

**After:**
- `Action` dataclass: NEW fields `reads_path: bool` + `read_path: str`
- `permission_gate` checks `action.read_path` against `read_paths ∪ global.read_paths`
- LLM next-action prompt extended: Qwen emits `reads_path` + `read_path` fields. A single action can both read AND write (e.g. read template.md, write output.md).
- `_qwen_next_action` parser populates the new fields.

**Side fix:** `permission_gate` now expands `~` on BOTH sides of the path comparison. Was a latent bug for `write_paths` (action with `~/Documents/x` wouldn't match grant glob `~/Documents/**` because the action wasn't expanded). Symmetric improvement that affects both read and write enforcement.

## Tests

6 new tests in `tests/test_agent_runner.py`:

| Test | What it locks |
|---|---|
| `test_blocked_on_qwen_in_state_machine` | Status registered with proper transitions |
| `test_run_agent_qwen_failure_uses_blocked_on_qwen` | `_run_agent` uses correct status on Qwen failure |
| `test_daemon_resumes_blocked_on_qwen_when_qwen_alive` | Auto-resume probe success path |
| `test_action_dataclass_supports_reads_path` | New Action fields exist |
| `test_permission_gate_blocks_read_path_outside_grants` | Read enforcement actually bites |
| `test_permission_gate_allows_read_path_in_grants` | Happy path with `~/Documents/**` glob |

## Full suite

944 passed / 20 failed / 73 skipped — same 20/73 baseline, +6 from this PR.

## Compat

- `Action` field additions are non-breaking (defaults preserve old behavior)
- New status `blocked_on_qwen` only fires from new code paths; no migration needed
- LLM prompt is additive; older Qwen responses without `reads_path` parse fine (default `False`)
- Plan schema unchanged

## Test plan
- [x] 🧪 `tests/test_agent_runner.py` → 42 passed
- [x] 🧪 Full suite — 944/20/73
- [x] Symmetric tilde expansion in permission_gate (write side benefits too)
- [ ] Post-merge deploy: `pm2 restart codec-agent-runner codec-dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)