### PR TITLE
feat(apple): Wave 5 PR-5F — code-sign + notarize pipeline (E-2/E-3, W5-7/8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,11 @@ jobs:
           tests/test_one_pager.py
           tests/test_apple_packaging.py
           tests/test_dependabot.py
-      - name: Apple packaging tests (W5-2 bundle + W5-3 launchd + W5-4 python + W5-12 uninstall)
+      - name: Apple packaging tests (W5-2/3/4/7/8/12 — bundle, launchd, python, sign, notarize, uninstall)
         run: >
           python -m pytest -v
           tests/test_app_bundle.py
           tests/test_launchd.py
           tests/test_python_bundle.py
           tests/test_uninstaller.py
+          tests/test_signing.py

--- a/docs/HANDOFF-MICKAEL.md
+++ b/docs/HANDOFF-MICKAEL.md
@@ -23,7 +23,15 @@ I work on isolated branches and never self-merge; each new branch builds on the 
 
 **Enrollment: ✅ done** (you confirmed Team ID + Developer ID Application cert in hand).
 
-**Progress:** W5-1 (metadata) ✅ · W5-2 (`.app` wrapper + launcher) ✅ · W5-3 (launchd toolkit) ✅ · W5-4 (bundled relocatable Python) ✅ · W5-12 (uninstaller, `packaging/macos/uninstall_codec.sh`) ⏳ in flight. Next: W5-5 (model downloader — needs your model-strategy decision), W5-6 (first-run permissions wizard — wires launchd install + Python remap + the in-app "Uninstall" item), W5-7/8 (sign + notarize).
+**Progress:** W5-1 (metadata) ✅ · W5-2 (`.app` wrapper) ✅ · W5-3 (launchd) ✅ · W5-4 (bundled Python) ✅ · W5-12 (uninstaller) ✅ · W5-7/8 (sign + notarize scripts, `packaging/macos/{sign_app,notarize_app}.sh`) ⏳ in flight. Next: W5-5 (model downloader — needs your model-strategy decision), W5-6 (first-run permissions wizard — wires launchd install + Python remap + in-app "Uninstall"), W5-11 (GUI onboarding), then DMG packaging.
+
+**The full release sequence is now scriptable** (run on your build Mac with the cert):
+```
+bash packaging/macos/build_app.sh --with-python --clean
+bash packaging/macos/sign_app.sh   --app "dist/Sovereign AI Workstation.app" --identity "Developer ID Application: … (TEAMID)"
+bash packaging/macos/notarize_app.sh --app "dist/Sovereign AI Workstation.app" --keychain-profile codec-notary
+```
+Each accepts `--dry-run` to preview. I've validated build + Python bundle + the sign/notarize *plans*; only the cert-gated execution is left to you.
 
 - ⚪ **Try the uninstaller (safe):** `bash packaging/macos/uninstall_codec.sh --dry-run` lists exactly what a real uninstall would remove and deletes nothing. (Real removal needs `--yes`; user data needs `--yes --purge-data`.) Note: macOS won't let the app revoke its own TCC grants — the script prints the System Settings path to clear them by hand.
 
@@ -88,6 +96,6 @@ I'm writing the docs; a few items need your accounts/assets:
 | D — Security | 1-2 | ✅ closed (PRs #56-#71 era) |
 | A — Code quality | 3 | ✅ closed |
 | C — Reliability | 4 | ✅ **fully closed** (all 5 CRITICAL + 9 HIGH + 6 MEDIUM + 2 LOW) |
-| E — Apple app | 5 | 🟠 in progress — W5-1 (metadata) + W5-2 (.app) + W5-3 (launchd) + W5-4 (Python) + W5-12 (uninstaller) done; next W5-5 models, W5-6 first-run, W5-7/8 sign+notarize (need your Mac/cert) |
+| E — Apple app | 5 | 🟠 in progress — W5-1/2/3/4/7/8/12 done (metadata, .app, launchd, Python, **sign+notarize scripts**, uninstaller); next W5-5 models, W5-6 first-run, W5-11 GUI, DMG. Cert-gated execution (sign/notarize) → your Mac |
 | F — Investor readiness | 6 | 🟢 ~90% closed — F-1,2,3,6,7,9,10,13,14,16,17 done; F-18 partial. Remaining gated on you: F-4 (ruff-cleanup decision), F-5 (versioning), F-8 (GIF), F-11 (pricing), F-12 (Discord), F-15 (pyproject, deferred). |
 | B — Projects + Pilot | 7 | ⏳ not started (needs your scope description) |

--- a/docs/W5-7-8-SIGN-NOTARIZE-DESIGN.md
+++ b/docs/W5-7-8-SIGN-NOTARIZE-DESIGN.md
@@ -1,0 +1,75 @@
+# W5-7 / W5-8 — code signing + notarization pipeline (design)
+
+> Wave 5 (Audit E). Closes **E-2** (code signing) + **E-3** (notarization).
+> Depends on W5-1 (entitlements), W5-2 (bundle), W5-4 (embedded Python).
+> Reference: `docs/audits/PHASE-1-APPLE-APP.md`.
+
+## Why these are author-now / validate-on-your-Mac
+
+Signing needs a **Developer ID Application** identity; notarization needs an
+**App Store Connect API key**. Neither lives in this repo or CI (correctly — they
+must not). So this PR ships the *scripts* + validates their **logic** via
+`--dry-run` (enumeration + command plan). Mickael runs them once on the build
+Mac with the cert. This split is the standard way to land a signing pipeline.
+
+## sign_app.sh (E-2)
+
+Hardened-runtime signing of the whole bundle, **inside-out** (nested code first,
+the `.app` last — codesign requires inner code be valid before the outer seal):
+
+1. Enumerate inner Mach-O: every `*.dylib` / `*.so` under `Contents/` (the
+   embedded Python's hundreds of extension modules + numpy/mlx/PyObjC dylibs),
+   plus Mach-O executables (`Contents/Frameworks/python/bin/python3*`, the
+   launcher `Contents/MacOS/codec`, any bundled `cloudflared`, the Touch ID
+   helper). Sign each:
+   `codesign --force --options runtime --timestamp --entitlements <ent> --sign <id>`
+2. Sign nested `.framework`/`.app` if present.
+3. Sign the **main `.app` last** with the same flags + entitlements
+   (`packaging/macos/codec.entitlements` from W5-1).
+4. Verify: `codesign --verify --deep --strict --verbose=2` (note: `spctl
+   --assess` only passes *after* notarization + staple — W5-8).
+
+Flags: `--app`, `--identity` (or `$CODEC_SIGN_IDENTITY`), `--entitlements`,
+`--dry-run`, `--verify-only`.
+
+## notarize_app.sh (E-3)
+
+1. Package: `ditto -c -k --keepParent "<app>" "<zip>"` (notarytool takes a zip).
+2. Submit + wait: `xcrun notarytool submit <zip> --keychain-profile <profile>
+   --wait` (or `--apple-id/--team-id/--password`).
+3. On accepted: `xcrun stapler staple "<app>"` then `stapler validate` +
+   `spctl --assess --type execute -vv` (now passes).
+
+Flags: `--app`, `--keychain-profile` (or Apple-ID trio), `--dry-run`,
+`--staple-only`.
+
+**Triage (documented in the script):** Apple most often rejects an embedded
+`.dylib` that's unsigned or lacks hardened runtime — almost always from
+`mlx`/`numpy`/`PyObjC` wheels. Fix: `xcrun notarytool log <submission-id>` to get
+the offending path, then re-run `sign_app.sh` (it signs *all* `.dylib`), resubmit.
+
+## Release sequence
+
+```
+build_app.sh --with-python --clean        # W5-2 + W5-4
+sign_app.sh   --app "dist/….app" --identity "Developer ID Application: … (TEAMID)"
+notarize_app.sh --app "dist/….app" --keychain-profile codec-notary
+# → DMG packaging is the installer step (later)
+```
+
+## Test plan (`tests/test_signing.py`)
+
+- Both scripts exist, executable, shebang.
+- `sign_app.sh`: references `codesign`, `--options runtime`, `--timestamp`,
+  `--entitlements`, signs inside-out, has `--dry-run` + a verify step.
+- `notarize_app.sh`: references `notarytool`, `stapler`, `ditto`, `--dry-run`.
+- **dry-run enumeration** (portable, `find`-based): build a skeleton `.app` +
+  inject a fake nested `*.dylib`; `sign_app.sh --dry-run` lists the nested
+  dylib **before** the `.app` (inside-out) and never invokes `codesign`.
+
+Wired into the CI packaging step. Real signing/notarization = Mickael's Mac.
+
+## Rollback
+
+Net-new scripts under `packaging/macos/` + one test + CI line + audit/handoff
+notes. No runtime/daemon code; `git revert`.

--- a/docs/audits/PHASE-1-APPLE-APP.md
+++ b/docs/audits/PHASE-1-APPLE-APP.md
@@ -83,12 +83,18 @@ The conclusion is unambiguous: there is no Apple-app distribution scaffolding in
 **Dependencies:** none (foundational).
 
 ### E-2 — No code signing pipeline [CRITICAL]
+
+> **🟡 SUBSTANTIALLY CLOSED — W5-7/PR-5F.** `packaging/macos/sign_app.sh` signs the bundle **inside-out** with **hardened runtime** + the W5-1 entitlements: every nested `*.dylib`/`*.so` (the embedded Python's extension modules + numpy/mlx/PyObjC) and Mach-O executable first, then the `.app` last (`codesign --force --options runtime --timestamp --entitlements codec.entitlements --sign <id>`), then `codesign --verify --deep --strict` + `spctl`. `--dry-run` validated on macOS (correct inside-out enumeration + command plan); 4 tests (`tests/test_signing.py`). **Handoff:** Mickael runs it once with the **Developer ID Application** cert (`--identity` / `$CODEC_SIGN_IDENTITY`) — the only thing that can't live in the repo/CI.
+
 **What's missing:** Zero references to `codesign`, `--sign`, Developer ID Application certificates, or hardened runtime in the repo. Both the Touch ID helper (`codec_auth/codec_auth`, compiled inline by `setup_codec.py:563-571` via `swiftc`) and the Swift overlay (`swift-overlay/`) ship unsigned.
 **Why it matters:** Unsigned binaries trip Gatekeeper on download; the user has to right-click → Open → Open or run `xattr -d com.apple.quarantine`. A paid app cannot ship like this. Hardened runtime (required for notarization) is also un-configured — affects subprocess injection (need `com.apple.security.cs.allow-jit`, `com.apple.security.cs.disable-library-validation`, or `com.apple.security.cs.allow-unsigned-executable-memory` to keep CPython + PyObjC working).
 **Effort:** **L** (acquire Developer ID Application cert, set up keychain for CI, write a `scripts/sign_app.sh` that signs the bundle including embedded Python, all `.dylib`, the cloudflared binary, and the Touch ID helper; test hardened-runtime entitlements against the actual launch path).
 **Dependencies:** E-1 (need a bundle to sign), E-13 (Apple Developer enrollment).
 
 ### E-3 — No notarization workflow [CRITICAL]
+
+> **🟡 SUBSTANTIALLY CLOSED — W5-8/PR-5F.** `packaging/macos/notarize_app.sh`: `ditto` zips the signed bundle → `xcrun notarytool submit --wait` (keychain-profile or apple-id trio) → `xcrun stapler staple` + `validate` + `spctl --assess`. Includes the documented **triage** for the common failure (Apple flags an unsigned embedded `mlx`/`numpy`/`PyObjC` `.dylib`: `notarytool log` → re-run `sign_app.sh` → resubmit). `--dry-run` validated on macOS. **Handoff:** Mickael runs it once with an **App Store Connect API key** stored via `notarytool store-credentials`. DMG/pkg packaging is the later installer step.
+
 **What's missing:** Zero references to `notarytool`, `xcrun stapler`, `altool`, or any CI hook that uploads the bundle to Apple. No `.dmg` or `.pkg` build target exists.
 **Why it matters:** As of macOS 10.15+, downloaded apps that aren't notarized refuse to launch on first run (Gatekeeper blocks them with the dreaded "cannot be opened because Apple cannot check it for malicious software" dialog). A paid app **must** be notarized. The notarization process scans all embedded binaries — Python interpreter, every `.dylib` from `mlx`, `numpy`, `pyobjc`, etc. — for signing/hardened-runtime compliance.
 **Effort:** **M** (script using `notarytool submit` + `stapler staple`; configure App Store Connect API key; test with a stub bundle; document the failure-mode triage when Apple flags an unsigned embedded `.dylib` — common with `mlx`/`numpy`/`PyObjC` builds).

--- a/packaging/macos/notarize_app.sh
+++ b/packaging/macos/notarize_app.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Notarize + staple the signed Sovereign AI Workstation .app (W5-8, E-3).
+#
+# Apple requires downloaded apps be notarized or Gatekeeper blocks first launch
+# ("Apple cannot check it for malicious software"). This zips the SIGNED bundle,
+# submits to Apple's notary service, waits for the verdict, then staples the
+# ticket so the app validates offline.
+#
+# Needs App Store Connect credentials (NOT in this repo). Easiest: store them
+# once with `xcrun notarytool store-credentials codec-notary --apple-id … \
+#   --team-id … --password <app-specific-pw>` then pass --keychain-profile codec-notary.
+# Or pass --apple-id/--team-id/--password directly. --dry-run prints the plan.
+#
+# Usage:
+#   notarize_app.sh --app "dist/Sovereign AI Workstation.app" --keychain-profile codec-notary
+#   notarize_app.sh --app "…" --staple-only         # re-staple an already-accepted app
+#
+# TRIAGE: if Apple rejects, almost always an embedded .dylib (mlx/numpy/PyObjC)
+# is unsigned or lacks hardened runtime. Get the path with
+#   xcrun notarytool log <submission-id> --keychain-profile codec-notary
+# then re-run sign_app.sh (signs ALL .dylib) and resubmit.
+# See docs/W5-7-8-SIGN-NOTARIZE-DESIGN.md.
+set -euo pipefail
+
+APP=""
+PROFILE="${CODEC_NOTARY_PROFILE:-}"
+APPLE_ID=""
+TEAM_ID=""
+PASSWORD=""
+DRY_RUN=0
+STAPLE_ONLY=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --app) APP="$2"; shift 2 ;;
+        --keychain-profile) PROFILE="$2"; shift 2 ;;
+        --apple-id) APPLE_ID="$2"; shift 2 ;;
+        --team-id) TEAM_ID="$2"; shift 2 ;;
+        --password) PASSWORD="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --staple-only) STAPLE_ONLY=1; shift ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "notarize_app.sh: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$APP" ] || { echo "notarize_app.sh: --app is required" >&2; exit 2; }
+[ -d "$APP/Contents" ] || { echo "notarize_app.sh: not an .app bundle: $APP" >&2; exit 1; }
+
+ZIP="${APP%.app}-notarize.zip"
+
+# Build the notarytool credential args (keychain profile OR apple-id trio).
+cred_args() {
+    if [ -n "$PROFILE" ]; then
+        printf '%s\n' "--keychain-profile" "$PROFILE"
+    elif [ -n "$APPLE_ID" ] && [ -n "$TEAM_ID" ] && [ -n "$PASSWORD" ]; then
+        printf '%s\n' "--apple-id" "$APPLE_ID" "--team-id" "$TEAM_ID" "--password" "$PASSWORD"
+    fi
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then echo "  [dry-run] $*"; else "$@"; fi
+}
+
+if [ "$STAPLE_ONLY" -eq 1 ]; then
+    echo "==> stapling ticket to $APP"
+    run xcrun stapler staple "$APP"
+    run xcrun stapler validate "$APP"
+    exit 0
+fi
+
+# Credentials required for the real submit.
+if [ "$DRY_RUN" -eq 0 ]; then
+    if [ -z "$PROFILE" ] && { [ -z "$APPLE_ID" ] || [ -z "$TEAM_ID" ] || [ -z "$PASSWORD" ]; }; then
+        echo "notarize_app.sh: need --keychain-profile OR --apple-id + --team-id + --password" >&2
+        exit 1
+    fi
+fi
+
+echo "==> packaging $APP -> $ZIP"
+run ditto -c -k --keepParent "$APP" "$ZIP"
+
+echo "==> submitting to Apple notary service (waits for verdict)"
+# shellcheck disable=SC2046
+run xcrun notarytool submit "$ZIP" $(cred_args) --wait
+
+echo "==> stapling ticket"
+run xcrun stapler staple "$APP"
+run xcrun stapler validate "$APP"
+run spctl --assess --type execute -vv "$APP"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] nothing submitted."
+else
+    rm -f "$ZIP"
+    echo "==> notarized + stapled. The .app now launches cleanly on any Mac."
+fi

--- a/packaging/macos/sign_app.sh
+++ b/packaging/macos/sign_app.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Code-sign the Sovereign AI Workstation .app with hardened runtime (W5-7, E-2).
+#
+# Signs INSIDE-OUT: every nested Mach-O (the embedded Python's .dylib/.so + its
+# python3 binary, the launcher, any bundled cloudflared / Touch ID helper) is
+# signed before the outer .app seal — codesign requires inner code be valid
+# first. Hardened runtime + the W5-1 entitlements are applied so the result can
+# be notarized (W5-8).
+#
+# Needs a Developer ID Application identity (NOT in this repo). Provide via
+# --identity or $CODEC_SIGN_IDENTITY. --dry-run prints the plan and signs nothing.
+#
+# Usage:
+#   sign_app.sh --app "dist/Sovereign AI Workstation.app" \
+#               --identity "Developer ID Application: NAME (TEAMID)" [--dry-run]
+#   sign_app.sh --app "…" --verify-only
+# See docs/W5-7-8-SIGN-NOTARIZE-DESIGN.md.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+APP=""
+IDENTITY="${CODEC_SIGN_IDENTITY:-}"
+ENTITLEMENTS="$HERE/codec.entitlements"
+DRY_RUN=0
+VERIFY_ONLY=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --app) APP="$2"; shift 2 ;;
+        --identity) IDENTITY="$2"; shift 2 ;;
+        --entitlements) ENTITLEMENTS="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --verify-only) VERIFY_ONLY=1; shift ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "sign_app.sh: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$APP" ] || { echo "sign_app.sh: --app is required" >&2; exit 2; }
+[ -d "$APP/Contents" ] || { echo "sign_app.sh: not an .app bundle: $APP" >&2; exit 1; }
+
+if [ "$VERIFY_ONLY" -eq 1 ]; then
+    echo "==> verifying signature on $APP"
+    codesign --verify --deep --strict --verbose=2 "$APP"
+    spctl --assess --type execute -vv "$APP" || echo "  (spctl passes only after notarization + staple — W5-8)"
+    exit 0
+fi
+
+[ -f "$ENTITLEMENTS" ] || { echo "sign_app.sh: entitlements not found: $ENTITLEMENTS" >&2; exit 1; }
+if [ "$DRY_RUN" -eq 0 ] && [ -z "$IDENTITY" ]; then
+    echo "sign_app.sh: no signing identity (pass --identity or set CODEC_SIGN_IDENTITY)" >&2
+    echo "  list yours with: security find-identity -v -p codesigning" >&2
+    exit 1
+fi
+
+codesign_one() {
+    local target="$1"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "  [dry-run] codesign --force --options runtime --timestamp --entitlements \"$ENTITLEMENTS\" --sign \"$IDENTITY\" \"$target\""
+    else
+        codesign --force --options runtime --timestamp --entitlements "$ENTITLEMENTS" --sign "$IDENTITY" "$target"
+        echo "  signed: $target"
+    fi
+}
+
+echo "==> signing $APP inside-out (identity: ${IDENTITY:-<dry-run>})"
+
+echo "-- nested libraries (*.dylib, *.so) --"
+while IFS= read -r lib; do
+    [ -n "$lib" ] && codesign_one "$lib"
+done < <(find "$APP/Contents" -type f \( -name '*.dylib' -o -name '*.so' \) | sort)
+
+echo "-- Mach-O executables --"
+while IFS= read -r exe; do
+    [ -n "$exe" ] || continue
+    if file "$exe" 2>/dev/null | grep -q "Mach-O"; then
+        codesign_one "$exe"
+    fi
+done < <(find "$APP/Contents" -type f -perm -u+x | sort)
+
+echo "==> finally sign the app bundle: $APP"
+codesign_one "$APP"
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    echo "==> verifying"
+    codesign --verify --deep --strict --verbose=2 "$APP"
+    spctl --assess --type execute -vv "$APP" || echo "  (spctl passes only after notarization + staple — W5-8)"
+    echo "==> signed. Next: notarize_app.sh --app \"$APP\""
+else
+    echo "[dry-run] nothing signed."
+fi

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,0 +1,69 @@
+"""Tests for PR-5F (Audit E / E-2, E-3, W5-7/8) — the codesign + notarize
+pipeline. Real signing needs a Developer ID cert (handoff); here we verify the
+script contracts and that sign_app.sh's --dry-run enumerates nested code
+inside-out (dylibs before the .app) without invoking codesign.
+
+Reference: docs/W5-7-8-SIGN-NOTARIZE-DESIGN.md, docs/audits/PHASE-1-APPLE-APP.md (E-2/E-3).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+PKG = REPO / "packaging" / "macos"
+SIGN = PKG / "sign_app.sh"
+NOTARIZE = PKG / "notarize_app.sh"
+
+
+def _fake_app(tmp_path: Path) -> Path:
+    app = tmp_path / "Sovereign AI Workstation.app"
+    (app / "Contents" / "MacOS").mkdir(parents=True)
+    (app / "Contents" / "Frameworks" / "python" / "lib").mkdir(parents=True)
+    (app / "Contents" / "Info.plist").write_text("<plist/>")
+    (app / "Contents" / "MacOS" / "codec").write_text("#!/bin/sh\n")
+    # a nested dylib that inside-out signing must handle before the .app
+    (app / "Contents" / "Frameworks" / "python" / "lib" / "fake.dylib").write_text("x")
+    return app
+
+
+def test_scripts_present_executable():
+    for s in (SIGN, NOTARIZE):
+        assert s.exists(), f"{s.name} must exist"
+        assert os.access(s, os.X_OK), f"{s.name} must be executable"
+        assert s.read_text().splitlines()[0].startswith("#!"), f"{s.name} needs a shebang"
+
+
+def test_sign_script_contract():
+    t = SIGN.read_text()
+    assert "codesign" in t
+    assert "--options runtime" in t, "must enable hardened runtime"
+    assert "--timestamp" in t, "must use a secure timestamp"
+    assert "--entitlements" in t, "must apply the W5-1 entitlements"
+    assert "codec.entitlements" in t, "must default to the project entitlements"
+    assert "--dry-run" in t
+    assert "--verify" in t or "codesign --verify" in t, "must verify after signing"
+
+
+def test_notarize_script_contract():
+    t = NOTARIZE.read_text()
+    assert "notarytool" in t, "must submit via notarytool"
+    assert "stapler" in t, "must staple the ticket"
+    assert "ditto" in t or "zip" in t, "must package the app for submission"
+    assert "--dry-run" in t
+
+
+def test_sign_dry_run_enumerates_inside_out(tmp_path):
+    app = _fake_app(tmp_path)
+    r = subprocess.run(
+        ["bash", str(SIGN), "--app", str(app), "--identity", "TEST-IDENTITY", "--dry-run"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert r.returncode == 0, f"dry-run failed: {r.stderr}\n{r.stdout}"
+    out = r.stdout
+    assert "fake.dylib" in out, "must enumerate nested dylibs"
+    assert "[dry-run]" in out, "must not actually sign in dry-run"
+    # inside-out: the nested dylib is planned before the final .app seal.
+    assert "finally" in out.lower(), "must sign the .app last"
+    assert out.index("fake.dylib") < out.lower().index("finally"), "dylib must be signed before the .app"


### PR DESCRIPTION
## Summary
Substantially closes **Audit-E E-2** (no code signing) + **E-3** (no notarization) — the two CRITICALs that gate a Gatekeeper-passing download.

- **`sign_app.sh`** — hardened-runtime signing **inside-out**: every nested `*.dylib`/`*.so` (the embedded Python's modules + numpy/mlx/PyObjC) and Mach-O executable first, then the `.app` last, with the W5-1 entitlements + secure timestamp; then `codesign --verify --deep --strict` + `spctl`. `--dry-run` / `--verify-only`; identity via `--identity` or `$CODEC_SIGN_IDENTITY`.
- **`notarize_app.sh`** — `ditto` zip → `xcrun notarytool submit --wait` → `stapler staple` + `validate` + `spctl`. Documents the common **triage** (Apple flags an unsigned embedded `mlx`/`numpy`/`PyObjC` dylib → `notarytool log` → re-sign → resubmit). `--dry-run` / `--staple-only`.

The whole release is now scriptable: `build_app.sh --with-python` → `sign_app.sh` → `notarize_app.sh`.

## Validation (macOS, dry-run)
```
sign:     nested _ssl.so + libpython3.12.dylib signed BEFORE the .app seal,
          with --options runtime --timestamp --entitlements codec.entitlements
notarize: ditto → notarytool submit --wait → stapler staple → validate → spctl
```

## Test plan
- [x] `tests/test_signing.py` (4) — script contracts + portable `--dry-run` proving inside-out enumeration without invoking `codesign`. Wired into the CI packaging step (runs on ubuntu).
- [x] `ruff` clean; full suite **41 baseline failures unchanged** (1,616 passed).
- [x] No runtime/daemon code touched.

## Handoff (cert-gated — your Mac)
Run `sign_app.sh` with the **Developer ID Application** cert and `notarize_app.sh` with an **App Store Connect API key** (`notarytool store-credentials`). DMG packaging = later installer step. Full sequence in `HANDOFF-MICKAEL.md §1`.

> Branched off `main` (W5-1/2/3/4/12 in). Independent of any open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)