### PR TITLE
fix(pilot-skill): send x-pilot-token to the now-authed Pilot API (PP-1 pair)

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -54,7 +54,7 @@
     "notification_reader.py": "7fbff9f9063c39b0c4c0ea2568ecaab352c1fc4911382f3dd347f601b4a75e59",
     "password_generator.py": "8affc3dcaaa57301fb808fd1600fc6b57a7d579c2b2fffb9513732e7db436c94",
     "philips_hue.py": "bcc2ef1b7e6c0e5e5f0165aae397fd6a3fd27367a3f100b949cd0efddac43496",
-    "pilot.py": "33fe0a8cb1f3f577f3ddf801ad6d4e1cb3c9ceae8e6b748edd29ef33149ec1c7",
+    "pilot.py": "09d004ebe147023d95a8f22ebcdf652633f7760862304822717412ad91a64040",
     "plugin_approve.py": "c93861353be2a9ebe08df212ca167bea646962dbeafe704b1864cd78a8cf57cc",
     "pm2_control.py": "1f67e3158920987c1f0d2452fcadd7405624b28a799297483a2d11f5d5c90d17",
     "pomodoro.py": "6c438ca3ce37afd10e9e96d3bc848e9e9407298761b06543b0aa00010317092d",

--- a/skills/pilot.py
+++ b/skills/pilot.py
@@ -35,12 +35,25 @@ _BASE = "http://localhost:8094"
 _TIMEOUT = 15
 
 
+def _pilot_token() -> str:
+    """Pilot PP-1: the shared secret the pilot-runner requires on every request
+    (header `x-pilot-token`). Both sides read ~/.codec/pilot_token; pilot-runner
+    bootstraps it on startup. Empty if Pilot has never run → request 401s."""
+    import os
+    try:
+        with open(os.path.expanduser("~/.codec/pilot_token")) as f:
+            return f.read().strip()
+    except Exception:
+        return ""
+
+
 # ── HTTP helpers ──────────────────────────────────────────────────────────────
 
 def _get(path: str) -> dict:
     url = _BASE + path
+    req = urllib.request.Request(url, headers={"x-pilot-token": _pilot_token()})
     try:
-        with urllib.request.urlopen(url, timeout=_TIMEOUT) as r:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as r:
             return json.loads(r.read())
     except urllib.error.HTTPError as e:
         body = e.read().decode(errors="replace")
@@ -54,7 +67,7 @@ def _post(path: str, body: dict | None = None) -> dict:
     data = json.dumps(body or {}).encode()
     req = urllib.request.Request(
         url, data=data,
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", "x-pilot-token": _pilot_token()},
         method="POST",
     )
     try:


### PR DESCRIPTION
## Summary
Paired codec-repo half of **Pilot PP-1** (audit P-1 — the live unauthenticated RCE, already emergency-stopped). The Pilot `pilot-runner` now requires an `x-pilot-token` header on every `:8094` request (loopback bind + CORS lockdown too; committed in the separate `~/codec` Pilot repo). This change makes the parent engine's Pilot skill send that token so it can still drive Pilot once it's safely restarted:

- `skills/pilot.py` reads the shared secret from `~/.codec/pilot_token` (bootstrapped by `pilot-runner`) and sends `x-pilot-token` on every `_get`/`_post`.
- Token read is a **function-local import** (no new module-level import → zero ruff E402 delta).
- `skills/.manifest.json` regenerated for the `pilot.py` edit (PR-1A hash-pin); `--check` passes.

⚠️ **Pilot stays stopped** until its own fix wave (PP-2…PP-5) lands; this PR just keeps the integration correct.

## Test plan
- [x] `skills/pilot.py` parses + imports; `_pilot_token` present; `run` callable.
- [x] Manifest `--check` passes (no drift).
- [x] Full suite: **41 failed / 1730 passed** — zero new failures vs the 41-failed baseline.
- [x] Ruff delta zero on `skills/pilot.py` (6=6).

Pilot-side fix + design: `~/codec/pilot/` (`pilot_runner.py`, `pilot/docs/PP1-API-AUTH-DESIGN.md`). Audit: `docs/audits/PHASE-1-PILOT-AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)