### PR TITLE
chore: add requirements-dev.txt for contributor test setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,17 @@ tests/                — 1,300+ pytest tests (1,386 functions across 99 files)
 
 ## Running Tests
 
+First install the dev/test dependencies (macOS):
+
+```bash
+pip install -r requirements-dev.txt   # runtime deps + pytest + ruff
+```
+
+Then:
+
 ```bash
 python3 -m pytest           # All tests
 python3 -m pytest -v        # Verbose
 python3 -m pytest -k "test_skills"  # Specific file
+ruff check .                # Lint (same gate as CI)
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+# CODEC — development & test dependencies.
+#
+# Install (on macOS, alongside a working CODEC checkout) with:
+#   pip install -r requirements-dev.txt
+#
+# This pulls the runtime deps (so the modules under test import cleanly) plus the
+# test runner and linter. CODEC is a macOS-first app, so the audio deps in
+# requirements.txt (sounddevice/soundfile) expect the platform's PortAudio/libsndfile.
+# CI (.github/workflows/ci.yml) installs a curated subset that runs on Linux instead.
+
+-r requirements.txt
+
+# Test + lint toolchain (matches CI)
+pytest>=8.0
+ruff>=0.10


### PR DESCRIPTION
## Summary
Closes the last F-15 dev-deps sliver. CONTRIBUTING tells contributors to run `pytest`, but there was no dependency manifest — a fresh clone hit `ModuleNotFoundError`.

- **`requirements-dev.txt`** — `-r requirements.txt` (runtime deps so modules import) + `pytest` + `ruff`.
- **CONTRIBUTING.md** — "Running Tests" now starts with `pip install -r requirements-dev.txt` and mentions `ruff check .` (the CI lint gate).

CI keeps its curated Linux-installable subset (this file's audio deps are macOS-first), so nothing changes on the runner.

## Verification
- Doc-guards (`test_repo_health`, `test_readme_investor`) pass.
- Additive only; no runtime/CI behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)