### PR TITLE
fix(reliability): codec.py graceful shutdown on SIGTERM (C-1, Wave 4 opener)

### DIFF
--- a/codec.py
+++ b/codec.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
+# C-1 (PR-4A): real SIGTERM/SIGINT handlers are registered in main() via
+# _graceful_shutdown (after `state` is defined). The old no-op handlers that
+# lived here ignored shutdown signals, orphaning the sox recording subprocess +
+# tkinter overlays and leaking temp .wav/.png files on every PM2 restart.
 import signal
-signal.signal(signal.SIGINT, lambda *a: None)
-signal.signal(signal.SIGTERM, lambda *a: None)
 """CODEC v2.1 | F13=on/off | F18=voice | F16=text | *=screenshot | +=doc | Wake word"""
-import logging, threading, tempfile, subprocess, os, time, json, re, base64, shutil
+import logging, threading, tempfile, subprocess, os, sys, time, json, re, base64, shutil
+import atexit
 from datetime import datetime
 from pynput import keyboard
 
@@ -835,9 +838,46 @@ def on_release(key):
         push(do_stop_voice)
 
 # ── MAIN ──────────────────────────────────────────────────────────────────────
+def _graceful_shutdown(signum=None, frame=None):
+    """C-1 (PR-4A): terminate the recording + overlay subprocesses and unlink the
+    temp audio file so PM2 SIGTERM (restart / reboot / max-memory) doesn't orphan
+    `sox`/tkinter children or leak temp files. Registered as the SIGTERM/SIGINT
+    handler AND via atexit. Idempotent (state nulled) and never raises. On the
+    signal path (signum set) it exits 0; on the atexit path it just cleans up."""
+    rec = state.get("rec_proc")
+    if rec:
+        try:
+            rec.terminate(); rec.wait(timeout=2)
+        except Exception as e:
+            log.debug("Shutdown: rec_proc cleanup failed: %s", e)
+        state["rec_proc"] = None
+    ovl = state.get("overlay_proc")
+    if ovl:
+        try:
+            ovl.terminate()
+        except Exception as e:
+            log.debug("Shutdown: overlay_proc cleanup failed: %s", e)
+        state["overlay_proc"] = None
+    audio = state.get("audio_path")
+    if audio:
+        try:
+            if os.path.exists(audio):
+                os.unlink(audio)
+        except Exception as e:
+            log.debug("Shutdown: audio_path unlink failed: %s", e)
+        state["audio_path"] = None
+    if signum is not None:   # real signal (not atexit) → exit within PM2's 10s window
+        sys.exit(0)
+
+
 def main():
     from codec_logging import setup_logging
     setup_logging()
+    # C-1 (PR-4A): graceful shutdown — registered here (not at module top) so the
+    # handler sees the `state` dict. Replaces the old no-op SIGINT/SIGTERM handlers.
+    signal.signal(signal.SIGTERM, _graceful_shutdown)
+    signal.signal(signal.SIGINT, _graceful_shutdown)
+    atexit.register(_graceful_shutdown)
     init_db()
     for f in [SESSION_ALIVE, TASK_QUEUE_FILE, DRAFT_TASK_FILE]:
         try: os.unlink(f)

--- a/docs/PR4A-CODEC-GRACEFUL-SHUTDOWN-DESIGN.md
+++ b/docs/PR4A-CODEC-GRACEFUL-SHUTDOWN-DESIGN.md
@@ -1,0 +1,39 @@
+# PR-4A — codec.py graceful shutdown (C-1) (DESIGN)
+
+**Status:** IMPLEMENTED — Wave 4 (Reliability) opener. Removed codec.py's no-op SIGINT/SIGTERM handlers; added `_graceful_shutdown` (terminates `rec_proc`/`overlay_proc` + unlinks `audio_path`, exits 0 on the signal path, idempotent + never-raises) registered via `signal.signal` + `atexit` in `main()`. Added `import sys, atexit`. 5 tests (`tests/test_graceful_shutdown.py`); full suite 1507 passing, zero new; zero net-new ruff. **Scoped to C-1 (codec.py);** H-1 (the `codec_lifecycle.py` helper across the other 10 daemons) follows.
+**Finding:** C-1 [CRITICAL] — the main `codec.py` daemon installs no-op SIGINT/SIGTERM handlers and has no shutdown path, so every `pm2 restart open-codec` (or reboot, or max-memory restart) orphans the `sox` recording subprocess + tkinter overlays and leaks temp `.wav`/`.png` files.
+**Wave:** 4. This is the **start of Wave 4** — scoped to **C-1 only** (the main daemon). H-1 (the `codec_lifecycle.py` helper across the other 10 PM2 daemons) is the larger follow-on (PR-4A-2+).
+
+---
+
+## 1. The bug (codec.py:1-4)
+```python
+import signal
+signal.signal(signal.SIGINT,  lambda *a: None)
+signal.signal(signal.SIGTERM, lambda *a: None)
+```
+No-op handlers installed before any cleanup logic; **no `atexit`** anywhere. PM2 SIGTERMs, the daemon ignores it, PM2 SIGKILLs after 10s → `state["rec_proc"]` (sox) reparents to init and keeps recording; `state["overlay_proc"]` (tkinter) orphaned; `state["audio_path"]` `.wav` never unlinked.
+
+## 2. Fix (mirror codec_dictate.py's `atexit._cleanup` + do_stop_voice cleanup)
+- **Remove** the two no-op handler lines (keep `import signal`). Add `import sys, atexit` (neither is currently imported).
+- **New `_graceful_shutdown(signum=None, frame=None)`** — idempotent, never-raises:
+  - `state["rec_proc"]`: `terminate()` + `wait(timeout=2)`, set None.
+  - `state["overlay_proc"]`: `terminate()`, set None.
+  - `state["audio_path"]`: `os.unlink` if it exists, set None.
+  - if `signum is not None` (called as a signal handler, not atexit): `sys.exit(0)`.
+- **Register in `main()`** (after `setup_logging()`, before the listener loop): `signal.signal(SIGTERM, _graceful_shutdown)`, `signal.signal(SIGINT, _graceful_shutdown)`, `atexit.register(_graceful_shutdown)`.
+
+Behavior: a SIGTERM now terminates the children + unlinks the temp file + exits 0 (within PM2's 10s window, before SIGKILL). atexit covers normal exit. Idempotent (the signal path's `sys.exit(0)` re-fires atexit → second call no-ops on the now-None state).
+
+**Why register in `main()` (not at module top):** the handler needs `state` (defined at codec.py:131) in scope. During the brief import window before `main()`, SIGTERM falls back to the default (terminate) — fine, there's no recording state yet. The real handler (registered last) wins over any pynput-installed handler.
+
+## 3. Test plan
+- `tests/test_graceful_shutdown.py`: `_graceful_shutdown()` (atexit path) terminates fake `rec_proc` + `overlay_proc`, unlinks a real temp `audio_path`, and nulls the `state` entries; never raises if a proc's `terminate()` throws; `_graceful_shutdown(15, None)` (signal path) raises `SystemExit`. Source invariant: the `lambda *a: None` no-op handlers are gone; `atexit.register` is present.
+- Regression: full suite — the 23 known-baseline failures, **zero new**. (Note: `test_full_product_audit::test_dry_run_enforcement` is a *pre-existing baseline failure* asserting `DRY_RUN` in the generated session script — unrelated to these top-of-file signal lines.)
+
+## 4. Risk + rollback
+- **Blast radius:** `codec.py` only — top-of-file handlers + one new helper + 3 registration lines in `main()`. Signal handling on the main daemon is PM2-supervision-adjacent → covered by a unit test for the cleanup + a manual `pm2 restart` check before merge.
+- **Rollback:** single-commit revert restores the (buggy but stable) no-ops.
+
+## 5. Wave 4 sequence (from the consolidated triage, for reference)
+PR-4A **C-1** (this) → H-1 lifecycle helper for the other 10 daemons → C-2 (`pwa_response.json` per-request files) → C-3+C-4+M-1+M-2 (atomic-write + `flock` + eviction for the `~/.codec/*.json` writers) → C-5 (`_atomic_set_status`) → H-3 (audit `flock`) → H-2 (`state` lock) → H-4/5/6/M-6 (bounded dicts) → H-7/8/9 (tempfile leaks) → M/L misc. Each its own design-first PR.

--- a/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
+++ b/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
@@ -264,7 +264,9 @@ Mirror the Intake Phase 3 wave pattern. 7 waves planned; sizes are PR-counts, NO
 ### Wave 4 — Reliability (target: 1 week)
 **Findings:** all 22 in Audit C
 **PR count estimate:** 5-6
-- PR-4A: C-1 + H-1 — unified SIGTERM/SIGINT/atexit lifecycle helper (`codec_lifecycle.py`) wired into all 11 PM2 daemons
+- PR-4A: C-1 + H-1 — unified SIGTERM/SIGINT/atexit lifecycle helper (`codec_lifecycle.py`) wired into all 11 PM2 daemons. **Split: C-1 first (the CRITICAL main-daemon fix), H-1 (the other 10 daemons) follows.**
+  - PR-4A (C-1) ✅ (branch `fix/pr4a-codec-graceful-shutdown`, design-first → `docs/PR4A-CODEC-GRACEFUL-SHUTDOWN-DESIGN.md`). Removed codec.py's no-op SIGINT/SIGTERM handlers; added `_graceful_shutdown` (terminate rec_proc/overlay_proc + unlink audio_path + exit 0 on signal path; idempotent, never-raises) registered via signal + atexit in `main()`. No more orphaned sox/tkinter + leaked temp files on PM2 restart. 5 tests (`tests/test_graceful_shutdown.py`); zero net-new ruff; full suite 1507 passing, zero new.
+  - PR-4A-2: H-1 — `codec_lifecycle.py` helper + wire the other 10 PM2 daemons (heartbeat, autopilot, scheduler-in-dashboard, telegram, imessage, mcp-http, overlay, watchdog, agent-runner, dictate). Pending.
 - PR-4B: C-2 — replace `~/.codec/pwa_response.json` with per-request files (or migrate to SQLite); add `request_id` correlation
 - PR-4C: C-3 + C-4 + M-1 + M-2 — unify all `~/.codec/*.json` writers on `_atomic_write_json`; add `fcntl.flock` for cross-process; add eviction
 - PR-4D: C-5 — narrow `_atomic_set_status` to `InvalidStatusTransition`-only; return bool; check at call sites

--- a/docs/audits/PHASE-1-RELIABILITY.md
+++ b/docs/audits/PHASE-1-RELIABILITY.md
@@ -31,6 +31,8 @@ Findings cross-reference each other to avoid double-counting the same root cause
 ## Findings
 
 ### C-1 — Main `codec.py` daemon ignores SIGINT and SIGTERM, leaks subprocesses on PM2 restart [CRITICAL]
+
+> **Closed by PR-4A** (Wave 4 opener). The two no-op handlers (`signal.signal(SIG*, lambda *a: None)`) are gone; `codec._graceful_shutdown(signum, frame)` now terminates `state["rec_proc"]` (sox) + `state["overlay_proc"]` (tkinter), unlinks `state["audio_path"]`, and exits 0 on the signal path — registered via `signal.signal(SIGTERM/SIGINT, …)` + `atexit.register(…)` in `main()` (after `state` is in scope). Idempotent + never-raises (mirrors `codec_dictate`'s `atexit._cleanup`). So `pm2 restart open-codec` / reboot / max-memory restart no longer orphans the recording subprocess or leaks temp `.wav`/`.png`. Pinned by `tests/test_graceful_shutdown.py` (5). See `docs/PR4A-CODEC-GRACEFUL-SHUTDOWN-DESIGN.md`. **H-1** (the `codec_lifecycle.py` helper for the other 10 PM2 daemons) is the follow-on.
 **Location:** `codec.py:1-4`
 **Description:**
 ```python

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,78 @@
+"""Tests for PR-4A (C-1) — codec.py graceful shutdown.
+
+The main daemon used to install no-op SIGINT/SIGTERM handlers (orphaning the sox
+recording subprocess + tkinter overlays + leaking temp files on every PM2
+restart). _graceful_shutdown terminates those children + unlinks the temp audio,
+and exits 0 on the signal path. Reference: docs/PR4A-CODEC-GRACEFUL-SHUTDOWN-DESIGN.md.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+import codec  # noqa: E402
+
+
+class _FakeProc:
+    def __init__(self, raise_on_terminate=False):
+        self.terminated = False
+        self.waited = False
+        self._raise = raise_on_terminate
+
+    def terminate(self):
+        self.terminated = True
+        if self._raise:
+            raise RuntimeError("terminate boom")
+
+    def wait(self, timeout=None):
+        self.waited = True
+
+
+def test_graceful_shutdown_terminates_and_unlinks(monkeypatch, tmp_path):
+    audio = tmp_path / "rec.wav"
+    audio.write_bytes(b"x")
+    rec, ovl = _FakeProc(), _FakeProc()
+    monkeypatch.setattr(codec, "state", {
+        "rec_proc": rec, "overlay_proc": ovl, "audio_path": str(audio)})
+    codec._graceful_shutdown()   # atexit path (signum=None) — no exit
+    assert rec.terminated and rec.waited
+    assert ovl.terminated
+    assert not audio.exists()
+    assert codec.state["rec_proc"] is None
+    assert codec.state["overlay_proc"] is None
+    assert codec.state["audio_path"] is None
+
+
+def test_graceful_shutdown_never_raises(monkeypatch, tmp_path):
+    audio = tmp_path / "rec.wav"
+    audio.write_bytes(b"x")
+    rec = _FakeProc(raise_on_terminate=True)
+    monkeypatch.setattr(codec, "state", {
+        "rec_proc": rec, "overlay_proc": None, "audio_path": str(audio)})
+    codec._graceful_shutdown()   # must not raise despite terminate() throwing
+    assert not audio.exists()     # cleanup continued past the failing terminate
+
+
+def test_graceful_shutdown_handles_empty_state(monkeypatch):
+    monkeypatch.setattr(codec, "state", {
+        "rec_proc": None, "overlay_proc": None, "audio_path": None})
+    codec._graceful_shutdown()   # no procs, no file — must be a clean no-op
+
+
+def test_graceful_shutdown_signal_path_exits(monkeypatch):
+    monkeypatch.setattr(codec, "state", {
+        "rec_proc": None, "overlay_proc": None, "audio_path": None})
+    with pytest.raises(SystemExit):
+        codec._graceful_shutdown(15, None)   # signum set → sys.exit(0)
+
+
+def test_no_noop_signal_handlers():
+    src = (REPO / "codec.py").read_text()
+    assert "signal.signal(signal.SIGINT, lambda *a: None)" not in src
+    assert "signal.signal(signal.SIGTERM, lambda *a: None)" not in src
+    assert "atexit.register(_graceful_shutdown)" in src


### PR DESCRIPTION
## Summary

**Wave 4 (Reliability) opener.** C-1 [CRITICAL]: the main `codec.py` daemon installed no-op SIGINT/SIGTERM handlers (`signal.signal(SIG*, lambda *a: None)`) before any cleanup and had no `atexit`, so every `pm2 restart open-codec` / reboot / max-memory restart **orphaned the `sox` recording subprocess + tkinter overlays and leaked temp `.wav`/`.png` files** (and F13/F18 silently stopped after a sleep/wake restart). Design → `docs/PR4A-CODEC-GRACEFUL-SHUTDOWN-DESIGN.md`.

### Fix (mirrors `codec_dictate`'s `atexit._cleanup` + the existing `do_stop_voice` cleanup)
- Removed the no-op handlers.
- Added **`_graceful_shutdown(signum, frame)`** — terminates `state["rec_proc"]` (terminate+wait) + `state["overlay_proc"]`, unlinks `state["audio_path"]`. **Idempotent** (nulls the state) and **never-raises**. On the signal path (`signum` set) it `sys.exit(0)` within PM2's 10s window; on the atexit path it just cleans up.
- Registered via `signal.signal(SIGTERM/SIGINT, …)` + `atexit.register(…)` in **`main()`** — after `state` is defined (the old handlers lived at module top and couldn't see it). Added `import sys, atexit`.

**Scoped to C-1** (the main daemon). **H-1** — the `codec_lifecycle.py` helper wired into the other 10 PM2 daemons — is the follow-on (PR-4A-2).

## Test plan
- [x] `tests/test_graceful_shutdown.py` — 5 tests: terminates + unlinks + nulls state; never-raises if `terminate()` throws; empty-state clean no-op; signal path raises `SystemExit`; source invariant (no-op handlers gone + `atexit.register` present).
- [x] Full suite: **1507 passed, 23 known-baseline failures, zero new**, 74 skipped.
- [x] Ruff: zero net-new (`sys`+`atexit` now used).
- [ ] Manual (Mac Studio): `pm2 restart open-codec` mid-recording → confirm the `sox` child + overlay are gone and the temp `.wav` is unlinked (no orphan in Activity Monitor / `/var/folders/.../T`).

## Wave 4 sequence (from triage)
C-1 (this) → H-1 lifecycle helper (other 10 daemons) → C-2 (`pwa_response.json` per-request) → C-3+C-4 atomic-write/`flock`/eviction → C-5 → H-3 audit `flock` → H-2 state lock → H-4/5/6 bounded dicts → H-7/8/9 tempfile leaks → M/L misc. Each design-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)