### PR TITLE
feat(messaging): Phase 3.5 — multi-channel notification dispatch (macOS / iMessage / Telegram)

### DIFF
--- a/codec_agent_messaging.py
+++ b/codec_agent_messaging.py
@@ -214,12 +214,128 @@ def post_message(agent_id: str, type: str, title: str, body: str,
 
         _atomic_write_json(_NOTIFICATIONS_PATH, notifs)
 
+    # Phase 3.5 — multi-channel notification dispatch.
+    # Reads agent's notification_channels from manifest. Each non-`pwa`
+    # channel gets its own dispatch (best-effort; failures don't block).
+    if not is_silenced(agent_id):
+        try:
+            channels = _agent_notification_channels(agent_id)
+            for ch in channels:
+                if ch == "pwa":
+                    continue   # already covered by notifications.json above
+                try:
+                    _dispatch_to_channel(ch, agent_id, title, body, type)
+                except Exception as e:
+                    log.debug("[%s] channel %s dispatch failed: %s", agent_id, ch, e)
+        except Exception as e:
+            log.debug("[%s] channel dispatch wrapper failed: %s", agent_id, e)
+
     # Audit emit
     _audit(AGENT_MESSAGE_SENT, message=f"{type} for {agent_id}",
            correlation_id=correlation_id,
            extra={"agent_id": agent_id, "type": type, "batched": batched})
 
     return record
+
+
+def _agent_notification_channels(agent_id: str) -> List[str]:
+    """Read manifest.notification_channels. Defaults to ['pwa']."""
+    manifest_path = _AGENTS_DIR / agent_id / "manifest.json"
+    if not manifest_path.exists():
+        return ["pwa"]
+    try:
+        data = json.loads(manifest_path.read_text())
+        chs = data.get("notification_channels") or ["pwa"]
+        return [c for c in chs if isinstance(c, str)] or ["pwa"]
+    except Exception:
+        return ["pwa"]
+
+
+def _dispatch_to_channel(channel: str, agent_id: str,
+                         title: str, body: str, msg_type: str) -> None:
+    """Best-effort dispatch to a single channel. Raises on hard failures.
+
+    Supported channels:
+      - "macos": macOS notification banner via osascript display notification
+      - "imessage": send via codec_imessage.send_message helper if available
+      - "telegram": send via codec_telegram.send_message helper if available
+
+    Phase 3.5 multi-channel notifications. Each channel is OPTIONAL —
+    if the underlying tooling isn't configured, dispatch is a no-op.
+    """
+    short_body = (body or "")[:200]
+    short_title = (title or f"CODEC agent {agent_id}")[:80]
+
+    if channel == "macos":
+        # macOS notification banner via osascript. No external dependencies.
+        import subprocess
+        # Sanitize for AppleScript single-quoting
+        def _esc(s: str) -> str:
+            return s.replace("\\", "\\\\").replace('"', '\\"')
+        script = (
+            f'display notification "{_esc(short_body)}" '
+            f'with title "{_esc(short_title)}" '
+            f'subtitle "agent: {_esc(agent_id)}"'
+        )
+        subprocess.run(["osascript", "-e", script], timeout=5,
+                       capture_output=True, check=False)
+        return
+
+    if channel == "imessage":
+        # Reuse the imessage_send skill's _send helper. Recipient is read
+        # from ~/.codec/config.json:notifications.imessage_recipient
+        # (phone number or Apple ID). If unset, skip silently.
+        recipient = _channel_config("imessage_recipient")
+        if not recipient:
+            log.debug("notifications.imessage_recipient not configured; skipping imessage")
+            return
+        try:
+            import sys as _sys
+            from pathlib import Path as _Path
+            skills_dir = str(_Path(__file__).resolve().parent / "skills")
+            if skills_dir not in _sys.path:
+                _sys.path.insert(0, skills_dir)
+            import imessage_send as _ims
+            _ims._send(recipient, f"[{short_title}]\n{short_body}")
+        except Exception as e:
+            log.debug("imessage send failed: %s", e)
+        return
+
+    if channel == "telegram":
+        # Send via Telegram Bot API directly (avoids tight coupling to
+        # codec_telegram.py's daemon internals). Reads token + chat_id
+        # from ~/.codec/config.json:notifications.{telegram_token,telegram_chat_id}.
+        token = _channel_config("telegram_token")
+        chat_id = _channel_config("telegram_chat_id")
+        if not token or not chat_id:
+            log.debug("notifications.telegram_{token,chat_id} not configured; skipping telegram")
+            return
+        try:
+            import requests
+            requests.post(
+                f"https://api.telegram.org/bot{token}/sendMessage",
+                json={"chat_id": chat_id,
+                      "text": f"*{short_title}*\n{short_body}",
+                      "parse_mode": "Markdown"},
+                timeout=5,
+            )
+        except Exception as e:
+            log.debug("telegram send failed: %s", e)
+        return
+
+    log.debug("unknown notification channel: %s", channel)
+
+
+def _channel_config(key: str) -> str:
+    """Read ~/.codec/config.json:notifications.<key>. Empty string if unset."""
+    cfg_path = _CODEC_DIR / "config.json"
+    if not cfg_path.exists():
+        return ""
+    try:
+        data = json.loads(cfg_path.read_text())
+        return str((data.get("notifications") or {}).get(key) or "")
+    except Exception:
+        return ""
 
 
 def post_user_reply(agent_id: str, body: str) -> Dict[str, Any]:

--- a/tests/test_agent_messaging.py
+++ b/tests/test_agent_messaging.py
@@ -377,3 +377,71 @@ def test_post_api_agents_silence_toggles_state(temp_codec_dir):
     r2 = client.post("/api/agents/a1/silence", json={"silenced": False})
     assert r2.status_code == 200
     assert cam.is_silenced("a1") is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3.5 — Multi-channel notification dispatch (5 tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_pwa_only_default_no_extra_dispatch(monkeypatch, temp_codec_dir):
+    """Default channels=['pwa']: no macOS/iMessage/Telegram dispatch."""
+    import codec_agent_messaging as cam
+    import codec_agent_plan as cap
+    cap.save_manifest("a1", {"agent_id": "a1", "title": "x",
+                              "notification_channels": ["pwa"]})
+    dispatched = []
+    monkeypatch.setattr(cam, "_dispatch_to_channel",
+                        lambda ch, *a, **k: dispatched.append(ch))
+    cam.post_message(agent_id="a1", type="agent_update", title="t",
+                     body="b", actions=[], correlation_id="cid")
+    assert dispatched == []  # pwa is skipped (handled inline)
+
+
+def test_macos_channel_dispatched_when_configured(monkeypatch, temp_codec_dir):
+    """When manifest includes 'macos', _dispatch_to_channel called for it."""
+    import codec_agent_messaging as cam
+    import codec_agent_plan as cap
+    cap.save_manifest("a1", {"agent_id": "a1", "title": "x",
+                              "notification_channels": ["pwa", "macos"]})
+    dispatched = []
+    monkeypatch.setattr(cam, "_dispatch_to_channel",
+                        lambda ch, *a, **k: dispatched.append(ch))
+    cam.post_message(agent_id="a1", type="agent_update", title="t",
+                     body="b", actions=[], correlation_id="cid")
+    assert dispatched == ["macos"]
+
+
+def test_dispatch_to_channel_macos_invokes_osascript(monkeypatch, temp_codec_dir):
+    """_dispatch_to_channel('macos', ...) builds an osascript command and runs it."""
+    import codec_agent_messaging as cam
+    captured = {"args": None}
+    class FakeProc:
+        returncode = 0
+    def fake_run(args, **kw):
+        captured["args"] = list(args)
+        return FakeProc()
+    import subprocess
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    cam._dispatch_to_channel("macos", "agent_test", "Test title", "Test body", "agent_update")
+    assert captured["args"] is not None
+    assert captured["args"][0] == "osascript"
+    assert "-e" in captured["args"]
+    # AppleScript text contains the title + body somewhere
+    full = " ".join(captured["args"])
+    assert "Test title" in full
+    assert "Test body" in full
+
+
+def test_imessage_channel_skipped_when_recipient_unset(monkeypatch, temp_codec_dir):
+    """Without config notifications.imessage_recipient, channel is no-op (no exception)."""
+    import codec_agent_messaging as cam
+    # No config.json → _channel_config returns ""
+    cam._dispatch_to_channel("imessage", "agent_test", "T", "B", "agent_update")
+    # Should not raise; should not call any send
+
+
+def test_telegram_channel_skipped_when_unconfigured(monkeypatch, temp_codec_dir):
+    """Without telegram token/chat_id, channel is no-op."""
+    import codec_agent_messaging as cam
+    cam._dispatch_to_channel("telegram", "agent_test", "T", "B", "agent_update")
+    # Should not raise


### PR DESCRIPTION
## Summary

Last Phase 3.5 backlog item. `manifest.notification_channels` already existed (set at agent spawn since Step 8) — this PR makes it actually do something beyond the default `pwa`.

When you spawn an agent with `notification_channels: ["pwa", "macos", "telegram"]`, every `agent_update` / `agent_blocked` / `agent_done` now dispatches to all 3 channels.

## What ships

| Channel | How | Configuration |
|---|---|---|
| `pwa` | `~/.codec/notifications.json` (existing) | None — default |
| `macos` | `osascript display notification` | None — works out of the box on macOS |
| `imessage` | `skills/imessage_send._send(recipient, text)` | `~/.codec/config.json:notifications.imessage_recipient` |
| `telegram` | direct Bot API `sendMessage` | `~/.codec/config.json:notifications.{telegram_token,telegram_chat_id}` |

If iMessage / Telegram config is missing, channel silently skips. macOS works without any setup. PWA is always-on.

## Configuration example

```json
// ~/.codec/config.json
{
  "notifications": {
    "imessage_recipient": "+33612345678",
    "telegram_token": "1234567890:AAEhBOweik6ad9r_QXz...",
    "telegram_chat_id": "987654321"
  }
}
```

If absent, channels gracefully skip. Never breaks `post_message`.

## To use

```bash
curl -X POST http://localhost:8090/api/agents \
  -H "Content-Type: application/json" \
  -d '{
    "title": "Property bot",
    "description": "...",
    "notification_channels": ["pwa", "macos", "telegram"]
  }'
```

The PWA's Project mode currently sends `notification_channels` is unset → defaults to `["pwa"]`. Future UI enhancement (small): checkbox set in the Project mode submit.

## Tests

5 new tests in `tests/test_agent_messaging.py`:
- pwa-only default → no extra dispatch
- 'macos' in manifest → `_dispatch_to_channel` called for macos
- macos dispatch builds `osascript` command with title + body
- imessage skipped when recipient unset (no exception)
- telegram skipped when unconfigured (no exception)

Full suite: 943 passed / 20 failed / 73 skipped — same 20/73 baseline, +5 from this PR.

## Phase 3.5 status

All backlog items shipped:

| Item | Status |
|---|---|
| Step 11: Project mode UI | ✅ PR #25 |
| Project folder creation | ✅ PR #28 |
| Step 13: Proactive intelligence overlay | ✅ PR #29 |
| Step 9 review C2 (`blocked_on_qwen`) | ✅ PR #30 |
| Step 9 review M4 (read_paths enforcement) | ✅ PR #30 |
| Multi-channel notifications | ✅ This PR |

Remaining: anchor example run (your test of the property bot) + Phase 3 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)