### PR TITLE
docs(readiness): Wave 6 PR-6G — README investor overhaul (F-3/9/10/14/17/18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -821,7 +821,7 @@ No agent task chains more than 8 steps without breaking. Hardcoded in `Crew.max_
 - New crews go in their own commit and update `CREW_REGISTRY` and §3
 
 ### Testing
-- `pytest` from repo root. **600+ tests collected** (live count via `pytest --collect-only`); all must pass before merge except known pre-existing failures documented in `docs/known-issues.md`
+- `pytest` from repo root. **1,300+ tests collected** (live count via `pytest --collect-only` — currently 1,685 collected / 1,386 `def test_` functions across 99 files); all must pass before merge except known pre-existing failures documented in `docs/known-issues.md`
 - Skill changes: add a smoke test that imports and calls `run("test")` with empty args
 - Audit-log changes: add a parser round-trip test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,8 @@ codec_textassist.py   — Right-click text services
 codec_search.py       — Web search (DuckDuckGo/Serper)
 codec_mcp.py          — MCP server for external tools
 codec_heartbeat.py    — System health monitoring
-skills/               — 50+ skill plugins
-tests/                — 168+ pytest tests
+skills/               — 76 skill plugins
+tests/                — 1,300+ pytest tests (1,386 functions across 99 files)
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -10,10 +10,17 @@
 </p>
 
 <p align="center">
+  <strong>CODEC turns a Mac into a voice-controlled AI workstation that runs 100% on your machine.</strong><br/>
+  Speak. See the screen. Click anywhere by voice. Run agent crews. Plug into Claude, Cursor, or VS&nbsp;Code as an MCP server — and let them drive your Mac back.<br/>
+  <em>Open source · MIT · no cloud required.</em>
+</p>
+
+<p align="center">
+  <a href="https://github.com/AVADSA25/codec/actions/workflows/ci.yml"><img src="https://github.com/AVADSA25/codec/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
   <a href="FEATURES.md"><img src="https://img.shields.io/badge/features-400+-blue?style=flat-square" alt="400+ Features"/></a>
-  <img src="https://img.shields.io/badge/skills-75-orange?style=flat-square" alt="75 Skills"/>
-  <img src="https://img.shields.io/badge/tests-940+-green?style=flat-square" alt="940+ Tests"/>
-  <img src="https://img.shields.io/badge/lines-58K+-purple?style=flat-square" alt="58K+ Lines"/>
+  <img src="https://img.shields.io/badge/skills-76-orange?style=flat-square" alt="76 Skills"/>
+  <img src="https://img.shields.io/badge/tests-1300+-green?style=flat-square" alt="1,300+ Tests"/>
+  <img src="https://img.shields.io/badge/lines-67K+-purple?style=flat-square" alt="67K+ Lines"/>
   <img src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square" alt="MIT License"/>
   <img src="https://img.shields.io/badge/engine-CODEC%20v2.3-E8711A?style=flat-square" alt="Engine: CODEC v2.3"/>
 </p>
@@ -39,6 +46,18 @@ It listens, sees the screen, speaks back, controls apps, writes code, drafts mes
 No cloud dependency. No data leaving the machine unless you choose. No subscription on the open-source build. MIT licensed.
 
 > **Sovereign AI Workstation** is the product brand. **CODEC** (v2.3) is the open-source engine that powers it — the codename you'll see in code paths, skill registries, the `codec_*` PM2 services, and the `~/.codec/` config directory. *Sovereign AI Workstation* is what you ship; *CODEC* is what you ship with. Same way iPhone runs on Darwin, or Tesla Model S runs on Roadster components — one is the product, the other is the engine.
+
+---
+
+## Why CODEC, not the alternatives
+
+CODEC's moat is the *combination* — local-first **and** voice **and** MCP-as-a-server **and** self-writing skills **and** a zero-dependency agent runtime. No single competitor has all five.
+
+- **Open Interpreter / Aider write code in a terminal. CODEC controls the whole Mac by voice** — including your IDE, your browser, your apps. The terminal is one surface; CODEC drives all of them.
+- **Cursor and Claude Desktop talk to LLMs. CODEC turns your Mac into a tool the LLM can use** — over MCP. Claude (or Cursor, or VS Code) gets your screen, your apps, your 76 skills, and your memory. CODEC is both an MCP *client* and an MCP *server*, so two CODECs can even peer — agent-to-agent — on the open protocol Anthropic standardized.
+- **CrewAI / LangChain orchestrate. CODEC orchestrates _and_ executes on your hardware** — with a ~795-line multi-agent runtime that has zero dependency on either framework.
+
+And all of it runs on *your* machine: no data leaves unless you explicitly route a request through a cloud model.
 
 ---
 
@@ -337,6 +356,30 @@ Three smart agents ship built-in: Daily Briefing, Restaurant Decider (location-a
 
 ---
 
+## Architecture
+
+CODEC is **not a monolith.** It runs as a swarm of small Python processes supervised by PM2 — each with one responsibility, each killable without breaking the others. Services coordinate through atomic JSON writes (`~/.codec/*.json`) and localhost HTTP, never a shared in-memory bus.
+
+```mermaid
+graph LR
+    U["You<br/>voice · hotkeys · PWA · iMessage/Telegram"] --> V["open-codec<br/>wake-word · vision · dispatch"]
+    U --> D["codec-dashboard<br/>FastAPI :8090 · chat/audit/UI"]
+    C["Claude · Cursor · VS Code"] -->|MCP + OAuth 2.1| M["codec-mcp-http<br/>:8091"]
+    V --> CORE["Engine<br/>skills · agents · memory · hooks · audit"]
+    D --> CORE
+    M --> CORE
+    OBS["codec-observer · autopilot<br/>agent-runner · heartbeat"] --> CORE
+    CORE --> S[("~/.codec/<br/>SQLite · audit.log · agent state")]
+```
+
+- **Inbound stays private** — the only inbound surface is the PWA over a Cloudflare Zero Trust tunnel (or Tailscale). Outbound bridges (Gmail, iMessage, Telegram) are user-owned.
+- **Every privileged action is gated and audited** — file/process/network access goes through a sandbox + consent gate and lands in an HMAC-signed `~/.codec/audit.log`.
+- **The LLM is swappable** — local Qwen by default; any OpenAI-compatible endpoint (or the paid cloud tier) drops in without touching the skill catalog.
+
+Full runtime topology, process table, and data-flow diagrams: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
+
+---
+
 ## Quick Start
 
 ```bash
@@ -440,11 +483,15 @@ Claude Desktop/Code/Cursor gain — through this one MCP bridge — everything C
 
 - **Your Mac, your apps** — native macOS control: mouse/keyboard via vision model, screenshot text extraction, app switching, clipboard, brightness/volume, Philips Hue, Spotify, Apple Notes, Reminders, Clock timers, music. No browser sandbox.
 - **Your memory** — FTS5-searchable history of every CODEC conversation. Claude can recall what *you* said weeks ago, not just this chat.
-- **Your skills, not Anthropic's** — 75 pluggable CODEC skills instantly callable as tools. Write one locally in Python, it shows up in Claude without a deploy.
+- **Your skills, not Anthropic's** — 76 pluggable CODEC skills instantly callable as tools. Write one locally in Python, it shows up in Claude without a deploy.
 - **Your LLM, your choice** — same skill catalog works whether the brain is local Qwen (offline, private) or cloud Claude. The toolkit outlives the model.
 - **Your voice pipeline** — Whisper STT, Kokoro TTS, wake-word — all reachable from the chat loop if you want voice output of a Claude answer.
 
 One install. Claude stops being a chat window and becomes a driver for the machine it's running on.
+
+### Bidirectional MCP — agent-to-agent on the open protocol
+
+CODEC is **both an MCP client and an MCP server.** As a *client* it consumes tools from any MCP host; as an MCP server it exposes its 76 skills, searchable memory, and voice pipeline to any MCP client — Claude, Cursor, VS&nbsp;Code, or **another CODEC.** Point two Macs at each other and they peer directly: **agent-to-agent** collaboration over the same protocol Anthropic standardized — no middleman cloud, each side keeping its own data local.
 
 ---
 
@@ -649,8 +696,8 @@ codec_marketplace.py  — Skill marketplace CLI
 codec_overlays.py     — AppKit overlay notifications (fullscreen compatible)
 ax_bridge/            — Swift AX accessibility bridge
 swift-overlay/        — Native macOS status bar app (NSPanel, event JSONL poller)
-skills/               — 75 built-in skills (incl. vision mouse control)
-tests/                — 940+ pytest tests across 53 files
+skills/               — 76 built-in skills (incl. vision mouse control)
+tests/                — 1,386 test functions across 99 files (1,685 collected via pytest --collect-only)
 request_mic.py        — macOS microphone permission helper (AVFoundation)
 install.sh            — One-line installer
 setup_codec.py        — Setup wizard (9 steps)
@@ -737,7 +784,7 @@ python3 setup_codec.py
 
 ## Contributing
 
-All skill contributions welcome. 75 built-in skills, 940+ tests, marketplace growing.
+All skill contributions welcome. 76 built-in skills, 1,300+ tests, marketplace growing.
 
 ```bash
 git clone https://github.com/AVADSA25/codec.git
@@ -756,6 +803,8 @@ If CODEC saves you time:
 - **Star** this repo
 - **[Donate via PayPal](https://paypal.me/avadsa25)** — ava.dsa25@proton.me
 - **Enterprise setup:** [avadigital.ai](https://avadigital.ai)
+
+**Paid Mac app — coming soon.** A signed, notarized, one-click install with managed setup and an optional cloud-LLM tier, for people who'd rather not assemble the local stack by hand. The open-source build stays free and MIT, forever. [Join the waitlist → avadigital.ai](https://avadigital.ai)
 
 ---
 

--- a/docs/PR6G-README-OVERHAUL-DESIGN.md
+++ b/docs/PR6G-README-OVERHAUL-DESIGN.md
@@ -1,0 +1,58 @@
+# PR-6G — README investor overhaul (design note)
+
+> Wave 6 (Audit F / Investor Readiness). Docs-only. Closes **F-3, F-9, F-10,
+> F-14, F-17, F-18**. Reference: `docs/audits/PHASE-1-INVESTOR-READINESS.md`.
+
+## What
+
+Rework the public README so a stranger from Hacker News understands what CODEC
+does in 30 seconds, the moat lands in the first screen, and every metric claim
+is truthful and internally consistent. Three files change: `README.md`,
+`CONTRIBUTING.md`, `AGENTS.md` (CLAUDE.md is a symlink → AGENTS.md, so one edit
+covers both).
+
+## Why (findings closed)
+
+| Finding | Sev | Fix in this PR |
+|---|---|---|
+| **F-3** | CRITICAL | Stop overstating. Replace static `tests-940+` with a **live GitHub Actions CI badge** + a conservative round-down count badge. Reconcile counts. |
+| **F-9** | HIGH | Lead with a one-sentence value prop above the fold (before "What This Is"). |
+| **F-10** | HIGH | Add a **"Why CODEC, not the alternatives"** section with the 3 moat bullets (vs Open Interpreter/Aider, vs Cursor/Claude desktop, vs CrewAI/LangChain). |
+| **F-14** | MEDIUM | Add a top-level **"## Architecture"** section: condensed topology + link to `docs/ARCHITECTURE.md`. |
+| **F-17** | LOW | One test number everywhere (README badge + body + CONTRIBUTING + AGENTS). |
+| **F-18** | LOW | State the **bidirectional MCP** story in the MCP section (CODEC is client AND server; two CODECs peer = agent-to-agent). |
+
+## Count reconciliation (the F-3 / F-17 core)
+
+Measured in this repo on 2026-05-24:
+
+| Metric | Old claim(s) | Measured | New claim |
+|---|---|---|---|
+| Tests | `940+` (badge + body), `600+` (AGENTS), `168+` (CONTRIBUTING) | `def test_` = **1,386** funcs / 99 files; `pytest --collect-only` = **1,685** collected | **`1,300+`** (rounds *down* from the function-count floor → unimpeachable by either measure) + live CI badge |
+| Skills | `75` | `76` modules with `SKILL_NAME` (excl. `_template`) | **`76`** |
+| Lines | `58K+` | **67,404** Python LOC | **`67K+`** |
+
+**Why 1,300+ and not 1,600+:** F-3 is CRITICAL specifically about *overstating*.
+The conservative round-down of the lowest defensible interpretation (`def test_`
+= 1,386 → 1,300+) cannot be called an overstatement by anyone running either
+`grep -rc 'def test_' tests/` (1,386) **or** `pytest --collect-only` (1,685).
+The exact numbers go in the body for full transparency.
+
+## Out of scope (flagged to HANDOFF-MICKAEL.md, need Mickael)
+
+- **F-8** demo GIF in first viewport — needs a screen recording.
+- **F-11** pricing/paid-tier shape — only a soft "waitlist" line added; tier + price band need Mickael's decision.
+- **F-12** Discord / GitHub Discussions — needs Mickael to create the surfaces.
+- **F-18 (Lucy)** — the README states the generic bidirectional-MCP/agent-to-agent story; whether "Lucy" is a separate brand to name is a Mickael call.
+
+## Test plan
+
+`tests/test_readme_investor.py` (regression guard):
+- No stale `940+` in README; no `168+` in CONTRIBUTING; no `600+ tests` in AGENTS.
+- One reconciled test number (`1,300+`) reachable in README + CONTRIBUTING + AGENTS.
+- Skills claim is `76`, not `75 built-in skills` / `skills-75`.
+- Value-prop sentence near the top; `## Why CODEC` section; `## Architecture` section linking `docs/ARCHITECTURE.md`; MCP section names both client AND server.
+
+## Rollback
+
+Pure docs. `git revert` the single commit; no runtime, schema, or daemon impact.

--- a/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
+++ b/docs/audits/PHASE-1-CONSOLIDATED-TRIAGE.md
@@ -338,6 +338,11 @@ Deferred:
 
 **Rationale:** Audit F's own findings have a clean burn-down plan. Day 1 hits 7/10; Day 2 hits 8.5/10.
 
+**Actually shipped (clustered for fewer PRs / fewer doc conflicts):**
+- **PR-6A** (#93) — F-1 SECURITY.md + F-6 CODE_OF_CONDUCT.md + F-7 FUNDING.yml + F-16 garbage delete.
+- **PR-6F** (#94) — F-2 PRIVACY.md.
+- **PR-6G** — F-3 + F-17 (count reconciliation + live CI badge) **+** F-9 (value prop) + F-10 (Why-CODEC) + F-14 (Architecture section) + F-18 (bidirectional MCP). Bundled because all six touch README; doing it once means README is edited a single time. F-11 partially addressed (soft waitlist line; tier/price → Mickael). F-8 (demo GIF), F-12 (Discord/Discussions), F-18-Lucy-naming → HANDOFF-MICKAEL.md. Remaining Wave-6: F-13 ONE-PAGER, F-5 release tags, F-4 CI expansion, F-15 pyproject (deferred).
+
 ### Wave 7 — Projects + Pilot (Audit B) (target: TBD)
 **Findings:** TBD pending Mickael's description.
 **Placeholder:** see §6 below.

--- a/docs/audits/PHASE-1-INVESTOR-READINESS.md
+++ b/docs/audits/PHASE-1-INVESTOR-READINESS.md
@@ -67,6 +67,8 @@ Reviewed in this order:
 
 ### F-3 — README badges overstate verified state ("940+ tests", "400+ features") [CRITICAL for investor trust]
 
+> **✅ CLOSED by PR-6G (2026-05-24).** Static `tests-940+` pill replaced with a **live GitHub Actions CI badge** + a conservative `tests-1300+` count — rounds *down* from the 1,386 `def test_` floor (1,685 collected via `pytest --collect-only`), so it can't be called an overstatement by either measure. Counts reconciled across README + CONTRIBUTING + AGENTS; `skills` 75→76, `lines` 58K→67K. Guarded by `tests/test_readme_investor.py`. (Expanding CI to run the full suite = F-4, separate. The `features-400+` badge links to FEATURES.md and was left as-is.)
+
 **What's missing:** Truthful representation of automated test coverage. README line 15 displays `tests-940+` badge. Verified count: **873 `def test_` functions in 54 test files** (`grep -rE "^def test_|^    def test_" tests/test_*.py | wc -l`). The CI workflow at `.github/workflows/ci.yml` only runs **four** of those files: `test_skill_imports.py`, `test_skill_contracts.py`, `test_oauth_provider.py`, `test_retry.py`. The remaining 50 test files are NOT run in CI.
 
 CLAUDE.md §9 *Testing* claims "600+ tests collected" — actual count 873 (more, not fewer). CONTRIBUTING.md line 75 says "168+ pytest tests" (stale from an earlier release). Three different numbers (168, 600, 940) exist in-repo describing the same artifact.
@@ -189,6 +191,8 @@ The "9 Products" section is dense walls of text. A 30-second-attention-span YC p
 
 ### F-9 — Top-of-README value prop is not stranger-readable in 30 seconds [HIGH]
 
+> **✅ CLOSED by PR-6G (2026-05-24).** README now leads with a one-sentence value prop ("CODEC turns a Mac into a voice-controlled AI workstation that runs 100% on your machine…") above the badges, before "What This Is". (Demo GIF in the first viewport = F-8, handoff to Mickael.)
+
 **What's missing:** Top of README is identity-and-credentials heavy:
 - 2 logos / titles / taglines (lines 1-9)
 - 6 badges (line 12-19)
@@ -213,6 +217,8 @@ Then GIF. Then 3 bullet points (the unique angles). Then the rest.
 ---
 
 ### F-10 — Unique angles per Mickael's brief are present but underweighted [HIGH]
+
+> **✅ CLOSED by PR-6G (2026-05-24).** New "## Why CODEC, not the alternatives" section near the top with the three moat bullets (vs Open Interpreter/Aider, vs Cursor/Claude Desktop via MCP-as-server, vs CrewAI/LangChain via the zero-dep runtime) + the five-way combination framing.
 
 **What's missing:** The four positioning angles from the brief are *in* the README but not prominent:
 
@@ -299,6 +305,8 @@ Also add `docs/VISION.md` (3 pages) for the longer narrative.
 
 ### F-14 — Architecture diagram exists but is buried [MEDIUM]
 
+> **✅ CLOSED by PR-6G (2026-05-24).** New top-level "## Architecture" section (right before Quick Start): condensed mermaid topology + 3 topology bullets (inbound-private, gated+audited, swappable LLM) + a direct link to `docs/ARCHITECTURE.md`.
+
 **What's missing:** `docs/ARCHITECTURE.md` *exists* (and is well-written, mermaid diagram, ~40 lines reviewed). README does NOT link to it from the body — only an indirect path through the "Project Structure" block at line 614+.
 
 **Why investors / enterprise customers expect it:**
@@ -352,6 +360,8 @@ authlib google-auth-httplib2 --break-system-packages
 
 ### F-17 — README + CONTRIBUTING.md test counts disagree (3 different numbers in repo) [LOW]
 
+> **✅ CLOSED by PR-6G (2026-05-24).** One number (`1,300+`) across the README badge+body, CONTRIBUTING.md and AGENTS.md; the exact `1,386` functions / `1,685` collected appear in the bodies for transparency. Skills reconciled to 76 in the same files. (Same PR as F-3.)
+
 **What's missing:** Three test-count claims live in the repo:
 - README badge: `tests-940+`
 - README line 653: `940+ pytest tests across 53 files`
@@ -369,6 +379,8 @@ Verified count: 873 test functions across 54 files (`grep` of `def test_` in `te
 ---
 
 ### F-18 — No README mention of "agent-to-agent like Lucy" (Mickael's headline angle) [LOW]
+
+> **🟡 PARTIALLY CLOSED by PR-6G (2026-05-24).** MCP section now has a "Bidirectional MCP — agent-to-agent" subsection: CODEC is **both an MCP client AND server**, two CODECs peer directly = agent-to-agent on the open protocol. The generic angle is stated. **Open for Mickael:** whether "Lucy" is a separate brand to *name* in the README (tracked in `docs/HANDOFF-MICKAEL.md`).
 
 **What's missing:** Per the audit brief, one of Mickael's headline unique angles is *"Talk to other agents like Lucy"* — i.e. multi-agent agent-to-agent collaboration via MCP. README's MCP section frames the bridge as CODEC → Claude (Claude consumes CODEC tools), not CODEC → other-agent (CODEC peers with Lucy or another MCP-speaking agent).
 

--- a/tests/test_readme_investor.py
+++ b/tests/test_readme_investor.py
@@ -1,0 +1,90 @@
+"""Tests for PR-6G (Audit F: F-3/F-9/F-10/F-14/F-17/F-18) — the README investor
+overhaul. Regression guard that the public README leads with a value prop, sells
+the moat, surfaces architecture, frames MCP bidirectionally, and that every
+test/skill/line metric is truthful + internally consistent across README,
+CONTRIBUTING.md and AGENTS.md.
+
+Reference: docs/audits/PHASE-1-INVESTOR-READINESS.md.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _read(name: str) -> str:
+    return (REPO / name).read_text()
+
+
+# ---- F-3 / F-17: counts are reconciled and not overstated ------------------
+
+def test_no_stale_test_counts_anywhere():
+    readme = _read("README.md")
+    contributing = _read("CONTRIBUTING.md")
+    agents = _read("AGENTS.md")
+    # The three contradictory historical numbers must all be gone.
+    assert "940+" not in readme, "F-3: stale '940+' must be removed from README"
+    assert "168+" not in contributing, "F-17: stale '168+' must be gone from CONTRIBUTING"
+    assert "600+ tests" not in agents, "F-17: stale '600+ tests' must be gone from AGENTS.md"
+
+
+def test_single_reconciled_test_number_present():
+    # One conservative, defensible number in all three doc surfaces.
+    for name in ("README.md", "CONTRIBUTING.md", "AGENTS.md"):
+        t = _read(name)
+        assert ("1,300+" in t) or ("1300+" in t), f"F-17: reconciled test count missing from {name}"
+
+
+def test_live_ci_badge_present():
+    readme = _read("README.md")
+    # F-3: a real workflow-status badge, not a hand-typed green pill.
+    assert "actions/workflows/ci.yml/badge.svg" in readme, "F-3: live CI status badge required"
+
+
+def test_skill_count_is_76_not_75():
+    readme = _read("README.md")
+    assert "75 built-in skills" not in readme, "F-3: skills overstated/stale (75) — repo has 76"
+    assert "badge/skills-75" not in readme, "F-3: skills badge must read 76"
+    assert "76" in readme, "skill count (76) must appear"
+
+
+# ---- F-9: stranger-readable value prop above the fold ---------------------
+
+def test_value_prop_leads_near_top():
+    lines = _read("README.md").splitlines()
+    head = "\n".join(lines[:30]).lower()
+    assert "voice-controlled ai workstation" in head, "F-9: one-line value prop must lead the README"
+    # And it must sit before the dense 'What This Is' prose.
+    body = _read("README.md")
+    assert body.lower().index("voice-controlled ai workstation") < body.index("## What This Is")
+
+
+# ---- F-10: the moat / why-not-X section -----------------------------------
+
+def test_why_codec_section_exists():
+    readme = _read("README.md")
+    assert "## Why CODEC" in readme, "F-10: a 'Why CODEC, not X' positioning section is required"
+    # The three named comparators from the audit recommendation.
+    low = readme.lower()
+    assert "open interpreter" in low or "aider" in low, "F-10: must contrast with terminal coding agents"
+    assert "crewai" in low and "langchain" in low, "F-10: must contrast with orchestration frameworks"
+
+
+# ---- F-14: architecture surfaced, not buried ------------------------------
+
+def test_architecture_section_and_link():
+    readme = _read("README.md")
+    assert "## Architecture" in readme, "F-14: a top-level Architecture section is required"
+    assert "docs/ARCHITECTURE.md" in readme, "F-14: must link the full architecture doc"
+
+
+# ---- F-18: bidirectional MCP / agent-to-agent -----------------------------
+
+def test_mcp_section_is_bidirectional():
+    readme = _read("README.md")
+    # Section must frame CODEC as BOTH client and server (peer/agent-to-agent).
+    assert "MCP client" in readme and "MCP server" in readme, (
+        "F-18: MCP section must state CODEC is both an MCP client AND server"
+    )
+    assert "agent-to-agent" in readme.lower(), "F-18: agent-to-agent peering angle must be stated"


### PR DESCRIPTION
## Summary
Bundles **every Audit-F finding that touches README** into one PR so the public README is edited a single time (no later header conflicts). Docs-only.

| Finding | Sev | Fix |
|---|---|---|
| **F-3** | CRITICAL | Stop overstating. Static `tests-940+` pill → **live GitHub Actions CI badge** + conservative `tests-1300+` (rounds *down* from the 1,386 `def test_` floor; 1,685 collected — can't be called an overstatement by either measure). Skills 75→76, lines 58K→67K. |
| **F-17** | LOW | One test number across README + CONTRIBUTING + AGENTS; exact `1,386`/`1,685` in bodies. |
| **F-9** | HIGH | README leads with a one-sentence value prop above the fold. |
| **F-10** | HIGH | New **"Why CODEC, not the alternatives"** section (vs Open Interpreter/Aider, vs Cursor/Claude Desktop via MCP-as-server, vs CrewAI/LangChain via the zero-dep runtime). |
| **F-14** | MEDIUM | New top-level **"Architecture"** section — condensed mermaid topology + link to `docs/ARCHITECTURE.md`. |
| **F-18** | LOW (partial) | MCP section now states CODEC is both an MCP **client AND server**; two CODECs peer = **agent-to-agent**. |
| **F-11** | MEDIUM (partial) | Soft paid-app waitlist line (commercial-intent signal; tier/price → Mickael). |

## Test plan
- [x] `tests/test_readme_investor.py` (8 new) — no stale `940+`/`168+`/`600+ tests`; one reconciled count; live CI badge; skills=76; value-prop near top; Why-CODEC section; Architecture section + link; bidirectional MCP.
- [x] `ruff check` clean.
- [x] Full suite: **41 baseline failures unchanged, zero new** (1,571 passed incl. the 8 new tests).
- [x] Docs-only — no runtime/daemon code touched.

## Handoff (flagged for Mickael, in HANDOFF-MICKAEL.md once #93 lands)
- **F-8** — record a ≤2 MB demo GIF for the first viewport.
- **F-11** — decide paid-tier shape + price band (only a waitlist line added here).
- **F-12** — create Discord + enable GitHub Discussions.
- **F-18** — decide whether to *name* "Lucy" as a brand in the README.

> Branched off `origin/main` (#91). Stacks cleanly behind open #92 (W5-1), #93 (PR-6A), #94 (PR-6F) — README is untouched by those, and the shared audit-doc edits are per-finding closed-notes that auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)