### PR TITLE
feat(apple): Wave 5 W5-1 — distribution decision record + signed-bundle metadata (E-4/E-5/E-16)

### DIFF
--- a/docs/APPLE-DISTRIBUTION.md
+++ b/docs/APPLE-DISTRIBUTION.md
@@ -1,0 +1,76 @@
+# CODEC — Apple Distribution Decision Record (Wave 5 / Audit E)
+
+> **Status:** W5-1 — decisions locked, foundation started. This is the authoritative
+> record of HOW the paid **Sovereign AI Workstation** Mac app ships. Every later
+> Wave-5 PR (bundle, signing, notarization, launchd migration, model packs) references
+> the decisions here. Source audit: `docs/audits/PHASE-1-APPLE-APP.md` (E-1…E-18).
+
+## 1. Locked decisions (2026-05-24)
+
+| # | Decision | Choice | Audit ref |
+|---|---|---|---|
+| D1 | **Distribution channel** | **Developer ID signed + notarized, direct download** (`.dmg`/`.pkg`). **Mac App Store ruled out** (forced — see §2). | E-4 |
+| D2 | **Apple Developer Program** | **Enrolled — Team ID + Developer ID Application cert in hand.** Signing/notarization are unblocked (no 2-4 week wait). | E-13 |
+| D3 | **Python runtime** | **Bundle `Python.framework`** (relocatable build + all pip deps in the `.app`, ~80 MB). Clean install with no Homebrew; every embedded `.so` gets signed. | E-6 |
+| D4 | **Service supervisor** | **macOS-native `launchd` LaunchAgents** (no Node/PM2 in the shipped app). The ~17 PM2 entries become per-service plists. | E-7 |
+| D5 | **OSS distribution** | **Stays unsigned** — `git clone && ./install.sh`, developer builds + trusts their own toolchain. Only the **paid** app is signed/notarized. | E-16 |
+| D6 | **Bundle identifier** | **`ai.avadigital.codec`** — matches the existing macOS Keychain service prefix `ai.avadigital.codec.*` (PR-2B/2D/2E) so TCC + Keychain identities line up. | E-1 |
+
+## 2. Why the Mac App Store is impossible (forced, not a preference) — E-4
+
+Five core capabilities are **non-sandboxable**; an App Store (sandboxed) build would gut ~80% of the value prop (Pilot, Observer OCR, Dictate, the F-key listeners, the PM2/launchd fleet, iMessage):
+
+| Capability | macOS API | Sandbox verdict |
+|---|---|---|
+| Screen recording / OCR (observer, "check my screen") | `screencapture -x` + Vision via osascript + Quartz | **No** — sandboxed apps can't capture other apps' windows |
+| Blanket AppleScript control (iMessage/Notes/Reminders/Spotify/… — 146 osascript sites) | `osascript`/NSAppleScript, per-target | **No** — App Store rejects blanket Apple-events; direct OK with per-target `NSAppleEventsUsageDescription` |
+| Hotkey listener / keystroke injection (F13/F18, F5 live-typing) | CGEvent tap (`pynput`/`pyautogui`) | **No** — requires Accessibility, not sandboxable |
+| Arbitrary subprocess spawning (launchd/python/mlx/sox/cloudflared/git — 105+ sites) | posix_spawn / fork+exec | **No** — sandbox forbids exec of binaries outside the bundle |
+| Full `~/.codec/**` + iMessage DB filesystem access | `open`/`sqlite3` over `~/Library/Messages/chat.db`, `~/.codec/memory.db`, … | **No** — outside any sandbox container; needs Full Disk Access |
+
+**Conclusion:** Developer ID + notarized direct download is the only viable path. (Network client/server, mic, clipboard, idle detection, Touch ID *are* sandbox-compatible, but the five above are not.)
+
+## 3. Signing + hardened-runtime shape (for E-2/E-3)
+
+- **Hardened runtime** is required for notarization. Because the app embeds CPython + PyObjC + native `.so`s and spawns subprocesses, it needs:
+  - `com.apple.security.cs.allow-jit` and `com.apple.security.cs.disable-library-validation` (let bundled CPython load + run the signed-but-third-party `.dylib`s from `mlx`/`numpy`/`pyobjc`).
+  - `com.apple.security.cs.allow-unsigned-executable-memory` (CPython/JIT-y extensions) — include if notarization flags it.
+- **NOT** `com.apple.security.app-sandbox` (direct distribution; see §2).
+- **Network**: `com.apple.security.network.client` + `.network.server` (dashboard :8090, MCP HTTP :8091, Cloudflare tunnel).
+- Sign order (later PR): every embedded `.so`/`.dylib` → `Python.framework` → `cloudflared` → Touch-ID helper → Swift overlay → outer `.app`, then `notarytool submit` + `stapler staple`.
+- **Models live OUTSIDE the bundle** (`~/Library/Application Support/CODEC/models/` or `~/.codec/models/`) — notarizing multi-GB binaries is impractical (E-8).
+
+## 4. The W5 bundle metadata (this PR — `packaging/macos/`)
+
+Decision-complete, no build required; consumed by the signing pipeline later:
+- **`Info.plist`** — `CFBundleIdentifier=ai.avadigital.codec`, version keys, `LSMinimumSystemVersion`, and every TCC usage string the §2 table implies (`NSMicrophoneUsageDescription`, `NSAppleEventsUsageDescription`, `NSScreenCaptureUsageDescription` (informational), `NSDesktopFolderUsageDescription`, `NSDocumentsFolderUsageDescription`, `NSDownloadsFolderUsageDescription`).
+- **`codec.entitlements`** — the hardened-runtime set in §3 (no app-sandbox).
+- **`PrivacyInfo.xcprivacy`** — Required-Reasons APIs CODEC actually hits: `NSPrivacyAccessedAPICategoryFileTimestamp` (observer recent-files mtime, scheduler) reason `C617.1`, `NSPrivacyAccessedAPICategoryDiskSpace` (heartbeat health, `df`) reason `E174.1`; `NSPrivacyTracking=false`, empty `NSPrivacyTrackingDomains`, empty `NSPrivacyCollectedDataTypes` (local-first — nothing leaves the machine).
+
+## 5. Roadmap (Audit E checklist, decisions filled in)
+
+| Step | Finding | Status |
+|---|---|---|
+| W5-Pre | E-13 Apple Developer enrollment | ✅ **done** (D2) |
+| **W5-1** | E-4 + E-16 decision docs | ✅ **this PR** (+ §4 metadata) |
+| W5-2 | E-1 + E-17 + E-5 `.app` wrapper + Info.plist/entitlements/PrivacyInfo | metadata ✅ this PR; `.app` wrapper + Python launcher next |
+| W5-3 | E-7 PM2 → **launchd** migration (17 services) | decided (D4); XL |
+| W5-4 | E-6 **bundle Python.framework** | decided (D3); XL |
+| W5-5 | E-8 model-pack downloader + bundled minimum set | **open** (recommend: bundle Whisper-turbo + Kokoro + a 7B-class 4-bit ≈ 8 GB, download larger on demand) |
+| W5-6 | E-9 first-launch permissions wizard (Swift) | pending |
+| W5-7 | E-2 code-signing pipeline | unblocked (D2) |
+| W5-8 | E-3 notarization pipeline | follows E-2 |
+| W5-9 | E-11 license validation wired in | **open** (AVA license server `ava-license.lucyvpa.com`; JWT verify + offline grace) |
+| W5-10 | E-10 Cloudflare tunnel for end-users | **open** (recommend: paid v1 LAN-only or AVA-vended tunnels — ops/cost call) |
+| W5-11 | E-15 GUI onboarding replacing `setup_codec.py` | pending |
+| W5-12 | E-14 uninstaller | pending |
+| W5-13 | E-12 Sparkle auto-update | pending (needs Sparkle EdDSA key) |
+| W5-Post | E-18 opt-in crash reporting | v1.1 |
+
+## 6. Still-open decisions (flagged for Mickael, downstream)
+- **Model strategy (E-8/W5-5):** which models bundle vs download-on-demand; storage location; resumable-download UX.
+- **License gating (E-11/W5-9):** offline grace window length; hard-cutoff UX; tier→feature map.
+- **Cloudflare for buyers (E-10/W5-10):** LAN-only v1 vs AVA-vended per-customer tunnels (recurring cost).
+- **Pricing / launch date:** business inputs that shape the license + onboarding work (not build-blocking).
+
+These don't block W5-2/3/4 (bundle + launchd + Python), which proceed on the locked decisions.

--- a/docs/audits/PHASE-1-APPLE-APP.md
+++ b/docs/audits/PHASE-1-APPLE-APP.md
@@ -92,12 +92,16 @@ The conclusion is unambiguous: there is no Apple-app distribution scaffolding in
 **Dependencies:** E-2.
 
 ### E-4 — Sandbox incompatibility blocks Mac App Store distribution [CRITICAL]
+
+> **Closed by PR-5A (W5-1).** Recorded in `docs/APPLE-DISTRIBUTION.md` §2 — the forced decision (Developer ID signed+notarized direct download; App Store ruled out) with the full capability→sandbox table. No implementation; it's the foundational architecture record the rest of Wave 5 references.
 **What's missing:** A decision/documentation acknowledging that CODEC cannot ship via the Mac App Store and the implications.
 **Why it matters:** Five core capabilities (screen recording / OCR, blanket AppleScript control, hotkey/CGEvent tap, arbitrary subprocess spawning including PM2, full filesystem access to `~/.codec/**`) are non-sandboxable. See §"CODEC system access → Apple sandbox mapping" for the entitlement-by-entitlement breakdown. Trying to ship a sandboxed build would strip CODEC of Core, Dictate, Pilot, Observer, the PM2 fleet, and iMessage — i.e. ~80% of the value prop. App Store is out.
 **Effort:** **S** (write the decision doc into `docs/`; no implementation).
 **Dependencies:** none.
 
 ### E-5 — No PrivacyInfo.xcprivacy manifest [HIGH]
+
+> **Closed by PR-5A (W5-1).** `packaging/macos/PrivacyInfo.xcprivacy` declares `NSPrivacyTracking=false`, empty tracking-domains + collected-data-types (local-first), and the two Required-Reasons APIs actually hit: `FileTimestamp` (C617.1 — observer/scheduler/heartbeat mtime) + `DiskSpace` (E174.1 — heartbeat/df). `plutil`-validated + key-asserted by `tests/test_apple_packaging.py`. (Re-audit the embedded C-extensions' API use once Python.framework is bundled in W5-4.)
 **What's missing:** No `PrivacyInfo.xcprivacy` declaring the Required Reasons APIs CODEC uses: `NSPrivacyAccessedAPICategoryFileTimestamp` (mtime checks for observer recent_files, scheduler), `NSPrivacyAccessedAPICategoryDiskSpace` (heartbeat health check, install.sh's `df -g /`), `NSPrivacyAccessedAPICategoryUserDefaults` (likely zero — Python doesn't touch NSUserDefaults directly, but embedded PyObjC frameworks might), `NSPrivacyAccessedAPICategorySystemBootTime` (uptime — none observed), `NSPrivacyAccessedAPICategoryActiveKeyboard` (likely none — `pynput` uses CGEvent tap, not the keyboard layout API). No declaration of data collection types or third-party SDKs.
 **Why it matters:** Required for any app submitted to the App Store *or* notarized through current `notarytool` versions (Apple has been tightening enforcement since 2024). Missing manifests trigger notarization warnings; in some cases, future Gatekeeper revisions can hard-block on missing manifests. Also affects the Reason codes the user sees in Privacy & Security settings.
 **Effort:** **M** (audit which APIs each embedded Python C-extension actually calls — `numpy`, `mlx`, `PyObjC`, `pynput`, `sounddevice`, `pyautogui`, `Pillow`, `requests` — write the manifest; document reason strings; test against current notarytool).
@@ -146,6 +150,8 @@ The conclusion is unambiguous: there is no Apple-app distribution scaffolding in
 **Dependencies:** E-1, E-2, E-3.
 
 ### E-13 — No Apple Developer Program enrollment evidence [CRITICAL]
+
+> **Resolved (W5-Pre, 2026-05-24).** Mickael confirmed AVA Digital LLC is **enrolled with a Team ID + Developer ID Application certificate in hand** — the 2-4 week critical path is already cleared, so the signing (E-2) + notarization (E-3) pipelines are unblocked. Provisioning the App Store Connect API key for `notarytool` + the Sparkle EdDSA key (E-12) happens in those PRs.
 **What's missing:** Any reference to a Team ID, Developer ID Application certificate, or Apple Developer Program membership in the repo or documented setup.
 **Why it matters:** Code signing, notarization, and App Store distribution all require Apple Developer Program enrollment ($99/year for individual; $299/year for organization — for AVA Digital LLC, organization enrollment likely required, which adds D-U-N-S Number verification, can take 2-4 weeks). Once enrolled: generate Developer ID Application certificate via Xcode, generate App Store Connect API key for `notarytool`, generate Sparkle EdDSA key for auto-updates. None of this exists today.
 **Effort:** **M** (enrollment paperwork + waiting period, then ~2h to provision certs).
@@ -164,6 +170,8 @@ The conclusion is unambiguous: there is no Apple-app distribution scaffolding in
 **Dependencies:** E-1, E-6, E-7, E-8, E-9.
 
 ### E-16 — OSS distribution is unsigned [MEDIUM]
+
+> **Closed by PR-5A (W5-1).** Decision recorded in `docs/APPLE-DISTRIBUTION.md` (D5): the OSS build **stays unsigned** (`git clone && ./install.sh`, developers build + trust their own toolchain) — only the **paid** app is signed + notarized. The `packaging/macos/` metadata applies to the paid build only.
 **What's missing:** A decision on whether the public GitHub `git clone` flow should produce a signed Touch-ID helper / Swift overlay / Python launcher, so users don't have to disable Gatekeeper.
 **Why it matters:** Today, `setup_codec.py:563-571` compiles `codec_auth` via `swiftc` inline (unsigned); the Swift overlay (`swift-overlay/`) has no build step in `install.sh` and isn't shipped. Users who clone the repo and run the installer end up with an unsigned helper they trust because they built it locally — that's fine. But if the OSS distribution ever ships a precompiled binary (e.g. via Homebrew tap or GitHub Releases), it needs to be signed (Developer ID), or users will hit Gatekeeper. Hybrid: keep OSS as "build from source" forever (user trusts their own `swiftc`); paid app gets signed binaries. **Recommended path: keep OSS as build-from-source; document the Gatekeeper workaround for any precompiled artifact.**
 **Effort:** **S** (write the decision doc).

--- a/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
+++ b/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
@@ -284,12 +284,12 @@ Mirror the Intake Phase 3 wave pattern. 7 waves planned; sizes are PR-counts, NO
 **Findings:** all 18 in Audit E
 **PR count estimate:** 8-12
 
-Mickael decision required first (see §5): launch date, pricing model, Apple Dev account status, bundle Python or probe, PM2 vs launchd, model distribution strategy.
+**Decisions locked 2026-05-24** (Mickael; recorded in `docs/APPLE-DISTRIBUTION.md`): Developer-ID signed+notarized direct download (App Store ruled out), **bundle Python.framework**, **launchd** (not PM2/Node), OSS stays unsigned, bundle ID `ai.avadigital.codec`, **Apple Developer enrollment DONE** (Team ID + cert in hand). Still open (downstream, non-blocking): model strategy (E-8), license gating (E-11), Cloudflare-for-buyers (E-10), pricing/launch.
 
-After decisions, the ordered checklist from Audit E:
-- W5-Pre: E-13 — start Apple Developer Program enrollment (D-U-N-S Number lookup for AVA Digital LLC, 2-4 weeks lag time) **DAY ZERO**
-- W5-1: E-4 + E-16 — decision docs (App Store is out, OSS stays unsigned)
-- W5-2: E-1 + E-17 + E-5 — `.app` bundle wrapper + Info.plist + entitlements + PrivacyInfo
+Ordered checklist from Audit E:
+- W5-Pre: E-13 — Apple Developer Program enrollment ✅ **done** (Team ID + Developer ID cert ready)
+- W5-1: E-4 + E-16 ✅ (branch `fix/pr5a-apple-foundation`) — `docs/APPLE-DISTRIBUTION.md` decision record (App Store out [forced], OSS unsigned, all 4 decisions) + the decision-complete signed-bundle metadata `packaging/macos/{Info.plist,codec.entitlements,PrivacyInfo.xcprivacy}` (E-5) with `plutil`-validated + key-asserting tests (`tests/test_apple_packaging.py`, 6).
+- W5-2: E-1 + E-17 — `.app` bundle wrapper + Python launcher (metadata already landed in W5-1)
 - W5-3: E-7 — pick PM2-vs-launchd, migrate 17 services
 - W5-4: E-6 — pick bundled-Python-vs-probe, implement (XL)
 - W5-5: E-8 — model-pack downloader + bundled minimum set (XL)

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  CODEC / Sovereign AI Workstation — Info.plist for the paid Developer ID app.
+  Bundle identity + every TCC usage string the non-sandbox capabilities imply.
+  Decisions: docs/APPLE-DISTRIBUTION.md (D1, D3, D4, D6). NOT for the OSS build (D5).
+-->
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>ai.avadigital.codec</string>
+    <key>CFBundleName</key>
+    <string>CODEC</string>
+    <key>CFBundleDisplayName</key>
+    <string>Sovereign AI Workstation</string>
+    <key>CFBundleExecutable</key>
+    <string>codec</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>2.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2026 AVA Digital LLC. All rights reserved.</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+
+    <!-- TCC usage strings — shown to the user when CODEC requests each permission.
+         See the sandbox table in docs/APPLE-DISTRIBUTION.md §2. -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>CODEC uses the microphone for voice commands, dictation, and the "Hey CODEC" wake word. Audio is transcribed locally and never leaves your Mac.</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>CODEC controls apps like Messages, Notes, Reminders, and Music on your behalf when you ask it to. You approve each app individually.</string>
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>CODEC reads what's on your screen only when you ask it to (e.g. "check my screen"). Screenshots are processed locally for text recognition and never uploaded.</string>
+    <key>NSDesktopFolderUsageDescription</key>
+    <string>CODEC reads and writes files on your Desktop when a task or skill you run needs to.</string>
+    <key>NSDocumentsFolderUsageDescription</key>
+    <string>CODEC reads and writes files in your Documents folder when a task or skill you run needs to.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>CODEC reads and writes files in your Downloads folder when a task or skill you run needs to.</string>
+</dict>
+</plist>

--- a/packaging/macos/PrivacyInfo.xcprivacy
+++ b/packaging/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Privacy manifest (E-5). CODEC is local-first: no tracking, no data collection,
+  no third-party SDKs phoning home. Declares only the Required-Reasons APIs the
+  code actually hits. See docs/APPLE-DISTRIBUTION.md §4.
+-->
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <!-- File mtime checks: observer recent-files, scheduler, heartbeat. -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <!-- Disk-space check: heartbeat health probe, install df -g. -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/packaging/macos/codec.entitlements
+++ b/packaging/macos/codec.entitlements
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened-runtime entitlements for the notarized Developer ID app.
+  Decisions: docs/APPLE-DISTRIBUTION.md §3. Deliberately NO com.apple.security.app-sandbox
+  (direct distribution; CODEC's screen-record / AppleScript / Accessibility / subprocess /
+  full-filesystem capabilities are non-sandboxable — see §2).
+-->
+<plist version="1.0">
+<dict>
+    <!-- Bundled CPython + PyObjC + native .so/.dylib (mlx, numpy, pyobjc) need to
+         load + execute code that wasn't signed by us, and use JIT-style memory. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- Dashboard (:8090), MCP HTTP (:8091), Cloudflare tunnel, outbound APIs. -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+</dict>
+</plist>

--- a/tests/test_apple_packaging.py
+++ b/tests/test_apple_packaging.py
@@ -1,0 +1,98 @@
+"""Tests for PR-5A (Wave 5 / W5-1) — the signed-bundle metadata under
+packaging/macos/ is well-formed and carries the keys the Developer ID +
+notarization path requires.
+
+These are config-asset validation/regression guards (the analog of a
+source-invariant): they pin the required Info.plist usage strings, the
+hardened-runtime entitlements (and the ABSENCE of app-sandbox), and the
+local-first privacy manifest, so a later edit can't silently drop one.
+
+Reference: docs/APPLE-DISTRIBUTION.md, docs/audits/PHASE-1-APPLE-APP.md (E-1/E-5/E-16).
+"""
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+PKG = REPO / "packaging" / "macos"
+
+
+def _load(name):
+    with open(PKG / name, "rb") as f:
+        return plistlib.load(f)
+
+
+# ── Info.plist ────────────────────────────────────────────────────────────────
+
+
+def test_info_plist_parses_and_has_identity():
+    p = _load("Info.plist")
+    assert p["CFBundleIdentifier"] == "ai.avadigital.codec", (
+        "bundle ID must match the ai.avadigital.codec.* Keychain prefix (PR-2B/2D/2E)"
+    )
+    for key in ("CFBundleName", "CFBundleExecutable", "CFBundleVersion",
+                "CFBundleShortVersionString", "LSMinimumSystemVersion"):
+        assert p.get(key), f"Info.plist missing {key}"
+
+
+def test_info_plist_has_all_tcc_usage_strings():
+    p = _load("Info.plist")
+    for key in ("NSMicrophoneUsageDescription",
+                "NSAppleEventsUsageDescription",
+                "NSScreenCaptureUsageDescription",
+                "NSDesktopFolderUsageDescription",
+                "NSDocumentsFolderUsageDescription",
+                "NSDownloadsFolderUsageDescription"):
+        val = p.get(key)
+        assert isinstance(val, str) and len(val) > 10, (
+            f"Info.plist needs a meaningful {key} (shown to the user in the TCC prompt)"
+        )
+
+
+# ── entitlements ──────────────────────────────────────────────────────────────
+
+
+def test_entitlements_hardened_runtime_and_no_sandbox():
+    e = _load("codec.entitlements")
+    for key in ("com.apple.security.cs.allow-jit",
+                "com.apple.security.cs.disable-library-validation",
+                "com.apple.security.cs.allow-unsigned-executable-memory"):
+        assert e.get(key) is True, f"hardened-runtime entitlement {key} must be true (bundled CPython/PyObjC)"
+    assert e.get("com.apple.security.network.client") is True
+    assert e.get("com.apple.security.network.server") is True
+    # Direct distribution — sandbox would break 5 core capabilities (see §2).
+    assert "com.apple.security.app-sandbox" not in e, (
+        "must NOT be sandboxed — App Store is ruled out (E-4)"
+    )
+
+
+# ── PrivacyInfo.xcprivacy ─────────────────────────────────────────────────────
+
+
+def test_privacy_manifest_is_local_first():
+    pm = _load("PrivacyInfo.xcprivacy")
+    assert pm.get("NSPrivacyTracking") is False, "CODEC does not track"
+    assert pm.get("NSPrivacyTrackingDomains") == [], "no tracking domains"
+    assert pm.get("NSPrivacyCollectedDataTypes") == [], "local-first — collects nothing"
+
+
+def test_privacy_manifest_declares_required_reasons():
+    pm = _load("PrivacyInfo.xcprivacy")
+    apis = {a["NSPrivacyAccessedAPIType"]: a.get("NSPrivacyAccessedAPITypeReasons", [])
+            for a in pm.get("NSPrivacyAccessedAPITypes", [])}
+    assert "NSPrivacyAccessedAPICategoryFileTimestamp" in apis, "observer/scheduler mtime checks"
+    assert "C617.1" in apis["NSPrivacyAccessedAPICategoryFileTimestamp"]
+    assert "NSPrivacyAccessedAPICategoryDiskSpace" in apis, "heartbeat disk-space check"
+    assert "E174.1" in apis["NSPrivacyAccessedAPICategoryDiskSpace"]
+
+
+# ── decision doc present ──────────────────────────────────────────────────────
+
+
+def test_distribution_decision_doc_exists():
+    doc = (REPO / "docs" / "APPLE-DISTRIBUTION.md")
+    assert doc.exists(), "W5-1 decision record must exist"
+    text = doc.read_text()
+    assert "Mac App Store" in text and "Developer ID" in text
+    assert "ai.avadigital.codec" in text


### PR DESCRIPTION
## Summary
**Starts Wave 5 (Apple app readiness).** After locking the 4 gating decisions, this lands the foundation: the authoritative distribution decision record + the decision-complete, `plutil`-validated signed-bundle metadata. The XL build pieces (Python.framework bundling, launchd migration, model packs, signing/notarization) are the subsequent PRs that consume this.

### Decisions locked (recorded in `docs/APPLE-DISTRIBUTION.md`)
| | Decision |
|---|---|
| Channel | Developer ID **signed + notarized, direct download** — **App Store ruled out** (forced; 5 non-sandboxable capabilities) |
| Apple Dev | **Enrolled — Team ID + cert in hand** (critical path already cleared) |
| Python | **Bundle `Python.framework`** |
| Supervisor | **launchd** (no Node/PM2 in the shipped app) |
| OSS | **stays unsigned** (clone + build); only the paid app is signed |
| Bundle ID | **`ai.avadigital.codec`** (matches the `ai.avadigital.codec.*` Keychain prefix from PR-2B/2D/2E) |

### What's in this PR
- **`docs/APPLE-DISTRIBUTION.md`** — App-Store-out rationale (capability→sandbox table), the 4 decisions, the hardened-runtime signing shape, and the full W5 roadmap with decisions filled in + downstream-open items flagged (models E-8 / license E-11 / Cloudflare E-10 / pricing).
- **`packaging/macos/Info.plist`** — bundle identity + every TCC usage string (mic, apple-events, screen-capture, desktop/documents/downloads).
- **`packaging/macos/codec.entitlements`** — hardened runtime (`allow-jit` + `disable-library-validation` + `allow-unsigned-executable-memory` for bundled CPython/PyObjC; network client+server); **no `app-sandbox`**.
- **`packaging/macos/PrivacyInfo.xcprivacy`** — local-first (no tracking/collection) + `FileTimestamp` (C617.1) + `DiskSpace` (E174.1) Required-Reasons.

## Test plan
- [x] All three plists pass **`plutil -lint`** (native macOS validation).
- [x] `tests/test_apple_packaging.py` — 6 tests: Info.plist identity + all 6 TCC usage strings; entitlements hardened-runtime keys + **absence of app-sandbox**; PrivacyInfo local-first + the two Required-Reasons; decision doc present.
- [x] Full suite: **zero new** (41 = 41 baseline; only new files added). `ruff` clean on the new test.

Closes **E-4, E-5, E-16**; **E-13** resolved (enrollment done). Audit: `docs/audits/PHASE-1-APPLE-APP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)