### PR TITLE
ci(readiness): Wave 6 PR-6I — expand CI coverage + Dependabot (F-4 partial)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Dependabot — automated dependency + GitHub Actions updates (Audit F / F-4).
+# Conservative cadence so it stays signal, not noise: weekly, grouped minor/patch,
+# capped open PRs. Enterprise security DD checks for this file's presence.
+version: 2
+updates:
+  # Python dependencies (requirements.txt at repo root)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "python"]
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions used by the CI workflow(s)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "ci"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,12 @@ jobs:
         run: python -m pytest tests/test_oauth_provider.py -v
       - name: Retry helper unit test
         run: python -m pytest tests/test_retry.py -v
+      - name: Readiness doc-guard tests (F-4 coverage expansion)
+        run: >
+          python -m pytest -v
+          tests/test_repo_health.py
+          tests/test_privacy_doc.py
+          tests/test_readme_investor.py
+          tests/test_one_pager.py
+          tests/test_apple_packaging.py
+          tests/test_dependabot.py

--- a/docs/HANDOFF-MICKAEL.md
+++ b/docs/HANDOFF-MICKAEL.md
@@ -6,26 +6,16 @@
 
 ---
 
-## 0. Right now — merge the open PR queue 🔴
+## 0. PR queue status ✅ (clear)
 
-I work on isolated branches and never self-merge. **Review + merge these in order** (each is design-first → TDD → CI-green; squash-merge is fine):
+All Wave-4/5/6 PRs through **#96 are merged**. Nothing blocking right now.
 
-| PR | Title | Wave |
-|---|---|---|
-| #82 | C-2 PWA response bridge | 4 |
-| #83 | C-5 `_atomic_set_status` | 4 |
-| #84 | H-1 lifecycle helper | 4 |
-| #85 | H-3 audit flock | 4 |
-| #86 | H-4/H-6/M-6 bounded dicts | 4 |
-| #87 | H-7/H-8/H-9 tempfile leaks | 4 |
-| #88 | M-3/M-4/L-1/L-2 small fixes | 4 |
-| #89 | H-5 rate-window eviction | 4 |
-| #90 | H-2 codec.py state lock | 4 |
-| #91 | M-5 per-thread DB | 4 ✅ (merged) |
-| #92 | W5-1 Apple distribution foundation | 5 |
-| #93+ | Wave-6 readiness PRs | 6 |
+- **Wave 4 (Reliability):** #82–#91 ✅ merged (all 5 CRITICAL + 9 HIGH + 6 MEDIUM + 2 LOW).
+- **Wave 5:** #92 (W5-1 Apple distribution foundation) ✅ merged.
+- **Wave 6:** #93 (SECURITY/COC/FUNDING + this tracker), #94 (PRIVACY.md), #95 (README investor overhaul), #96 (ONE-PAGER) ✅ merged.
+- **In flight:** **PR-6I** — expand CI test coverage + add Dependabot (F-4). Review + merge when its CI is green.
 
-*(Once merged, my later branches that built on origin/main pick them up automatically.)*
+I work on isolated branches and never self-merge; each new branch builds on the latest `main`.
 
 ---
 
@@ -64,7 +54,11 @@ I'm writing the docs; a few items need your accounts/assets:
 - 🟠 **Record a ~20-second demo GIF** (F-8) for the top of the README — a real screen-capture of voice→action is something only you can shoot on your machine. I'll wire it into the README once you drop the file in `docs/assets/`.
 - 🟠 **Create a Discord server + enable GitHub Discussions** (F-12). Give me the invite link and I'll add the badge/links to the README.
 - ⚪ **GitHub Sponsors** (F-7) — `.github/FUNDING.yml` is in place pointing at your PayPal + site; optionally enroll the org in GitHub Sponsors to light up the "Sponsor" button.
-- 🟡 **Lucy / agent-to-agent positioning (F-18)** — your brand call on how prominently to feature it in the README.
+- 🟡 **Lucy / agent-to-agent positioning (F-18)** — your brand call on how prominently to feature it in the README. (The generic bidirectional-MCP / agent-to-agent story is already in the README; this is only about whether to *name* "Lucy".)
+- 🟡 **Release-versioning decision (F-5)** — the product is **v2.3** but the only git tag is **v3.0.0**. Pick the source of truth, then I'll prepare a `scripts/tag_releases.sh` that maps each CHANGELOG entry → its commit; you run it to push the tags + enable GitHub Releases. (Nothing is tagged today, so the Releases page is empty.)
+- 🟡 **F-4 CI depth — your call on the trade-off.** PR-6I expands CI to gate the deterministic readiness/doc tests + adds Dependabot (no working-code edits). Gating the *full* test suite would mean cleaning **639 repo-wide `ruff` findings** in working modules — which I won't touch without your explicit OK (your standing "never touch working code" rule). Options: leave as-is (CI already gates 6 test files + the D-1 manifest gate + the readiness tests), **or** greenlight a dedicated ruff-cleanup pass.
+- 🟠 **Fill the ONE-PAGER private fields** — `docs/ONE-PAGER.md` ships with explicit placeholders for the **founder bio**, the **raise/ask sentence**, and the **pricing band** (left blank because the repo is public). Fill a private copy before any investor send. Optionally I can draft `docs/VISION.md` (3-page narrative) on the same public-safe-placeholder basis.
+- ⚪ **Tiny follow-up:** link `docs/PRIVACY.md` from the README "Privacy & Security" section (one line; I'll fold it into the next README-polish PR).
 
 ---
 
@@ -74,6 +68,7 @@ I'm writing the docs; a few items need your accounts/assets:
 - **Keychain rotation:** procedures for the secrets migrated in Wave 2 (audit HMAC, internal token, provider keys) are documented in `AGENTS.md §10` — only needed if you rotate.
 - **Feature-flag env vars:** `ASKUSER_ENABLED`, `STUCK_DETECTION_ENABLED`, `OBSERVER_ENABLED`, `TRIGGERS_ENABLED`, `AGENT_RUNNER_ENABLED`, etc. (defaults true) — documented in `AGENTS.md §10`.
 - **Branch protection:** `main` is protected (you enabled it earlier).
+- **Cold "repo-readiness audit" email (2026-05-24):** `PressureDesk <pressuredesk@agentmail.to>` → `ava.dsa25@proton.me`, offering a "fixed-scope full audit" for **49 USDC**, teaser "75/100, missing_claude_project_settings." Assessment: **automated cold outreach — don't pay, don't reply.** We already run four internal audits far deeper than a public-signals scorecard. Its one concrete hook (`.claude/` project settings) is moot — `.claude/` is intentionally git-ignored, and the repo's `CLAUDE.md`/`AGENTS.md` front door already covers agent-onboarding far beyond a settings file. Logged here for the record only.
 
 ---
 
@@ -85,5 +80,5 @@ I'm writing the docs; a few items need your accounts/assets:
 | A — Code quality | 3 | ✅ closed |
 | C — Reliability | 4 | ✅ **fully closed** (all 5 CRITICAL + 9 HIGH + 6 MEDIUM + 2 LOW) |
 | E — Apple app | 5 | 🟠 in progress (W5-1 done; build pieces are XL + need your Mac/cert) |
-| F — Investor readiness | 6 | 🟢 in progress (doc-heavy, mostly doable now) |
+| F — Investor readiness | 6 | 🟢 ~90% closed — F-1,2,3,6,7,9,10,13,14,16,17 done; F-18 partial. Remaining gated on you: F-4 (ruff-cleanup decision), F-5 (versioning), F-8 (GIF), F-11 (pricing), F-12 (Discord), F-15 (pyproject, deferred). |
 | B — Projects + Pilot | 7 | ⏳ not started (needs your scope description) |

--- a/docs/audits/PHASE-1-INVESTOR-READINESS.md
+++ b/docs/audits/PHASE-1-INVESTOR-READINESS.md
@@ -90,6 +90,8 @@ CLAUDE.md §9 *Testing* claims "600+ tests collected" — actual count 873 (more
 
 ### F-4 — CI runs <10% of the test suite [HIGH]
 
+> **🟡 PARTIALLY CLOSED by PR-6I (2026-05-24).** CI already grew past the audit's 4-file snapshot (now also runs the D-1 manifest gate, `test_skill_registry`, `test_keychain`). PR-6I adds a **Dependabot config** (`.github/dependabot.yml`: weekly pip + github-actions, grouped, capped) **and** gates the deterministic readiness doc-guards (`test_repo_health`, `test_privacy_doc`, `test_readme_investor`, `test_one_pager`, `test_apple_packaging`, `test_dependabot`) — all stdlib-pure so they stay green on the ubuntu runner. **Still open (Mickael's call, `docs/HANDOFF-MICKAEL.md §3`):** gating the *full* suite would require cleaning ~639 repo-wide `ruff` findings + resolving platform/optional-dep test failures on the runner — deliberately NOT done unilaterally (touches working code). No coverage gate / Python-version matrix yet.
+
 **What's missing:** `.github/workflows/ci.yml` runs exactly 4 test scripts on push/PR to main:
 ```yaml
 - run: python tests/test_skill_imports.py

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -1,0 +1,35 @@
+"""Tests for PR-6I (Audit F / F-4 partial) — Dependabot config exists and is
+sane, and CI gates the deterministic readiness doc-guard tests. String-based
+validation only (no PyYAML dependency in the test env).
+
+Reference: docs/audits/PHASE-1-INVESTOR-READINESS.md F-4.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_dependabot_config_present_and_sane():
+    f = REPO / ".github" / "dependabot.yml"
+    assert f.exists(), "F-4: .github/dependabot.yml must exist"
+    t = f.read_text()
+    assert "version: 2" in t, "Dependabot config must declare version: 2"
+    assert "pip" in t, "must track Python (pip) dependencies"
+    assert "github-actions" in t, "must track GitHub Actions versions"
+    assert "weekly" in t, "must set an update cadence"
+    assert "open-pull-requests-limit" in t, "must cap open PRs so it stays signal, not noise"
+
+
+def test_ci_gates_the_readiness_doc_guards():
+    t = (REPO / ".github" / "workflows" / "ci.yml").read_text()
+    # F-4: the investor/Apple readiness artifacts must be protected by CI.
+    for guard in (
+        "test_repo_health",
+        "test_privacy_doc",
+        "test_readme_investor",
+        "test_one_pager",
+        "test_dependabot",
+    ):
+        assert guard in t, f"F-4: CI must run {guard}.py"


### PR DESCRIPTION
## Summary
Partially closes **Audit-F F-4** ("CI runs <10% of the suite") **without touching any working code**:

- **`.github/dependabot.yml`** — weekly `pip` + `github-actions` updates, grouped minor/patch, capped open PRs. The supply-chain-hygiene file enterprise security DD checks for.
- **`ci.yml`** — now also gates the deterministic **readiness doc-guards**: `test_repo_health`, `test_privacy_doc`, `test_readme_investor`, `test_one_pager`, `test_apple_packaging`, `test_dependabot`. All stdlib-pure → green on the ubuntu runner. Protects every investor/Apple readiness artifact from silent regression.

**Deliberately not done** (your call — HANDOFF §3): gating the *full* suite needs ~639 repo-wide `ruff` findings cleaned + runner platform/optional-dep failures resolved, which means editing working modules. Left for an explicit greenlight.

## Test plan
- [x] `tests/test_dependabot.py` (2 new) — config sanity + CI wiring.
- [x] The exact CI doc-guard set runs locally: **26 passed**.
- [x] `ruff` clean; both YAML files parse.
- [x] Full suite: **41 baseline failures unchanged** (1,589 passed).

## Also in this PR
- `docs/HANDOFF-MICKAEL.md` synced — PR queue marked cleared, F-4/F-5 decisions added, ONE-PAGER private fields + the cold "repo-audit" email logged for the record.
- F-4 audit closed-note.

> Branched off the post-merge `main`. New files + workflow/doc edits only — no runtime/daemon code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)