### PR TITLE
docs(readiness): Wave 6 PR-6F — PRIVACY.md (F-2)

### DIFF
--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,63 @@
+# CODEC — Privacy & Data Handling
+
+> **Plain-English summary:** CODEC is **local-first**. By default, everything — your voice, your screen, your files, your conversation memory — is processed **on your Mac** and never leaves it. Data only leaves your machine when *you* turn on a feature that needs the network (a cloud LLM, a messaging bridge, web search, the remote dashboard), and this document says exactly what each of those sends and to whom.
+>
+> ⚠️ **Not legal advice.** This is a good-faith engineering disclosure. Before the paid tier launches, it should be reviewed by a privacy lawyer (tracked in `docs/HANDOFF-MICKAEL.md`).
+
+---
+
+## 1. What stays on your Mac (the default)
+
+These are processed locally and never transmitted unless you explicitly route them through a cloud feature in §2:
+
+| Data | Where it's processed | Where it's stored | Retention |
+|---|---|---|---|
+| Microphone audio (voice, dictation, wake word) | local Whisper STT | not persisted (transient buffers) | discarded after transcription |
+| Screen captures / OCR ("check my screen") | local `screencapture` + Vision/Qwen-VL | temp file, deleted after OCR | per-use; nothing kept |
+| Conversation + task memory | SQLite | `~/.codec/memory.db` | until you delete; `cleanup(retention_days=90)` available |
+| Audit log (every action CODEC takes) | local | `~/.codec/audit.log` (0600, HMAC-signed, secrets redacted) | 30-day rotation |
+| Skills, plugins, agent workspaces | local | `~/.codec/` | until you delete |
+| Clipboard, recent-file metadata, idle time (observer) | local, RAM only | `collections.deque`, wiped on restart | ≤10 min ring buffer |
+
+The local LLM (Qwen via MLX), STT (Whisper), and TTS (Kokoro) all run on-device.
+
+## 2. What leaves your Mac — only when you enable it
+
+Each of these is **off by default** or requires explicit configuration. When active, here's the data flow:
+
+| Feature | What's sent | To whom | When |
+|---|---|---|---|
+| **Cloud LLM fallback** (paid tier) | your prompt + relevant context + tool outputs | Anthropic (Claude) / OpenAI (GPT) via the AVA proxy (`ava-proxy.lucyvpa.com`) | only if you select a cloud model |
+| **MCP HTTP transport** (claude.ai connector) | prompts + tool inputs/outputs for the tools claude.ai invokes | Anthropic (claude.ai) over a Cloudflare tunnel | only while you've connected claude.ai |
+| **Web search** | your search query | DuckDuckGo and/or Serper (if a Serper key is set) | per search-skill call |
+| **Google Workspace** (Docs/Sheets/Gmail/Calendar/etc.) | the content of the operation you request | Google APIs (OAuth, your own account) | per Google-skill call |
+| **iMessage / Telegram bridges** | the message you send + the reply | Apple / Telegram (your own accounts) | per outbound message |
+| **Twilio bridge** (if configured) | SMS content + recipient number | Twilio | per outbound SMS |
+| **Remote PWA / voice from phone** | dashboard traffic | your own Cloudflare tunnel (Zero Trust auth) → your Mac | only while the tunnel runs |
+| **License check** (paid tier) | license key (JWT) | AVA license server (`ava-license.lucyvpa.com`) | periodic validation |
+
+CODEC does **not** include analytics, telemetry, tracking SDKs, or ad identifiers. The macOS `PrivacyInfo.xcprivacy` manifest (`packaging/macos/`) declares `NSPrivacyTracking=false` and no collected data types.
+
+## 3. Third-party processors (when the relevant feature is used)
+
+DuckDuckGo / Serper (search) · Cloudflare (tunnel transport) · Anthropic and/or OpenAI (cloud LLM, only if configured) · Google (Workspace OAuth) · Apple (iMessage) · Telegram · Twilio (if configured) · AVA Digital LLC (license + LLM proxy for the paid tier). Each processes only the data the corresponding feature sends, per §2.
+
+## 4. GDPR (paid tier) — Art. 13 disclosures
+
+- **Controller:** AVA Digital LLC (contact: `privacy@avadigital.ai`).
+- **Categories of personal data:** account/license identifiers; any personal data *you* choose to include in prompts, messages, or files you ask CODEC to act on. CODEC does not independently collect special-category data.
+- **Legal basis:** performance of the service contract (Art. 6(1)(b)) for license + paid features; legitimate interest (Art. 6(1)(f)) for local operation; consent (Art. 6(1)(a)) for any optional cloud feature you enable.
+- **Recipients:** the processors in §3, only for the features you activate.
+- **International transfers:** cloud LLM / proxy may process data in the US (Anthropic/OpenAI) — covered by the relevant SCCs/DPA where applicable.
+- **Retention:** local data per §1 (you control deletion); license records per the AVA backend's policy.
+- **Your rights:** access, rectification, erasure, restriction, portability, and objection — exercise via `privacy@avadigital.ai`. Most local data you can also delete directly (`~/.codec/`, the dashboard's data controls).
+
+## 5. EU AI Act — Art. 50 transparency
+
+CODEC is an AI system that interacts with you directly. You are always informed you are interacting with an AI (it is the explicit purpose of the product). CODEC does not generate deep-fakes or manipulate users; agent actions that touch your files, apps, or external services are gated behind explicit consent (strict-consent for destructive operations) and recorded in the local audit log.
+
+## 6. Children
+CODEC is not directed at children under 16 and should not be used to process children's personal data.
+
+## 7. Changes
+Material changes to this policy will be noted in `CHANGELOG.md` and dated here. Last updated: 2026-05-24.

--- a/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
+++ b/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
@@ -319,7 +319,7 @@ Day 1 afternoon (~4h):
 - PR-6E: F-9 — rewrite top of README to lead with value prop
 
 Day 2 morning (~4h):
-- PR-6F: F-2 — PRIVACY.md with EU/AI Act statement
+- PR-6F: F-2 ✅ (branch `fix/pr6f-privacy`). `docs/PRIVACY.md` — local-first default + "what leaves your Mac" data-flow table (cloud LLM / MCP-HTTP / search / Google / iMessage / Telegram / Twilio / Cloudflare / license) + third-party processors + GDPR Art. 13 + AI Act Art. 50 + `privacy@avadigital.ai`. 2 tests (`tests/test_privacy_doc.py`); full suite zero new; ruff clean. Handoff: lawyer review + README link (README-overhaul PR). **Both Audit-F CRITICALs (F-1, F-2) closed.**
 - PR-6G: F-10 — add "Why CODEC, not X" comparison block
 
 Day 2 afternoon (~3h):

--- a/docs/audits/PHASE-1-INVESTOR-READINESS.md
+++ b/docs/audits/PHASE-1-INVESTOR-READINESS.md
@@ -53,6 +53,7 @@ Reviewed in this order:
 
 ### F-2 — No public-facing privacy / data-handling statement [CRITICAL]
 
+> **Closed by PR-6F.** `docs/PRIVACY.md` covers: the local-first default (what stays on the Mac + retention), an explicit "what leaves your Mac — only when you enable it" data-flow table (cloud LLM via AVA proxy, MCP HTTP/claude.ai, DuckDuckGo/Serper, Google OAuth, iMessage/Telegram/Twilio, Cloudflare tunnel, license check), a third-party-processor list, GDPR Art. 13 disclosures for the paid tier (controller, legal basis, recipients, transfers, retention, rights), and an EU AI Act Art. 50 transparency statement. 2 tests (`tests/test_privacy_doc.py`). **Handoff:** privacy-lawyer review + confirm `privacy@avadigital.ai` before paid launch (`docs/HANDOFF-MICKAEL.md`); link from README in the README-overhaul PR.
 **What's missing:** No `PRIVACY.md`, no privacy page at opencodec.org referenced in README, no AI Act / GDPR alignment note. README §"Privacy & Security" lists 6 technical layers but does not answer the EU enterprise question: *"what categories of personal data are processed, on what legal basis, with what retention?"*.
 
 **Why investors / enterprise customers expect it:**

--- a/tests/test_privacy_doc.py
+++ b/tests/test_privacy_doc.py
@@ -1,0 +1,29 @@
+"""Tests for PR-6F (Audit F / F-2) — PRIVACY.md exists and answers the EU
+enterprise questions (what data, legal basis, retention) + discloses the
+data flows that leave the machine. Regression guard for the privacy statement.
+
+Reference: docs/audits/PHASE-1-INVESTOR-READINESS.md F-2.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_privacy_doc_present_and_complete():
+    f = REPO / "docs" / "PRIVACY.md"
+    assert f.exists(), "F-2: docs/PRIVACY.md must exist"
+    t = f.read_text()
+    assert "local-first" in t.lower(), "must state the local-first default"
+    assert "GDPR" in t, "must cover GDPR (paid tier, EU market)"
+    assert "AI Act" in t, "must cover the EU AI Act transparency obligation"
+    assert "privacy@avadigital.ai" in t, "must give a data-subject contact"
+
+
+def test_privacy_doc_discloses_cloud_flows():
+    t = (REPO / "docs" / "PRIVACY.md").read_text()
+    # The data flows that actually leave the machine must be named.
+    for processor in ("Anthropic", "Cloudflare", "Google", "Telegram"):
+        assert processor in t, f"PRIVACY.md must disclose the {processor} data flow"
+    assert "leaves your Mac" in t, "must have an explicit 'what leaves the machine' section"


### PR DESCRIPTION
## Summary
Closes **Audit-F finding F-2** (the second Audit-F CRITICAL): the repo had no privacy / data-handling disclosure, a blocker for the paid tier and the EU market.

Adds **`docs/PRIVACY.md`** — a plain-English, good-faith engineering disclosure:
- **Local-first default** + an explicit *"what leaves your Mac"* data-flow table naming every processor and exactly what each feature sends (cloud LLM via the AVA proxy, MCP HTTP/claude.ai over the Cloudflare tunnel, web search, Google Workspace OAuth, iMessage/Telegram/Twilio bridges, remote PWA tunnel, license check).
- Third-party processor list, **GDPR Art. 13** disclosures (controller, legal basis, retention, data-subject rights, `privacy@avadigital.ai`), **EU AI Act Art. 50** transparency, children, change policy.
- States it is **not legal advice** and flags lawyer review before the paid launch (tracked in `docs/HANDOFF-MICKAEL.md`).

## Test plan
- [x] `tests/test_privacy_doc.py` (2 new) — presence + completeness (local-first / GDPR / AI Act / contact) + cloud-flow disclosure (Anthropic / Cloudflare / Google / Telegram + "leaves your Mac").
- [x] `ruff check` clean on the new test.
- [x] Full suite: **41 baseline failures unchanged, zero new** (1565 passed).
- [x] Docs-only + test-only change — no runtime/daemon code touched.

> Merge order note: branched off `origin/main` (#91). Stacks cleanly behind the still-open #92 (Wave 5 W5-1) and #93 (PR-6A) — audit-doc edits are per-finding closed-notes that auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)