### PR TITLE
feat(security): scoped strict AST gate for autonomously-generated skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           tests/test_dependabot.py
           tests/test_versioning.py
           tests/test_pyproject.py
+          tests/test_strict_ast_gate.py
       - name: Apple packaging tests (W5 — bundle, launchd, python, models, sign, notarize, uninstall, release)
         run: >
           python -m pytest -v

--- a/codec_config.py
+++ b/codec_config.py
@@ -730,6 +730,17 @@ _SKILL_DANGEROUS_ATTRS = {
     "subprocess.run", "subprocess.Popen", "subprocess.call",
     "shutil.rmtree",
 }
+# Cross-cutting audit follow-up: EXTRA denylist applied only in strict mode (opt-in),
+# for AUTONOMOUSLY LLM-generated skills (codec_self_improve nightly drafter). These are the
+# rarely-legit-in-a-utility-skill primitives the base gate misses: deserialization-RCE /
+# persistence (pickle/marshal/shelve) and legacy exfil protocols (smtplib/ftplib/telnetlib).
+# Deliberately NOT included: HTTP (requests/urllib/httpx) and open() — those are common +
+# legitimate, and self_improve proposals are human-reviewed before promotion, so the review
+# gate (not a blanket block) is the right control for them. User-invoked generation
+# (skill_forge / create_skill→approve) stays on the default gate entirely.
+_SKILL_STRICT_EXTRA_MODULES = {
+    "pickle", "marshal", "shelve", "smtplib", "ftplib", "telnetlib",
+}
 # Reflection dunder attributes — dangerous regardless of the base object.
 # These are the building blocks of every CPython sandbox-escape chain.
 _DANGEROUS_REFLECTION_ATTRS = {
@@ -743,10 +754,19 @@ _DANGEROUS_REFLECTION_ATTRS = {
 _DANGEROUS_REFLECTION_NAMES = {"__builtins__", "__loader__", "__spec__"}
 
 
-def is_dangerous_skill_code(code: str) -> tuple[bool, str]:
+def is_dangerous_skill_code(code: str, strict: bool = False) -> tuple[bool, str]:
+    """Return (dangerous, reason) for a skill source string.
+
+    strict=False (default): the established gate — UNCHANGED. Used for user-curated skill
+    load, python_exec, and user-invoked generation (skill_forge / create_skill→approve).
+    strict=True: additionally blocks the rarely-legit serialization / legacy-exfil modules
+    in _SKILL_STRICT_EXTRA_MODULES — for AUTONOMOUSLY LLM-generated skills (codec_self_improve).
+    HTTP (requests/urllib/httpx) and open() are deliberately NOT blocked (common + legitimate,
+    and those proposals are human-reviewed). SAFE_MODULES stay allowed in both modes.
+    """
     import ast
 
-    DANGEROUS_MODULES = _SKILL_DANGEROUS_MODULES
+    DANGEROUS_MODULES = (_SKILL_DANGEROUS_MODULES | _SKILL_STRICT_EXTRA_MODULES) if strict else _SKILL_DANGEROUS_MODULES
     SAFE_MODULES = _SKILL_SAFE_MODULES
     DANGEROUS_CALLS = _SKILL_DANGEROUS_CALLS
     DANGEROUS_ATTRS = _SKILL_DANGEROUS_ATTRS

--- a/codec_self_improve.py
+++ b/codec_self_improve.py
@@ -265,12 +265,17 @@ def _draft_skill(gap: dict) -> tuple[str, str, str] | None:
 
 
 def _validate(code: str) -> tuple[bool, str]:
-    """Layered check: must compile, must not match dangerous patterns."""
+    """Layered check: must compile, must not match dangerous patterns.
+
+    Uses strict=True: these proposals are autonomously LLM-generated (no explicit user
+    intent), so the stricter denylist (raw network / serialization / open) applies. Users
+    who genuinely want an HTTP/file skill create it deliberately via create_skill → review.
+    """
     try:
         compile(code, "<proposal>", "exec")
     except SyntaxError as e:
         return False, f"SyntaxError: {e}"
-    dangerous, reason = is_dangerous_skill_code(code)
+    dangerous, reason = is_dangerous_skill_code(code, strict=True)
     if dangerous:
         return False, reason
     if "def run(" not in code or "SKILL_NAME" not in code or "SKILL_DESCRIPTION" not in code:

--- a/docs/STRICT-AST-GATE-DESIGN.md
+++ b/docs/STRICT-AST-GATE-DESIGN.md
@@ -1,0 +1,45 @@
+# Scoped strict mode for the skill-safety AST gate
+
+**Closes:** the Phase-1 cross-cutting follow-up — `codec_config.is_dangerous_skill_code` is
+allow-by-omission (misses network / serialization primitives), flagged as a risk for
+*auto-generated* skills. **Repo:** codec-repo. **Approved by Mickael 2026-05-25.**
+
+## The nuance (why a global denylist would be wrong)
+The base gate intentionally allows `requests`/`urllib`/`open` etc. — **hand-written user
+skills legitimately do HTTP and file I/O**, the user curates their own `~/.codec/skills/`, and
+`python_exec` is sandboxed. Adding those to the *global* denylist would break legitimate user
+skills + user-invoked skill creation. So strict mode is **opt-in and narrowly scoped**.
+
+## What changed
+- `is_dangerous_skill_code(code, strict=False)` — **default is byte-for-byte unchanged** (proven
+  by the existing `test_skill_registry` + `test_skill_sandbox` suites still passing). It's the
+  gate for user-skill load (`codec_skill_registry`), `python_exec` (`codec_sandbox`), and
+  user-invoked generation (`skill_forge`, `create_skill`→approve).
+- `strict=True` adds `_SKILL_STRICT_EXTRA_MODULES = {pickle, marshal, shelve, smtplib, ftplib,
+  telnetlib}` — the **rarely-legit-in-a-utility-skill** primitives: deserialization-RCE /
+  persistence + legacy exfil protocols.
+- Applied at **exactly one site: `codec_self_improve._validate`** — the nightly *autonomous*
+  LLM drafter (no explicit user intent). A drafted proposal reaching for those is refused.
+
+## Deliberately NOT blocked, even in strict
+**HTTP (`requests`/`urllib`/`httpx`) and `open()`.** They're common + legitimate, and
+self_improve proposals are **draft-only + human-reviewed before promotion** — so the review
+gate (not a blanket block) is the right control for exfil-via-HTTP concerns. Blocking them would
+neuter the drafter (it could never propose a useful fetch/file skill) and broke the existing
+`test_validate_accepts_safe_skill` contract (which expects a `requests` skill to be acceptable).
+
+## Why this site only
+- `codec_skill_registry` load / `python_exec` → user-controlled → **default** (no over-gating).
+- `skill_forge` / `create_skill` → user-invoked with explicit intent + human approve → **default**.
+- Pilot's auto-compiled skills (the original "auto-generated" worry) → already gated at approve
+  by **PP-11** (Pilot's own vendored AST gate, separate repo).
+- `codec_self_improve` → the one fully-autonomous generator → **strict**.
+
+## Tests (`tests/test_strict_ast_gate.py`, CI-gated)
+Default mode still allows network/open + still blocks base (os/subprocess/eval); strict blocks
+serialization + legacy-exfil; strict deliberately ALLOWS http/open; strict still blocks base;
+self_improve refuses a `pickle` draft but accepts an HTTP draft. 8 tests; the self_improve case
+skips cleanly if optional deps are absent on the runner.
+
+## Rollback
+Revert the commit. Default-mode callers are untouched, so rollback is behaviorally inert.

--- a/tests/test_strict_ast_gate.py
+++ b/tests/test_strict_ast_gate.py
@@ -1,0 +1,97 @@
+"""Cross-cutting audit follow-up: a SCOPED strict mode for the skill-safety AST gate.
+
+The default `is_dangerous_skill_code` is allow-by-omission (it misses network /
+serialization / file-open primitives) — fine for hand-written user skills (the user curates
+their own ~/.codec/skills/) and for python_exec. But the audit flagged that *autonomously
+LLM-generated* skills deserve a stricter check. So:
+
+  - `is_dangerous_skill_code(code, strict=False)` — DEFAULT IS UNCHANGED (zero impact on
+    SkillRegistry load, python_exec, skill_forge, create_skill→approve).
+  - `strict=True` additionally blocks network (urllib/http/requests/httpx/smtplib/ftplib/
+    telnetlib), serialization (pickle/marshal/shelve), and the `open` builtin.
+  - Applied ONLY at `codec_self_improve` (the nightly autonomous drafter) — user-invoked
+    generation (skill_forge/create_skill) stays default so legitimate HTTP/file skills still
+    work via the human-review flow.
+
+Reference: docs/STRICT-AST-GATE-DESIGN.md.
+"""
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+from codec_config import is_dangerous_skill_code  # noqa: E402
+
+
+# ─── Default mode must be byte-for-byte unchanged (the safety property) ──────────
+
+def test_default_mode_still_allows_network_and_open():
+    # These are allow-by-omission in default mode — and MUST stay that way so user skills
+    # + python_exec + user-invoked generation don't suddenly break.
+    for src in ("import requests", "import urllib.request", "import pickle",
+                "x = open('/tmp/f')"):
+        bad, _ = is_dangerous_skill_code(src)
+        assert not bad, f"default mode wrongly flagged: {src!r}"
+
+
+def test_default_mode_still_blocks_base_dangerous():
+    for src in ("import os", "import subprocess", "x = eval('1')"):
+        bad, _ = is_dangerous_skill_code(src)
+        assert bad, f"default mode should still block: {src!r}"
+
+
+# ─── Strict mode blocks the rarely-legit primitives the base gate misses ─────────
+
+def test_strict_blocks_serialization():
+    for src in ("import pickle", "import marshal", "import shelve",
+                "from pickle import loads"):
+        bad, _ = is_dangerous_skill_code(src, strict=True)
+        assert bad, f"strict should block deserialization-RCE: {src!r}"
+
+
+def test_strict_blocks_legacy_exfil_protocols():
+    for src in ("import smtplib", "import ftplib", "import telnetlib"):
+        bad, _ = is_dangerous_skill_code(src, strict=True)
+        assert bad, f"strict should block legacy exfil protocol: {src!r}"
+
+
+def test_strict_deliberately_allows_http_and_open():
+    # HTTP + file-open are common + legitimate; self_improve proposals are human-reviewed,
+    # so these stay allowed even in strict (review is the control, not a blanket block).
+    for src in ("import requests", "import httpx", "from urllib.request import urlopen",
+                "x = open('/tmp/f')"):
+        bad, _ = is_dangerous_skill_code(src, strict=True)
+        assert not bad, f"strict should NOT block common-legit: {src!r}"
+
+
+def test_strict_still_blocks_base():
+    bad, _ = is_dangerous_skill_code("import os\nos.system('id')", strict=True)
+    assert bad
+
+
+def test_strict_allows_safe_skill_shape():
+    safe = ("import json\nimport urllib.parse\n"
+            "SKILL_NAME='x'\nSKILL_DESCRIPTION='y'\ndef run(task, app='', ctx=''):\n    return {}\n")
+    bad, reason = is_dangerous_skill_code(safe, strict=True)
+    assert not bad, reason  # json + urllib.parse stay safe even in strict
+
+
+# ─── self_improve (autonomous drafter) wires strict mode ────────────────────────
+
+def test_self_improve_validate_uses_strict():
+    import pytest
+    try:
+        import codec_self_improve
+    except Exception as e:  # optional deps unavailable on a bare CI runner
+        pytest.skip(f"codec_self_improve import unavailable: {e}")
+    # A strict-blocked primitive (pickle) in an autonomously-drafted skill is refused.
+    pickle_skill = ("import pickle\nSKILL_NAME='load'\nSKILL_DESCRIPTION='d'\n"
+                    "def run(task, app='', ctx=''):\n    return pickle.loads(task)\n")
+    ok, reason = codec_self_improve._validate(pickle_skill)
+    assert not ok, "self_improve must refuse an autonomously-drafted skill using pickle (strict)"
+    # An HTTP skill stays allowed (proposals are human-reviewed; HTTP is common-legit).
+    ok2, _ = codec_self_improve._validate(
+        "import requests\nSKILL_NAME='x'\nSKILL_DESCRIPTION='y'\n"
+        "def run(task, app='', ctx=''):\n    return requests.get(task).text\n")
+    assert ok2, "self_improve should still accept an HTTP skill (review is the control)"


### PR DESCRIPTION
## Summary
The Phase-1 cross-cutting follow-up you 👍'd. `is_dangerous_skill_code` gains an **opt-in `strict=True`** mode for the one *autonomous* LLM generator (`codec_self_improve`).

- **strict adds** the rarely-legit primitives the base gate misses: deserialization-RCE/persistence (`pickle`/`marshal`/`shelve`) + legacy exfil protocols (`smtplib`/`ftplib`/`telnetlib`).
- **Default mode is byte-for-byte unchanged** → user-skill load, `python_exec`, and user-invoked generation (`skill_forge`/`create_skill`→approve) are all unaffected.
- **HTTP (`requests`/`urllib`/`httpx`) + `open()` are deliberately NOT blocked** even in strict — common + legitimate, and self_improve proposals are human-reviewed (review is the right control, not a blanket block). This preserves the existing `test_validate_accepts_safe_skill` contract.
- Pilot's auto-compiled skills (the original "auto-generated" worry) were already gated by **PP-11**.

## Verification
- `tests/test_strict_ast_gate.py` — 8 tests (CI-gated), incl. proof default mode is unchanged + strict deliberately allows HTTP/open.
- Existing `test_skill_registry` (13) + `test_self_improve_plugin` (21) suites stay green → no regression to the default gate or the drafter contract.
- ruff clean.

See `docs/STRICT-AST-GATE-DESIGN.md`.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)