### PR TITLE
fix(agent): Wave 7 PR-7A — wire the real destructive-consent gate (B-1)

### DIFF
--- a/codec_agent_runner.py
+++ b/codec_agent_runner.py
@@ -521,29 +521,44 @@ class ConsentResult:
 
 
 def _strict_consent(action: Action, deadline: int = DESTRUCTIVE_CONSENT_TIMEOUT_S) -> ConsentResult:
-    """Lazy-imported codec_ask_user.strict_consent_gate wrapper.
-    Returns ConsentResult. Reuses Phase 1 Step 3 §1.7 verb-match
-    enforcement — generic 'yes' is rejected, two-strike timeout
-    in <2s emits ambiguous_consent."""
-    try:
-        from codec_ask_user import strict_consent_gate
-    except Exception as e:
-        log.warning("codec_ask_user.strict_consent_gate unavailable: %s", e)
-        return ConsentResult(approved=False, timed_out=True,
-                              user_response="ask_user_unavailable")
+    """Strict-consent gate for a destructive agent op (Audit B / B-1).
 
+    Routes through the REAL ``codec_ask_user.ask(destructive=True, ...)`` — which
+    implements Phase 1 Step 3 §1.7 on the reply path (literal verb-match;
+    generic 'yes'/'ok' rejected; two-strike → ambiguous_consent timeout). Maps
+    ``ask()``'s string return to a ConsentResult.
+
+    Fail-safe: anything that is NOT a verb-matched answer (timeout, ask-user
+    disabled, or any error) returns ``approved=False`` — a destructive op is
+    never auto-approved. (Prior to B-1 this imported a consent helper that did
+    not exist, so the prompt never actually ran.)
+    """
+    verb = "confirm"
     question = (
-        f"⚠️ Destructive op requested by agent: {action.skill}: {action.task[:80]}\n\n"
-        f"To approve, type the literal verb: 'delete' / 'send' / 'pay' / 'authorize' "
-        f"(matching the operation). Generic 'yes' will be rejected."
+        f"⚠️ Agent requests a DESTRUCTIVE operation\n"
+        f"skill: {action.skill}\n"
+        f"task: {action.task[:160]}\n\n"
+        f"To approve, type '{verb}'. A generic 'yes'/'ok' will be rejected."
     )
-    result = strict_consent_gate(question, deadline_seconds=deadline,
-                                  source=f"agent_runner")
-    return ConsentResult(
-        approved=getattr(result, "approved", False),
-        timed_out=getattr(result, "timed_out", False),
-        user_response=getattr(result, "user_response", ""),
-    )
+    try:
+        import codec_ask_user
+        answer = codec_ask_user.ask(
+            question,
+            destructive=True,
+            destructive_verb=verb,
+            timeout=deadline,
+            asked_from="crew",
+            tool_name=action.skill,
+        )
+    except Exception as e:  # never let a consent-path error become an auto-approve
+        log.warning("strict-consent ask() failed: %s", e)
+        return ConsentResult(approved=False, timed_out=True, user_response=f"ask_error:{e}")
+
+    if answer in (codec_ask_user.TIMEOUT_SENTINEL, codec_ask_user.DISABLED_SENTINEL):
+        return ConsentResult(approved=False, timed_out=True, user_response=answer)
+    # In destructive mode ask() reaches an 'answered' status (and returns the
+    # answer) only once the reply contained the verb — so this is real consent.
+    return ConsentResult(approved=True, timed_out=False, user_response=answer)
 
 
 def _enforce_destructive_gate(action: Action,

--- a/docs/HANDOFF-MICKAEL.md
+++ b/docs/HANDOFF-MICKAEL.md
@@ -13,9 +13,9 @@ All PRs through **#112 are merged**. Queue clear.
 - **Wave 4 (Reliability):** #82–#91 ✅.
 - **Wave 5 (Apple):** #92, #98, #106–#112 ✅ — full build→sign→notarize→staple→DMG pipeline + launchd + Python bundle + models + first-run + uninstaller. All Audit-E CRITICALs closed.
 - **Wave 6 (Investor):** #93–#97 ✅ + the 7 Dependabot bumps you merged.
-- **In flight:** **Audit-B findings PR** (`docs/audits/PHASE-1-PROJECTS-PILOT.md`) — docs-only, the last audit.
+- **In flight:** **Wave 7 has started** — **PR-7A fixes B-1** (the phantom destructive-consent gate → now wired to the real `codec_ask_user.ask`).
 
-> 🔴 **Heads-up — Audit B found 3 CRITICALs in the autonomous-agent permission gate** (`PHASE-1-PROJECTS-PILOT.md` B-1/B-2/B-3): the destructive-consent function is a phantom import, `permission_gate` trusts LLM-self-declared flags, and `/api/agents/grant` skips the path blocklist. These are the **live security boundary of an agent that runs on your Mac** — they're the top-priority fix work (Wave 7). They are *findings*, not yet fixed; tell me to start Wave 7 and I'll burn them down (design-first → TDD → PR) like the other waves.
+> 🔴 **Audit B found 3 CRITICALs in the autonomous-agent permission gate** (`PHASE-1-PROJECTS-PILOT.md`). Status: **B-1 ✅ fixed (PR-7A)**; **B-2** (`permission_gate` trusts LLM-self-declared flags — the manifest is advisory) and **B-3** (`/api/agents/grant` skips the path blocklist + no per-agent authz) are **next** (PR-7B, PR-7C). These are the live security boundary of an agent that runs on your Mac — keep going to close them.
 
 I work on isolated branches and never self-merge; each new branch builds on the latest `main`.
 
@@ -103,4 +103,4 @@ I'm writing the docs; a few items need your accounts/assets:
 | C — Reliability | 4 | ✅ **fully closed** (all 5 CRITICAL + 9 HIGH + 6 MEDIUM + 2 LOW) |
 | E — Apple app | 5 | 🟠 **all CRITICALs closed; full build→DMG pipeline + first-run logic done.** W5-1/2/3/4/5/6/7/8/12 + capstone shipped. Remaining: W5-11 Swift wizard, W5-9 license, W5-10 Cloudflare, W5-13 Sparkle — all GUI/decision/key-gated → you |
 | F — Investor readiness | 6 | 🟢 ~90% closed — F-1,2,3,6,7,9,10,13,14,16,17 done; F-18 partial. Remaining gated on you: F-4 (ruff-cleanup decision), F-5 (versioning), F-8 (GIF), F-11 (pricing), F-12 (Discord), F-15 (pyproject, deferred). |
-| B — Projects (+ Pilot) | 7 | ✅ **Audit done** (`docs/audits/PHASE-1-PROJECTS-PILOT.md`, 20 findings: 3 CRITICAL/6 HIGH/7 MEDIUM/4 LOW). Fix-PRs (Wave 7) not started. **Pilot half deferred** — needs the `~/codec/pilot/` checkout. |
+| B — Projects (+ Pilot) | 7 | ✅ Audit done (20 findings). **Wave 7 fixes in progress: B-1 ✅ (PR-7A); B-2/B-3 next.** **Pilot half deferred** — needs the `~/codec/pilot/` checkout. |

--- a/docs/PR7A-STRICT-CONSENT-DESIGN.md
+++ b/docs/PR7A-STRICT-CONSENT-DESIGN.md
@@ -1,0 +1,91 @@
+# PR-7A — fix the phantom destructive-consent gate (Audit B / B-1)
+
+> Wave 7 (Audit B burn-down). Closes **B-1** — the highest-confidence CRITICAL
+> from `docs/audits/PHASE-1-PROJECTS-PILOT.md`. Reference: that doc, §B-1.
+
+## What's broken (verified)
+
+`codec_agent_runner._strict_consent` (the destructive-op consent gate for the
+autonomous agent) does:
+
+```python
+from codec_ask_user import strict_consent_gate   # ← does NOT exist
+```
+
+`codec_ask_user` exposes no `strict_consent_gate` (confirmed: defined nowhere;
+only a `MagicMock` in `tests/test_agent_runner.py`). In production the import
+raises `ImportError`, the `except` returns `ConsentResult(approved=False,
+timed_out=True, user_response="ask_user_unavailable")`, so:
+
+- a destructive op the LLM **does** flag (`is_destructive=true`) is **never
+  actually shown to the user** — it dead-ends at `blocked_on_destructive`;
+- the literal-verb consent prompt the Step-3 §1.7 design promises **never runs**.
+
+It survived because every test mocks the `_strict_consent` *wrapper*, never the
+real body (B-1's own observation).
+
+## The fix
+
+Rewire `_strict_consent` to the **real** API, `codec_ask_user.ask(...)`, which
+already implements §1.7 strict-consent (literal-verb match, generic "yes"
+rejected, two-strike → `ambiguous_consent` timeout) on the reply path
+(`submit_answer`):
+
+```python
+answer = codec_ask_user.ask(
+    question,
+    destructive=True,
+    destructive_verb="confirm",
+    timeout=deadline,
+    agent=action.agent or "agent",
+    asked_from="crew",
+    tool_name=action.skill,
+)
+```
+
+Return contract of `ask()` (read from source):
+- **answered** (in `destructive=True` mode the question only reaches
+  `answered` when the reply contained the verb) → returns the answer string →
+  **approved**.
+- timeout / two-strike ambiguous-consent → returns `TIMEOUT_SENTINEL` → **not
+  approved, `timed_out=True`** (caller → `blocked_on_destructive`, fail-safe).
+- `ASKUSER_ENABLED=false` → returns `DISABLED_SENTINEL` → treat as **not
+  approved, `timed_out=True`** (blocked, never auto-approve).
+
+Mapping → `ConsentResult`:
+
+| `ask()` returns | approved | timed_out |
+|---|---|---|
+| `TIMEOUT_SENTINEL` | False | True |
+| `DISABLED_SENTINEL` | False | True |
+| any other string (verb-matched answer) | True | False |
+
+**Verb:** `"confirm"` — the framework's sanctioned non-generic default
+(`_default_destructive_verb` fallback); generic "yes"/"ok" are still rejected by
+`ask()`'s §1.7 logic. The question text instructs typing `confirm`.
+
+## Scope
+
+- Only `_strict_consent`'s body changes. `ConsentResult`,
+  `_enforce_destructive_gate`, the caller in `_execute_checkpoint`, and the
+  `blocked_on_destructive` state machine are **unchanged**.
+- Existing consent tests mock `_strict_consent` at the wrapper level → unaffected.
+- **Not in scope:** B-2 (gate trusts LLM-self-declared flags) is the separate,
+  larger PR-7B; this PR makes the consent prompt *function* for flagged ops.
+
+## Test plan (`tests/test_strict_consent_fix.py`)
+
+Red→green, exercising the **real** `_strict_consent` (the gap B-1 left):
+- verb-matched answer (mock `codec_ask_user.ask` → `"confirm"`) → `approved=True`,
+  `timed_out=False`, and `ask` was called with `destructive=True`.
+- `ask` → `TIMEOUT_SENTINEL` → `approved=False, timed_out=True`.
+- `ask` → `DISABLED_SENTINEL` → `approved=False, timed_out=True` (blocked, not approved).
+- **regression guard:** `inspect.getsource(_strict_consent)` does NOT reference
+  `strict_consent_gate`, and `codec_ask_user` has no such attribute (so the
+  phantom can't return).
+
+Plus: full `test_agent_runner.py` (51 tests) stays green (they mock the wrapper).
+
+## Rollback
+
+Single-function change in `codec_agent_runner.py` + one new test. `git revert`.

--- a/docs/audits/PHASE-1-PROJECTS-PILOT.md
+++ b/docs/audits/PHASE-1-PROJECTS-PILOT.md
@@ -25,6 +25,9 @@ Four read-only specialist passes over the four modules + their six test files (`
 ## Findings
 
 ### B-1 — Destructive-consent gate imports a non-existent function [CRITICAL]
+
+> **✅ FIXED by PR-7A (2026-05-24).** `_strict_consent` now routes through the real `codec_ask_user.ask(destructive=True, destructive_verb="confirm", …)` and maps its return (`TIMEOUT_SENTINEL`/`DISABLED_SENTINEL` → blocked, never approved; verb-matched answer → approved). Fail-safe: any error/timeout/disabled → not approved. 4 regression tests (`tests/test_strict_consent_fix.py`) exercise the **real** body (the gap B-1 left) + assert the phantom symbol can't return; the 51 existing runner tests stay green. *(B-2 — the gate trusting LLM-self-declared flags — is the separate PR-7B and is what makes this consent prompt actually fire for currently-unflagged ops.)*
+
 **What:** `codec_agent_runner.py:529` does `from codec_ask_user import strict_consent_gate`, but `codec_ask_user` exposes no such symbol (only `ask()` / `submit_answer()`); it exists solely as a mock in `tests/test_agent_runner.py`. **Verified.**
 **Why it matters:** in production the import raises, `_strict_consent` returns not-approved, and any destructive op the LLM *does* flag gets stuck on `blocked_on_destructive` — while the literal-verb consent prompt the design promises **never actually runs**. The gate is dead code kept green by a test mock.
 **Fix:** call the real `codec_ask_user.ask(..., destructive=True, destructive_verb=<server-chosen>)`; add an import-time smoke test so a missing symbol fails CI instead of being mocked away.

--- a/tests/test_strict_consent_fix.py
+++ b/tests/test_strict_consent_fix.py
@@ -1,0 +1,70 @@
+"""Tests for PR-7A (Audit B / B-1) — the destructive-consent gate must call the
+REAL codec_ask_user.ask, not a non-existent `strict_consent_gate`.
+
+These exercise the real `_strict_consent` body (the gap B-1 left: every existing
+test mocks the wrapper, so the phantom import was never hit).
+
+Reference: docs/PR7A-STRICT-CONSENT-DESIGN.md, docs/audits/PHASE-1-PROJECTS-PILOT.md (B-1).
+"""
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path[:] = [p for p in sys.path if p != str(REPO)]
+sys.path.insert(0, str(REPO))
+
+import codec_agent_runner as car  # noqa: E402
+import codec_ask_user  # noqa: E402
+
+
+def _destructive_action():
+    return car.Action(skill="file_ops", task="delete ~/Documents/old.txt", is_destructive=True)
+
+
+def _recording_ask(return_value):
+    calls = []
+
+    def fake_ask(question, **kwargs):
+        calls.append({"question": question, **kwargs})
+        return return_value
+
+    fake_ask.calls = calls
+    return fake_ask
+
+
+def test_strict_consent_approved_on_verb_match(monkeypatch):
+    ask = _recording_ask("confirm")  # verb-matched answer ⇒ ask() returns the answer
+    monkeypatch.setattr(codec_ask_user, "ask", ask)
+    res = car._strict_consent(_destructive_action())
+    assert res.approved is True, "verb-matched consent must approve"
+    assert res.timed_out is False
+    assert ask.calls, "must actually call codec_ask_user.ask"
+    assert ask.calls[0].get("destructive") is True, "must call ask in destructive mode"
+
+
+def test_strict_consent_timeout_maps_to_blocked(monkeypatch):
+    ask = _recording_ask(codec_ask_user.TIMEOUT_SENTINEL)
+    monkeypatch.setattr(codec_ask_user, "ask", ask)
+    res = car._strict_consent(_destructive_action())
+    assert ask.calls, "must call ask"
+    assert res.approved is False and res.timed_out is True
+
+
+def test_strict_consent_disabled_is_blocked_never_approved(monkeypatch):
+    ask = _recording_ask(codec_ask_user.DISABLED_SENTINEL)
+    monkeypatch.setattr(codec_ask_user, "ask", ask)
+    res = car._strict_consent(_destructive_action())
+    assert ask.calls, "must call ask"
+    assert res.approved is False, "ask_user disabled must NEVER auto-approve a destructive op"
+    assert res.timed_out is True
+
+
+def test_no_phantom_strict_consent_gate():
+    # B-1 regression guard: the wrapper must not reference the non-existent symbol,
+    # and the symbol genuinely does not exist in codec_ask_user.
+    src = inspect.getsource(car._strict_consent)
+    assert "strict_consent_gate" not in src, "must not import the phantom strict_consent_gate"
+    assert not hasattr(codec_ask_user, "strict_consent_gate"), "phantom symbol must stay absent"


### PR DESCRIPTION
## Summary
Closes **Audit-B CRITICAL B-1** — the first Wave-7 fix.

`codec_agent_runner._strict_consent` imported `codec_ask_user.strict_consent_gate`, **a symbol that exists nowhere** (only a test mock). In production the import raised → the gate returned not-approved → the §1.7 **literal-verb consent prompt never actually ran**. It survived because every test mocks the `_strict_consent` *wrapper*.

**Fix:** route through the **real** `codec_ask_user.ask(destructive=True, destructive_verb="confirm", …)` (which already implements §1.7 verb-match / two-strike on the reply path) and map its return:

| `ask()` returns | result |
|---|---|
| `TIMEOUT_SENTINEL` / `DISABLED_SENTINEL` | **blocked** (`approved=False, timed_out=True`) |
| verb-matched answer | **approved** |
| any exception | **blocked** (fail-safe — never auto-approve) |

## Test plan
- [x] `tests/test_strict_consent_fix.py` (4) — exercises the **real** `_strict_consent` (verb-match→approved, timeout/disabled→blocked) + a regression guard that the phantom symbol can't return. This is the path B-1 left untested.
- [x] The **51 existing `test_agent_runner.py` tests stay green** (they mock the wrapper).
- [x] `ruff` delta clean (−1 pre-existing F541); full suite **41 baseline failures unchanged** (1,636 passed).

## Scope
Only `_strict_consent`'s body changes; `ConsentResult` / `_enforce_destructive_gate` / the `blocked_on_destructive` state machine are untouched. **B-2** (the gate trusting LLM-self-declared flags — the bigger fix that makes this prompt fire for currently-unflagged ops) is the next PR (7B).

> Branched off `main` (Audit B #113 in). Touches the agent daemon — design-first (`docs/PR7A-STRICT-CONSENT-DESIGN.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)