### PR TITLE
feat(packaging): F-15 — pyproject.toml project metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           tests/test_apple_packaging.py
           tests/test_dependabot.py
           tests/test_versioning.py
+          tests/test_pyproject.py
       - name: Apple packaging tests (W5 — bundle, launchd, python, models, sign, notarize, uninstall, release)
         run: >
           python -m pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ codec_smoke_test.py
 
 # macOS .app build output (W5-2)
 dist/
+
+# Python build artifacts (F-15 pyproject — `pip wheel` / `python -m build`)
+build/
+*.egg-info/
+*.egg
+*.whl

--- a/docs/F15-PYPROJECT-DESIGN.md
+++ b/docs/F15-PYPROJECT-DESIGN.md
@@ -1,0 +1,42 @@
+# F-15 — pyproject.toml (project metadata)
+
+**Closes:** Investor-readiness audit **F-15** (no Python project metadata; version not
+introspectable). **Repo:** codec-repo. **Greenlit by Mickael 2026-05-25.**
+
+## The honest constraint
+CODEC is an **application run via PM2 from a checkout**, not a pip-installable library:
+- 57 flat `codec_*.py` modules that import each other as top-level names (no `src/` layout).
+- `skills/` is a **runtime-loaded directory** (no `__init__.py`) — the SkillRegistry AST-loads
+  files from it + `~/.codec/skills/` at runtime; they are not package data.
+
+So a pyproject that claims to vendor all 57 flat modules into a wheel would be both fiddly and
+misleading. F-15 instead delivers what actually has value: **declarative, introspectable
+project metadata + a single dependency manifest + a valid modern build-system** — the
+"this is a real, maintained project" signal investors/enterprises look for — without faking
+library distribution.
+
+## What ships
+`pyproject.toml`:
+- **`[project]`** — name, description, `license = MIT`, `requires-python = ">=3.10"` (matches
+  the README claim), authors, keywords, trove classifiers (incl. Python 3.10–3.13), URLs.
+- **`dynamic = ["version"]`** ← `[tool.setuptools.dynamic] version = {file = "VERSION"}`, so the
+  version flows from the **F-5 single source of truth** (no second place to bump).
+- **`dependencies`** — the core runtime set mirrored from `requirements.txt`; the optional
+  stacks (TTS / STT / Google) become `[project.optional-dependencies]` extras.
+- **`[build-system]`** — setuptools; **`[tool.setuptools] py-modules = []`** documents that the
+  flat modules are intentionally not vendored (keeps the metadata build valid, avoids
+  flat-layout auto-discovery errors).
+
+`pytest.ini` is left as-is (test discovery config); the F-4 ruff config stays in `ruff.toml`
+(ruff prefers `ruff.toml` over `[tool.ruff]` in pyproject, so they don't conflict).
+
+## Verification
+- `tests/test_pyproject.py` (5 tests, stdlib `tomllib`) — pins the `[project]` shape, the
+  build-system, dynamic-version-from-VERSION, the core deps, and the `>=3.10` claim. CI-gated.
+- **Builds a valid wheel**: `pip wheel . --no-deps` →
+  `codec-2.3.0-py3-none-any.whl` (version resolved from VERSION). So the metadata + build-system
+  are correct, not just well-formed text.
+
+## Not done (deliberate)
+- Full library packaging of the 57 flat modules — CODEC isn't consumed as `import codec`; see
+  the constraint above. If CODEC is ever refactored to a `src/codec/` package, revisit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codec"
+dynamic = ["version"]                       # ← VERSION file (F-5 single source of truth)
+description = "CODEC — the engine behind the Sovereign AI Workstation: a voice-controlled, local-first AI agent for macOS."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+authors = [{ name = "AVA Digital LLC", email = "ava.dsa25@proton.me" }]
+keywords = ["ai-agent", "voice-assistant", "local-first", "mcp", "macos", "automation"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: MacOS X",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Office/Business",
+    "Topic :: Multimedia :: Sound/Audio :: Speech",
+]
+# Core runtime deps (mirrors requirements.txt). Optional stacks are extras below.
+dependencies = [
+    "pynput>=1.8.2",
+    "sounddevice>=0.4.6",
+    "soundfile>=0.12.1",
+    "numpy>=2.4.6",
+    "requests>=2.34.2",
+    "simple-term-menu>=1.6.6",
+    "httpx>=0.28.1",
+    "fastmcp>=0.1.0",
+]
+
+[project.optional-dependencies]
+tts = ["mlx-audio", "misaki", "num2words", "phonemizer-fork", "spacy"]
+stt = ["mlx-whisper", "fastapi", "uvicorn"]
+google = ["google-auth", "google-auth-oauthlib", "google-api-python-client"]
+
+[project.urls]
+Homepage = "https://avadigital.ai"
+Repository = "https://github.com/AVADSA25/codec"
+Changelog = "https://github.com/AVADSA25/codec/blob/main/CHANGELOG.md"
+
+[tool.setuptools.dynamic]
+version = { file = "VERSION" }
+
+[tool.setuptools]
+# CODEC is an APPLICATION run via PM2 from a checkout — NOT a pip-installable library.
+# The 57 flat `codec_*.py` modules import each other as top-level names, and `skills/` is a
+# runtime-loaded directory (no __init__.py), not a package. This file therefore declares
+# project metadata + the dependency set (introspectable, modern-packaging signal) and
+# deliberately does not vendor the flat modules into a wheel. Run CODEC from the repo per
+# README → "Professional Setup". (py-modules = [] keeps the metadata build valid without
+# triggering flat-layout auto-discovery errors.)
+py-modules = []

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,0 +1,58 @@
+"""F-15 — pyproject.toml provides modern, introspectable project metadata.
+
+CODEC is an application run via PM2 from a checkout (57 flat codec_*.py modules; skills/ is
+runtime-loaded, not a package), so pyproject is a metadata + dependency declaration, not a
+distributable wheel of the flat modules. These tests pin the metadata shape + tie the version
+to the F-5 single source of truth (VERSION). Stdlib-only (tomllib) → green on the CI runner.
+
+Reference: docs/F15-PYPROJECT-DESIGN.md.
+"""
+import sys
+import tomllib
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+
+def _load():
+    with open(_REPO / "pyproject.toml", "rb") as f:
+        return tomllib.load(f)
+
+
+def test_pyproject_has_project_metadata():
+    d = _load()
+    p = d["project"]
+    assert p["name"] == "codec"
+    assert p["description"]
+    assert "MIT" in str(p["license"])
+    assert p["requires-python"]
+    assert p["authors"]
+    assert p["urls"]["Repository"].endswith("/codec")
+
+
+def test_pyproject_has_valid_build_system():
+    d = _load()
+    assert d["build-system"]["build-backend"] == "setuptools.build_meta"
+    assert any("setuptools" in r for r in d["build-system"]["requires"])
+
+
+def test_pyproject_version_is_dynamic_from_VERSION_file():
+    d = _load()
+    assert "version" in d["project"]["dynamic"], "version must be dynamic"
+    assert d["tool"]["setuptools"]["dynamic"]["version"]["file"] == "VERSION"
+    # VERSION must exist and match the F-5 single source of truth
+    assert (_REPO / "VERSION").read_text(encoding="utf-8").strip() == "2.3.0"
+
+
+def test_pyproject_declares_core_runtime_dependencies():
+    d = _load()
+    deps = " ".join(d["project"]["dependencies"])
+    for pkg in ("pynput", "httpx", "fastmcp", "requests", "numpy"):
+        assert pkg in deps, f"core dependency {pkg} not declared"
+
+
+def test_pyproject_requires_python_matches_readme_claim():
+    """README claims 3.10+; pyproject must agree."""
+    d = _load()
+    assert ">=3.10" in d["project"]["requires-python"]


### PR DESCRIPTION
## Summary
Closes **F-15** (no introspectable project metadata). **You greenlit it.**

**Honest scope:** CODEC is an application run via PM2 from a checkout — 57 flat `codec_*.py` modules that import each other top-level, and `skills/` is a runtime-loaded directory (not a package). So this is a **metadata + dependency declaration**, not a faked library wheel of the flat modules.

- **`[project]`** — name, description, MIT license, `requires-python >=3.10` (matches the README), authors, keywords, trove classifiers (3.10–3.13), URLs.
- **dynamic version** ← `VERSION` file (the F-5 single source of truth — no second bump site).
- **dependencies** mirrored from `requirements.txt`; TTS / STT / Google as `optional-dependencies` extras.
- **`[build-system]`** setuptools; `py-modules = []` documents the intentional non-vendoring.

## Verification
- `tests/test_pyproject.py` (5 tests, stdlib `tomllib`, CI-gated) — pins the metadata shape, build-system, dynamic-version-from-VERSION, core deps, and the `>=3.10` claim.
- **Builds a valid wheel**: `pip wheel . --no-deps` → `codec-2.3.0-py3-none-any.whl` (version resolved from VERSION) — proves the metadata + build-system are correct, not just well-formed.

See `docs/F15-PYPROJECT-DESIGN.md`.

## Test plan
- [ ] CI green (new `test_pyproject` gated in the doc-guard job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)