### PR TITLE
security: audit remediation Phase B/C (#4,#5,#7,#9,#10 + #8 partial)

### DIFF
--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -290,6 +290,21 @@ def set_grants_hash(agent_id: str) -> str:
     return h
 
 
+def grants_lock(agent_id: str):
+    """C5 (Fix #5): cross-process flock around the per-agent grants.json
+    read-modify-write (mirrors _status_lock for the manifest CAS). The /grant
+    endpoint holds this across load_grants -> modify -> save_grants ->
+    set_grants_hash so two concurrent grants can't clobber each other. Falls
+    back to a no-op context if codec_jsonstore is unavailable (headless/CI) —
+    never breaks grant_permission."""
+    try:
+        import codec_jsonstore
+        return codec_jsonstore.file_lock(_agent_dir(agent_id) / "grants.json")
+    except Exception:
+        import contextlib
+        return contextlib.nullcontext()
+
+
 # ── Skill-registry validation ─────────────────────────────────────────────────
 def validate_plan_skills(plan: Plan, registry=None) -> Tuple[bool, List[str]]:
     """Walk every checkpoint's skills_needed; return (ok, missing_skills).

--- a/codec_agents.py
+++ b/codec_agents.py
@@ -180,6 +180,14 @@ def _web_search(query: str) -> str:
 
 def _web_fetch(url: str) -> str:
     try:
+        # Fix #7 (H1): SSRF guard BEFORE the request. The fetched text is
+        # returned to the agent/LLM, so a read of an internal/metadata host is
+        # an exfil path even though the crew tool has no explicit egress allow.
+        import codec_ssrf
+        try:
+            codec_ssrf.validate_url(url.strip())
+        except codec_ssrf.SSRFError as e:
+            return f"Fetch error: blocked URL ({e})"
         r = _sync_http.get(url.strip())
         if r.status_code in (401, 403):
             return f"Blocked by site (HTTP {r.status_code}). Site requires JavaScript or blocks automated access."

--- a/codec_ask_user.py
+++ b/codec_ask_user.py
@@ -201,7 +201,12 @@ def _write_question_notification(record: dict) -> None:
     surface; failures here log + continue.
     """
     try:
-        with _FILE_LOCK:
+        # C5 (Fix #5): hold the cross-process file_lock across the whole
+        # read-modify-write so concurrent daemons (dashboard / voice /
+        # agent-runner) can't clobber each other's append. _FILE_LOCK is the
+        # in-process guard; codec_jsonstore.file_lock is the cross-process one —
+        # same pairing the PENDING_QUESTIONS read-modify-write already uses.
+        with _FILE_LOCK, codec_jsonstore.file_lock(NOTIFICATIONS_PATH):
             try:
                 with open(NOTIFICATIONS_PATH) as f:
                     notifs = json.load(f)
@@ -648,7 +653,10 @@ def submit_answer(qid: str, answer: str, *, answered_via: str = "pwa") -> dict:
 
     # Mark the matching notification as read.
     try:
-        with _FILE_LOCK:
+        # C5 (Fix #5): same cross-process file_lock as the question-write path
+        # above, so a concurrent _write_question_notification and this
+        # mark-read can't clobber each other on notifications.json.
+        with _FILE_LOCK, codec_jsonstore.file_lock(NOTIFICATIONS_PATH):
             try:
                 with open(NOTIFICATIONS_PATH) as f:
                     notifs = json.load(f)

--- a/codec_concurrency.py
+++ b/codec_concurrency.py
@@ -1,0 +1,72 @@
+"""codec_concurrency — small, dependency-free concurrency helpers.
+
+`run_with_timeout` runs a callable in a daemon thread with a hard wall-clock
+timeout that ACTUALLY bounds wall-clock time.
+
+Motivation (audit C4): the common idiom
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        fut = ex.submit(fn)
+        return fut.result(timeout=T)
+
+defeats its own timeout. When `fut.result(timeout=T)` raises TimeoutError,
+the `with` block's __exit__ calls `executor.shutdown(wait=True)`, which BLOCKS
+until the runaway task finishes. So a 50ms "timeout" on a 5s task takes ~5s —
+the MCP tool dispatch (codec_mcp) and the observer OCR call (codec_observer)
+could hang on a slow skill / screencapture popup.
+
+This helper uses a daemon thread + `join(timeout=...)` and never calls
+shutdown(wait=True): on timeout it abandons the still-running worker and
+raises promptly. daemon=True means an abandoned worker never blocks process
+shutdown. Same shape as the proven `codec_hooks._run_hook_with_timeout`.
+"""
+import queue
+import threading
+from typing import Any, Callable
+
+__all__ = ["run_with_timeout"]
+
+
+def run_with_timeout(
+    fn: Callable[..., Any],
+    timeout: float,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Run ``fn(*args, **kwargs)`` in a daemon thread, bounded by ``timeout`` seconds.
+
+    Returns ``fn``'s return value on success. Re-raises, in the calling thread,
+    any exception ``fn`` raised (original type, message, and instance preserved).
+    Raises ``TimeoutError`` if ``fn`` does not complete within ``timeout`` —
+    promptly, without waiting for the (abandoned, still-running) worker to finish.
+
+    On Python 3.11+ ``concurrent.futures.TimeoutError`` is an alias of the
+    builtin ``TimeoutError``, so call sites catching either are satisfied.
+    """
+    result_q: "queue.Queue[Any]" = queue.Queue(maxsize=1)
+    exc_q: "queue.Queue[BaseException]" = queue.Queue(maxsize=1)
+
+    def _runner() -> None:
+        try:
+            result_q.put(fn(*args, **kwargs))
+        except BaseException as e:  # noqa: BLE001 — propagate ANY error to the caller
+            try:
+                exc_q.put(e)
+            except Exception:
+                pass
+
+    t = threading.Thread(target=_runner, daemon=True, name="codec-run-with-timeout")
+    t.start()
+    t.join(timeout=timeout)
+
+    if t.is_alive():
+        # Abandon the worker — daemon=True so it never blocks shutdown. No
+        # shutdown(wait=True), so we return control to the caller immediately.
+        raise TimeoutError(f"operation exceeded {timeout}s timeout")
+    if not exc_q.empty():
+        raise exc_q.get_nowait()
+    if not result_q.empty():
+        return result_q.get_nowait()
+    # Thread finished without putting a result or exception — only reachable if
+    # the result put itself failed. Treat as a None return.
+    return None

--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -2646,6 +2646,118 @@ def _should_escalate_to_project(user_text: str, session_id: str) -> dict:
     }
 
 
+def _chat_vision_response(body: dict, messages: list):
+    """If the request carries images, route to the vision model and return the
+    response dict; else return None. Fix #8 (intra-file CC reduction):
+    extracted verbatim from chat_completion, behavior-preserving. The inline
+    vision POST is an A-11-pending site and stays in codec_dashboard."""
+    images = body.get("images", [])
+    if not images:
+        return None
+    import requests as rq2
+    config2 = {}
+    try:
+        with open(CONFIG_PATH) as f:
+            config2 = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning(f"Config read failed; proceeding without overrides: {e}")
+    vision_url = config2.get("vision_base_url", "http://localhost:8083/v1")
+    vision_model = config2.get("vision_model", "mlx-community/Qwen2.5-VL-7B-Instruct-4bit")
+    # Build multimodal message: last user text + all images
+    last_text = ""
+    for m in reversed(messages):
+        if m.get("role") == "user" and isinstance(m.get("content"), str):
+            last_text = m["content"]
+            break
+    if not last_text:
+        last_text = "Describe and analyze this image in detail."
+    mm_content = []
+    for img_b64 in images:
+        mm_content.append({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}})
+    mm_content.append({"type": "text", "text": last_text})
+    v_payload = {
+        "model": vision_model,
+        "messages": [{"role": "user", "content": mm_content}],
+        "max_tokens": 4000,
+        "temperature": 0.7
+    }
+    vr = rq2.post(f"{vision_url}/chat/completions", json=v_payload, headers={"Content-Type": "application/json"}, timeout=120)
+    vdata = vr.json()
+    vanswer = vdata["choices"][0]["message"]["content"].strip()
+    import re as re2
+    vanswer = re2.sub(r'<think>[\s\S]*?</think>', '', vanswer).strip()
+    return {"response": vanswer, "model": vision_model}
+
+
+def _build_chat_system_prompt(config: dict, budget, has_attachment: bool,
+                              last_user_text: str) -> str:
+    """Build the chat system prompt: override-aware base + per-turn step-budget
+    warnings + attachment / content-rewrite / observer-injection suffixes.
+
+    Fix #8 (intra-file CC reduction): extracted verbatim from chat_completion;
+    behavior-preserving. `budget` is mutated exactly as before — warn_now() and
+    consume('llm_call') happen here, once, where they ran inline.
+    """
+    from datetime import datetime as _dt
+    _overrides = _load_prompt_overrides()
+    _chat_prompt = _overrides.get("chat", CHAT_SYSTEM_PROMPT)
+    sys_prompt = _chat_prompt.format(date=_dt.now().strftime("%A, %B %d, %Y"))
+    if budget.warn_now():
+        sys_prompt += (
+            "\n\n⚠ 1 step remaining in this turn. Wrap up — do NOT "
+            "emit additional [SKILL:...] tags."
+        )
+    budget.consume("llm_call")
+    if budget.at_limit():
+        sys_prompt += (
+            "\n\n## Step Budget Exhausted\n"
+            "You've hit the per-turn step budget. Summarize what you "
+            "accomplished and any blockers in one short paragraph. "
+            "DO NOT emit [SKILL:...] tags or call additional tools."
+        )
+    if has_attachment:
+        sys_prompt += (
+            "\n\n## This Turn\n"
+            "The user has attached a file or image and its content is already "
+            "embedded in their message between [IMAGE ANALYSIS]/[DOCUMENT] markers. "
+            "Respond conversationally about the attached content. "
+            "DO NOT emit [SKILL:...] tool-calling tags in this response."
+        )
+    _u_text_lower = (last_user_text or "").lower()
+    _content_rewrite_intent = any(
+        kw in _u_text_lower for kw in (
+            "format my email", "format this email", "format my message",
+            "reformat", "rewrite", "reword", "redraft", "polish",
+            "proofread", "edit my email", "fix my email", "fix the grammar",
+            "make this sound", "translate this", "translate the following",
+            "draft a reply", "draft an email", "draft this",
+        )
+    )
+    if _content_rewrite_intent:
+        sys_prompt += (
+            "\n\n## This Turn\n"
+            "The user is asking you to generate or rewrite text directly "
+            "(format/edit/draft/translate/polish their email or message). "
+            "Respond with the rewritten content as plain prose. "
+            "DO NOT emit [SKILL:...] tool-calling tags in this response — "
+            "the answer IS the rewritten text, no tools needed."
+        )
+    try:
+        from codec_observer import maybe_inject_observation_summary
+        _obs_transport = "local" if "localhost" in (config.get("llm_base_url") or "") else "chat"
+        _obs_summary, _obs_reason = maybe_inject_observation_summary(
+            user_prompt=last_user_text or "",
+            transport=_obs_transport,
+            skill_name=None,           # post-LLM tag path, no skill resolved yet
+            skill_module=None,
+        )
+        if _obs_summary:
+            sys_prompt += f"\n\n{_obs_summary}"
+    except Exception as _e:
+        log.debug(f"[observer] injection failed (non-fatal): {_e}")
+    return sys_prompt
+
+
 @app.post("/api/chat")
 async def chat_completion(request: Request):
     """Direct LLM chat with full context window + tool calling"""
@@ -2730,41 +2842,10 @@ async def chat_completion(request: Request):
                 else:
                     return {"response": f"**⚡ {skill_name}**: {skill_result}", "skill": skill_name}
 
-    # Check for images — route to vision model
-    images = body.get("images", [])
-    if images:
-        import requests as rq2
-        config2 = {}
-        try:
-            with open(CONFIG_PATH) as f: config2 = json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
-            log.warning(f"Config read failed; proceeding without overrides: {e}")
-        vision_url = config2.get("vision_base_url", "http://localhost:8083/v1")
-        vision_model = config2.get("vision_model", "mlx-community/Qwen2.5-VL-7B-Instruct-4bit")
-        # Build multimodal message: last user text + all images
-        last_text = ""
-        for m in reversed(messages):
-            if m.get("role") == "user" and isinstance(m.get("content"), str):
-                last_text = m["content"]
-                break
-        if not last_text:
-            last_text = "Describe and analyze this image in detail."
-        mm_content = []
-        for img_b64 in images:
-            mm_content.append({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}})
-        mm_content.append({"type": "text", "text": last_text})
-        v_payload = {
-            "model": vision_model,
-            "messages": [{"role": "user", "content": mm_content}],
-            "max_tokens": 4000,
-            "temperature": 0.7
-        }
-        vr = rq2.post(f"{vision_url}/chat/completions", json=v_payload, headers={"Content-Type": "application/json"}, timeout=120)
-        vdata = vr.json()
-        vanswer = vdata["choices"][0]["message"]["content"].strip()
-        import re as re2
-        vanswer = re2.sub(r'<think>[\s\S]*?</think>', '', vanswer).strip()
-        return {"response": vanswer, "model": vision_model}
+    # Check for images — route to vision model (extracted, Fix #8)
+    vision_resp = _chat_vision_response(body, messages)
+    if vision_resp is not None:
+        return vision_resp
 
     try:
         config = {}
@@ -2783,84 +2864,12 @@ async def chat_completion(request: Request):
         force_search = body.get("force_search", False)
         messages = _enrich_messages(messages, config, force_search=bool(force_search))
 
-        # Inject CODEC system prompt (use override if user edited it)
-        from datetime import datetime as _dt
-        _overrides = _load_prompt_overrides()
-        _chat_prompt = _overrides.get("chat", CHAT_SYSTEM_PROMPT)
-        sys_prompt = _chat_prompt.format(date=_dt.now().strftime("%A, %B %d, %Y"))
-        # Phase 1 Step 3 §3 — consume one step for the LLM call itself.
-        # If we're now at limit-1, append the "1 step remaining" warning
-        # to the system prompt so the LLM wraps up. If we're already
-        # exhausted, switch to forced-summary mode.
-        if _budget.warn_now():
-            sys_prompt += (
-                "\n\n⚠ 1 step remaining in this turn. Wrap up — do NOT "
-                "emit additional [SKILL:...] tags."
-            )
-        _budget.consume("llm_call")
-        if _budget.at_limit():
-            sys_prompt += (
-                "\n\n## Step Budget Exhausted\n"
-                "You've hit the per-turn step budget. Summarize what you "
-                "accomplished and any blockers in one short paragraph. "
-                "DO NOT emit [SKILL:...] tags or call additional tools."
-            )
-        # Bugfix 2026-04-16: when the user attaches a file/image, the default
-        # system prompt still teaches the LLM to emit [SKILL:...] tags, which
-        # then leak through the streaming path. Force conversational mode for
-        # this turn so the LLM analyses the attached content directly.
-        if has_attachment:
-            sys_prompt += (
-                "\n\n## This Turn\n"
-                "The user has attached a file or image and its content is already "
-                "embedded in their message between [IMAGE ANALYSIS]/[DOCUMENT] markers. "
-                "Respond conversationally about the attached content. "
-                "DO NOT emit [SKILL:...] tool-calling tags in this response."
-            )
-
-        # Bugfix 2026-04-27: detect content-rewriting intents (format/draft/
-        # rewrite/reword/proofread an email/message/text) — these are pure-text
-        # generation tasks, NOT skill calls. Past failure: LLM emitted
-        # [SKILL:translate:<email body>] for "format my email", which ran the
-        # translate skill on the email and returned "Translation failed."
-        _u_text_lower = (last_user_text or "").lower()
-        _content_rewrite_intent = any(
-            kw in _u_text_lower for kw in (
-                "format my email", "format this email", "format my message",
-                "reformat", "rewrite", "reword", "redraft", "polish",
-                "proofread", "edit my email", "fix my email", "fix the grammar",
-                "make this sound", "translate this", "translate the following",
-                "draft a reply", "draft an email", "draft this",
-            )
+        # Build the system prompt (override + step-budget + attachment /
+        # content-rewrite / observer suffixes) — extracted to a helper for
+        # readability (Fix #8). Consumes the llm_call step budget internally.
+        sys_prompt = _build_chat_system_prompt(
+            config, _budget, has_attachment, last_user_text
         )
-        if _content_rewrite_intent:
-            sys_prompt += (
-                "\n\n## This Turn\n"
-                "The user is asking you to generate or rewrite text directly "
-                "(format/edit/draft/translate/polish their email or message). "
-                "Respond with the rewritten content as plain prose. "
-                "DO NOT emit [SKILL:...] tool-calling tags in this response — "
-                "the answer IS the rewritten text, no tools needed."
-            )
-        # Phase 2 Step 5 — Observer summary injection (gated per §X).
-        # Local Qwen always injects; cloud transports (this chat path uses
-        # local-by-default but may be cloud-routed by the user — pass the
-        # detected transport tag) gate on possessive / continuation /
-        # skill-flag patterns. Returns (summary_or_None, reason); audit
-        # emit fires inside the helper ONLY when summary non-None.
-        try:
-            from codec_observer import maybe_inject_observation_summary
-            _obs_transport = "local" if "localhost" in (config.get("llm_base_url") or "") else "chat"
-            _obs_summary, _obs_reason = maybe_inject_observation_summary(
-                user_prompt=last_user_text or "",
-                transport=_obs_transport,
-                skill_name=None,           # post-LLM tag path, no skill resolved yet
-                skill_module=None,
-            )
-            if _obs_summary:
-                sys_prompt += f"\n\n{_obs_summary}"
-        except Exception as _e:
-            log.debug(f"[observer] injection failed (non-fatal): {_e}")
 
         # Prepend system message (or replace existing one)
         if messages and messages[0].get("role") == "system":

--- a/codec_jsonstore.py
+++ b/codec_jsonstore.py
@@ -24,15 +24,27 @@ from contextlib import contextmanager
 from typing import Any, Iterator
 
 
-def atomic_write_json(path: Any, data: Any) -> None:
-    """Atomically write `data` as JSON to `path` (tmp + fsync + replace, 0600)."""
+def atomic_write_json(
+    path: Any,
+    data: Any,
+    *,
+    default: Any = None,
+    sort_keys: bool = False,
+) -> None:
+    """Atomically write `data` as JSON to `path` (tmp + fsync + replace, 0600).
+
+    `default` is the json.dump fallback serializer (pass `str` for datetime/Path
+    values — Fix #9 Phase 0, so this primitive subsumes the hand-rolled
+    `default=str` helpers). `sort_keys` forces deterministic key ordering for
+    callers that need stable diffs/hashes. Both default to the prior behavior.
+    """
     path = str(path)
     directory = os.path.dirname(path) or "."
     os.makedirs(directory, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=directory, suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as f:
-            json.dump(data, f, indent=2)
+            json.dump(data, f, indent=2, default=default, sort_keys=sort_keys)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp, path)
@@ -66,3 +78,32 @@ def file_lock(path: Any) -> Iterator[None]:
         except Exception:
             pass
         lock_file.close()
+
+
+def read_modify_write(
+    path: Any,
+    mutate_fn,
+    *,
+    default_factory=dict,
+    default: Any = None,
+    sort_keys: bool = False,
+) -> Any:
+    """Lock + read + mutate + atomic-write `path` as one cross-process-safe unit.
+
+    Holds `file_lock(path)` across the whole read-modify-write so concurrent
+    daemons can't lose each other's update (Fix #9 — standardizes the pattern so
+    a future RMW site can't forget the lock). `mutate_fn(data)` receives the
+    current parsed JSON (or `default_factory()` if the file is missing/corrupt)
+    and returns the new value to persist. Returns the persisted value.
+    `default`/`sort_keys` are forwarded to `atomic_write_json`.
+    """
+    path = str(path)
+    with file_lock(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            data = default_factory()
+        new_data = mutate_fn(data)
+        atomic_write_json(path, new_data, default=default, sort_keys=sort_keys)
+        return new_data

--- a/codec_mcp.py
+++ b/codec_mcp.py
@@ -18,6 +18,7 @@ log = logging.getLogger("codec_mcp")
 SKILL_TIMEOUT_SEC = int(os.environ.get("CODEC_SKILL_TIMEOUT", "30"))
 
 from codec_audit import audit as _audit
+from codec_concurrency import run_with_timeout
 from codec_hooks import HookVeto, run_with_hooks
 
 
@@ -213,15 +214,17 @@ def _load_skill_tools_into(mcp):
                 _transport = os.environ.get("CODEC_MCP_TRANSPORT", "stdio")
 
                 def _invoke(t: str, c: str) -> str:
-                    import concurrent.futures
                     def _run_inner():
                         mod = registry.load(rkey)
                         if mod is None or not hasattr(mod, "run"):
                             raise _SkillLoadError("load_failed")
                         return mod.run(t, c)
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-                        fut = ex.submit(_run_inner)
-                        return fut.result(timeout=SKILL_TIMEOUT_SEC)
+                    # C4 fix: run_with_timeout actually bounds wall-clock time.
+                    # The old `with ThreadPoolExecutor() as ex` exit blocked on
+                    # shutdown(wait=True), so a hung skill defeated the timeout.
+                    # It raises TimeoutError (== concurrent.futures.TimeoutError
+                    # on py3.11+), caught by the except clause below.
+                    return run_with_timeout(_run_inner, SKILL_TIMEOUT_SEC)
 
                 import concurrent.futures
                 try:

--- a/codec_memory.py
+++ b/codec_memory.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sqlite3
+import threading
 from datetime import datetime, timedelta
 
 log = logging.getLogger(__name__)
@@ -34,6 +35,13 @@ class CodecMemory:
     def __init__(self, db_path: str = DB_PATH):
         self.db_path = db_path
         self._conn = None
+        # C5 (Fix #5): serialize all runtime use of the shared sqlite3
+        # connection (check_same_thread=False) across threads — concurrent
+        # access to one connection can corrupt cursor state or segfault.
+        # RLock so a locked method calling another (get_context->search,
+        # cleanup->close) doesn't self-deadlock. WAL + busy_timeout remain the
+        # cross-PROCESS layer; this lock is the in-process one.
+        self._lock = threading.RLock()
         self._init_fts()
 
     # ── Connection ────────────────────────────────────────────────────────────
@@ -48,12 +56,13 @@ class CodecMemory:
 
     def close(self):
         """Close the persistent connection. Safe to call multiple times."""
-        if self._conn is not None:
-            try:
-                self._conn.close()
-            except Exception as e:
-                log.debug("Memory DB connection close failed: %s", e)
-            self._conn = None
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                except Exception as e:
+                    log.debug("Memory DB connection close failed: %s", e)
+                self._conn = None
 
     # ── Init ─────────────────────────────────────────────────────────────────
 
@@ -181,13 +190,14 @@ class CodecMemory:
 
     def save(self, session_id: str, role: str, content: str, user_id: str = "default") -> int:
         """Insert one message. Triggers keep FTS in sync automatically."""
-        conn = self._get_conn()
-        cur = conn.execute(
-            "INSERT INTO conversations (session_id, timestamp, role, content, user_id) VALUES (?,?,?,?,?)",
-            (session_id, datetime.now().isoformat(), role, content[:4000], user_id),
-        )
-        conn.commit()
-        return cur.lastrowid
+        with self._lock:
+            conn = self._get_conn()
+            cur = conn.execute(
+                "INSERT INTO conversations (session_id, timestamp, role, content, user_id) VALUES (?,?,?,?,?)",
+                (session_id, datetime.now().isoformat(), role, content[:4000], user_id),
+            )
+            conn.commit()
+            return cur.lastrowid
 
     # ── Search ───────────────────────────────────────────────────────────────
 
@@ -197,11 +207,12 @@ class CodecMemory:
         sanitized = _sanitize_fts_query(query)
         if not sanitized:
             return []
-        conn = self._get_conn()
-        try:
-            return self._fts_query(conn, sanitized, limit, user_id=user_id)
-        except sqlite3.OperationalError:
-            return []
+        with self._lock:
+            conn = self._get_conn()
+            try:
+                return self._fts_query(conn, sanitized, limit, user_id=user_id)
+            except sqlite3.OperationalError:
+                return []
 
     def _fts_query(self, conn, query: str, limit: int, user_id: str = None) -> list[dict]:
         if user_id is not None:
@@ -232,28 +243,29 @@ class CodecMemory:
         """Return recent conversations from the past N days.
         If user_id is provided, only return results for that user."""
         since = (datetime.now() - timedelta(days=days)).isoformat()
-        conn = self._get_conn()
-        if user_id is not None:
-            rows = conn.execute("""
-                SELECT id, session_id, timestamp, role, content
-                FROM conversations
-                WHERE timestamp >= ? AND user_id = ?
-                ORDER BY id DESC
-                LIMIT ?
-            """, (since, user_id, limit)).fetchall()
-        else:
-            rows = conn.execute("""
-                SELECT id, session_id, timestamp, role, content
-                FROM conversations
-                WHERE timestamp >= ?
-                ORDER BY id DESC
-                LIMIT ?
-            """, (since, limit)).fetchall()
-        return [
-            {"id": r[0], "session_id": r[1], "timestamp": r[2],
-             "role": r[3], "content": r[4]}
-            for r in rows
-        ]
+        with self._lock:
+            conn = self._get_conn()
+            if user_id is not None:
+                rows = conn.execute("""
+                    SELECT id, session_id, timestamp, role, content
+                    FROM conversations
+                    WHERE timestamp >= ? AND user_id = ?
+                    ORDER BY id DESC
+                    LIMIT ?
+                """, (since, user_id, limit)).fetchall()
+            else:
+                rows = conn.execute("""
+                    SELECT id, session_id, timestamp, role, content
+                    FROM conversations
+                    WHERE timestamp >= ?
+                    ORDER BY id DESC
+                    LIMIT ?
+                """, (since, limit)).fetchall()
+            return [
+                {"id": r[0], "session_id": r[1], "timestamp": r[2],
+                 "role": r[3], "content": r[4]}
+                for r in rows
+            ]
 
     def get_context(self, query: str, n: int = 5, user_id: str = None) -> str:
         """Return a formatted string of top-N matching snippets for LLM injection."""
@@ -270,68 +282,71 @@ class CodecMemory:
     def get_sessions(self, limit: int = 20, user_id: str = None) -> list[dict]:
         """Return distinct sessions with message count and last timestamp.
         If user_id is provided, only return sessions for that user."""
-        conn = self._get_conn()
-        if user_id is not None:
-            rows = conn.execute("""
-                SELECT session_id,
-                       COUNT(*) AS msg_count,
-                       MIN(timestamp) AS started,
-                       MAX(timestamp) AS last_msg,
-                       MAX(CASE WHEN role='user' THEN content ELSE '' END) AS last_user_msg
-                FROM conversations
-                WHERE user_id = ?
-                GROUP BY session_id
-                ORDER BY last_msg DESC
-                LIMIT ?
-            """, (user_id, limit)).fetchall()
-        else:
-            rows = conn.execute("""
-                SELECT session_id,
-                       COUNT(*) AS msg_count,
-                       MIN(timestamp) AS started,
-                       MAX(timestamp) AS last_msg,
-                       MAX(CASE WHEN role='user' THEN content ELSE '' END) AS last_user_msg
-                FROM conversations
-                GROUP BY session_id
-                ORDER BY last_msg DESC
-                LIMIT ?
-            """, (limit,)).fetchall()
-        return [
-            {"session_id": r[0], "msg_count": r[1],
-             "started": r[2], "last_msg": r[3],
-             "preview": (r[4] or "")[:100]}
-            for r in rows
-        ]
+        with self._lock:
+            conn = self._get_conn()
+            if user_id is not None:
+                rows = conn.execute("""
+                    SELECT session_id,
+                           COUNT(*) AS msg_count,
+                           MIN(timestamp) AS started,
+                           MAX(timestamp) AS last_msg,
+                           MAX(CASE WHEN role='user' THEN content ELSE '' END) AS last_user_msg
+                    FROM conversations
+                    WHERE user_id = ?
+                    GROUP BY session_id
+                    ORDER BY last_msg DESC
+                    LIMIT ?
+                """, (user_id, limit)).fetchall()
+            else:
+                rows = conn.execute("""
+                    SELECT session_id,
+                           COUNT(*) AS msg_count,
+                           MIN(timestamp) AS started,
+                           MAX(timestamp) AS last_msg,
+                           MAX(CASE WHEN role='user' THEN content ELSE '' END) AS last_user_msg
+                    FROM conversations
+                    GROUP BY session_id
+                    ORDER BY last_msg DESC
+                    LIMIT ?
+                """, (limit,)).fetchall()
+            return [
+                {"session_id": r[0], "msg_count": r[1],
+                 "started": r[2], "last_msg": r[3],
+                 "preview": (r[4] or "")[:100]}
+                for r in rows
+            ]
 
     def cleanup(self, retention_days: int = 90) -> dict:
         """Delete conversations older than retention_days and VACUUM the database.
         Returns dict with deleted count and final size."""
         cutoff = (datetime.now() - timedelta(days=retention_days)).isoformat()
-        conn = self._get_conn()
-        before = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
-        conn.execute("DELETE FROM conversations WHERE timestamp < ?", (cutoff,))
-        conn.commit()
-        after = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
-        deleted = before - after
-        # Rebuild FTS after bulk delete
-        if deleted > 0:
-            conn.execute("INSERT INTO conversations_fts(conversations_fts) VALUES('rebuild')")
+        with self._lock:
+            conn = self._get_conn()
+            before = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+            conn.execute("DELETE FROM conversations WHERE timestamp < ?", (cutoff,))
             conn.commit()
-        # VACUUM requires closing and reopening (cannot run inside a transaction on reused conn)
-        self.close()
-        tmp = sqlite3.connect(self.db_path)
-        tmp.execute("VACUUM")
-        tmp.close()
-        size = os.path.getsize(self.db_path)
-        return {"deleted": deleted, "remaining": after, "size_bytes": size}
+            after = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+            deleted = before - after
+            # Rebuild FTS after bulk delete
+            if deleted > 0:
+                conn.execute("INSERT INTO conversations_fts(conversations_fts) VALUES('rebuild')")
+                conn.commit()
+            # VACUUM requires closing and reopening (cannot run inside a transaction on reused conn)
+            self.close()  # RLock is reentrant, so this nested acquire is safe
+            tmp = sqlite3.connect(self.db_path)
+            tmp.execute("VACUUM")
+            tmp.close()
+            size = os.path.getsize(self.db_path)
+            return {"deleted": deleted, "remaining": after, "size_bytes": size}
 
     def rebuild_fts(self) -> int:
         """Full FTS rebuild — use after bulk imports. Returns row count."""
-        conn = self._get_conn()
-        conn.execute("INSERT INTO conversations_fts(conversations_fts) VALUES('rebuild')")
-        conn.commit()
-        count = conn.execute("SELECT COUNT(*) FROM conversations_fts").fetchone()[0]
-        return count
+        with self._lock:
+            conn = self._get_conn()
+            conn.execute("INSERT INTO conversations_fts(conversations_fts) VALUES('rebuild')")
+            conn.commit()
+            count = conn.execute("SELECT COUNT(*) FROM conversations_fts").fetchone()[0]
+            return count
 
 
 # ── CLI ──────────────────────────────────────────────────────────────────────

--- a/codec_observer.py
+++ b/codec_observer.py
@@ -79,10 +79,12 @@ import sys
 import threading
 import time
 from collections import deque
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+from codec_concurrency import run_with_timeout
 
 # ── Audit emit ────────────────────────────────────────────────────────────────
 # Lazy-import so module import doesn't pull in codec_audit at startup time.
@@ -273,9 +275,10 @@ def _get_screenshot_ocr(timeout_ms: int, retry_timeout_ms: int) -> Tuple[str, bo
             # skill triggers heavy imports. Instead, use the same primitive
             # the skill uses (screencapture + Vision via osascript), but
             # subject to a hard timeout.
-            with ThreadPoolExecutor(max_workers=1) as ex:
-                future = ex.submit(_screencapture_and_ocr_blocking)
-                return future.result(timeout=timeout_s)
+            # C4 fix: run_with_timeout actually bounds wall-clock time. The old
+            # `with ThreadPoolExecutor() as ex` exit blocked on shutdown(wait=True),
+            # so a stuck screencapture popup hung each poll for ~5s.
+            return run_with_timeout(_screencapture_and_ocr_blocking, timeout_s)
         except (FuturesTimeoutError, TimeoutError):
             return None
         except Exception as e:

--- a/codec_ssrf.py
+++ b/codec_ssrf.py
@@ -1,0 +1,83 @@
+"""codec_ssrf — SSRF guard for outbound URL fetches (Fix #7 / H1·H2·H6).
+
+`validate_url(url)` raises `SSRFError` when a URL is unsafe to fetch, and
+returns the URL unchanged when it is safe. It is the shared chokepoint for
+every place CODEC fetches an attacker-influenceable URL (the `web_fetch`
+skill — which `clipboard_url_fetch` delegates to — and the `_web_fetch`
+crew tool).
+
+Rejections:
+- scheme not in {http, https} (blocks file://, ftp://, gopher://, …)
+- missing host
+- the host resolves to ANY non-public address: loopback (127.0.0.1, ::1),
+  private (10/8, 172.16/12, 192.168/16, fc00::/7), link-local (incl.
+  169.254.169.254 cloud-metadata), multicast, reserved, or unspecified
+  (0.0.0.0). Every resolved address is checked, so a dual-record /
+  dual-stack host that mixes a public and an internal IP is still rejected.
+
+Limitation (documented): there is a TOCTOU gap between this DNS resolution
+and the actual connect() inside requests/httpx — a determined DNS-rebinding
+attacker controlling an authoritative server could return a public IP here
+and an internal IP at connect time. Closing that fully needs IP-pinned
+connections (custom adapter); this guard covers the static-URL and
+naive-rebind cases the audit flagged. Keep call sites' own timeouts/size
+caps as defence in depth.
+"""
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+__all__ = ["SSRFError", "validate_url"]
+
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+class SSRFError(Exception):
+    """Raised when a URL is rejected by the SSRF guard."""
+
+
+def _is_blocked_ip(ip_str: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # unparseable address → block (fail closed)
+    # IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) — unwrap and re-check.
+    if getattr(ip, "ipv4_mapped", None) is not None:
+        ip = ip.ipv4_mapped
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def validate_url(url: str) -> str:
+    """Return `url` if safe to fetch; raise `SSRFError` otherwise."""
+    if not url or not isinstance(url, str):
+        raise SSRFError("empty or non-string URL")
+
+    parsed = urlparse(url.strip())
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise SSRFError(f"scheme '{parsed.scheme}' not allowed (only http/https)")
+
+    host = parsed.hostname
+    if not host:
+        raise SSRFError("URL has no host")
+
+    port = parsed.port or (443 if scheme == "https" else 80)
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise SSRFError(f"DNS resolution failed for {host}: {e}") from e
+
+    addrs = {info[4][0] for info in infos}
+    if not addrs:
+        raise SSRFError(f"no addresses resolved for {host}")
+    for addr in addrs:
+        if _is_blocked_ip(addr):
+            raise SSRFError(f"host {host!r} resolves to blocked address {addr}")
+    return url

--- a/docs/FIX8-ROUTES-CHAT-EXTRACTION-DESIGN.md
+++ b/docs/FIX8-ROUTES-CHAT-EXTRACTION-DESIGN.md
@@ -1,0 +1,132 @@
+# FIX8 — `routes/chat.py` extraction (first slice of the dashboard god-module)
+
+> Follow-on design note required by `docs/SECURITY-REMEDIATION-DESIGN.md` Fix #8
+> and CLAUDE.md §11 (>1-module structural change). **No code is written until
+> this note is approved.** Closes the start of audit finding C9.
+
+**Author:** audit follow-up · **Status:** AWAITING APPROVAL
+
+---
+
+## 1. What & why
+
+`codec_dashboard.py` is **3,861 LOC** — the audit's C9 "god-module". The single
+most complex unit in it is the chat handler `chat_completion`
+(`codec_dashboard.py:2650-3005`, ~356 lines, cyclomatic complexity ~48 per the
+audit). High complexity in the request path that runs every chat turn is a
+maintenance + correctness risk (the streaming/skill-tag/step-budget interplay
+is hard to reason about and easy to regress).
+
+**Goal:** a *behavior-preserving* extraction of the chat-handler cluster into a
+new `routes/chat.py` `APIRouter`, mounted via `app.include_router(...)` exactly
+like the existing `routes/agents.py`, `routes/skills.py`, `routes/auth.py`.
+Pure move + seam. **Zero behavior change.** Complexity of the handler itself is
+reduced by splitting its phases into named helpers as part of the move.
+
+This is explicitly the *first* slice — it does NOT attempt to dismantle the
+whole god-module. One coherent, low-risk extraction with the existing chat/
+stream tests as the safety net.
+
+## 2. The cluster to move (verified against current HEAD)
+
+| Symbol | Lines | Role |
+|---|---|---|
+| `CHAT_SKILL_ALLOWLIST` | 2207 | set gating pre-LLM hijack + post-LLM tag |
+| `_StepBudget` | 2369 | per-turn step cap (Phase 1 Step 3) |
+| `_try_skill` / `_try_skill_by_name` | 2442 / 2459 | pre-LLM skill hijack |
+| `_classify_chat_message` | 2570 | Qwen project-escalation classifier (Step 10) |
+| `_should_escalate_to_project` | 2616 | 2-signal escalation gate (Step 10) |
+| `chat_completion` | 2650-3005 | the `@app.post("/api/chat")` handler |
+| `_stream_gen` (nested) | 2889 | SSE streaming generator inside the handler |
+
+Contiguous span ≈ **lines 2207-3005 (~800 LOC)**.
+
+## 3. Collaborators (the seam — what crosses the new module boundary)
+
+`chat_completion` references, and the extraction must thread (import or pass):
+
+- **Cross-module (already importable, no change):** `codec_chat_stream`
+  (`SkillTagBuffer`, `SKILL_TAG_RE` — already imported at dashboard:39),
+  `codec_llm` (`stream(keepalive=True)`, `call(raise_on_error=True)`),
+  `codec_observer` (system-prompt injection), `codec_memory` (context),
+  `codec_dispatch.run_skill`, `codec_slash_commands.parse_slash`,
+  `codec_identity` (system prompt), `codec_audit`.
+- **Dashboard-local state that must be SHARED, not duplicated:**
+  `_autoescalate_silence_set` + `_AUTOESCALATE_SILENCE_LOCK` (Step 10 in-memory
+  per-session silence — CLAUDE.md "don't-touch from outside"),
+  `AGENT_AUTO_ESCALATE_ENABLED`, `ESCALATE_CHECKPOINTS_THRESHOLD`, the memory
+  singleton, any LLM config getters.
+
+**Decision point (see §7, Decision A):** how to share that module-level state
+between `codec_dashboard.py` and the new `routes/chat.py` without creating a
+circular import.
+
+## 4. Proposed approach
+
+1. **Create `routes/chat.py`** with `router = APIRouter()` (mirrors the 4
+   existing route modules).
+2. **Move the cluster** (§2) verbatim into it. Convert `@app.post("/api/chat")`
+   → `@router.post("/api/chat")`.
+3. **Resolve shared state via a small `routes/_chat_state.py` (or extend
+   `routes/_shared.py`)** that owns `_autoescalate_silence_set`,
+   `_AUTOESCALATE_SILENCE_LOCK`, and the escalation flags/consts. Both
+   `codec_dashboard` (if it still references them) and `routes/chat` import from
+   there. This breaks the would-be circular import (`dashboard → chat → dashboard`).
+4. **Reduce `chat_completion` CC** by extracting its phases into named helpers
+   *during* the move (each is a straight cut of an existing block, no logic
+   change): `_resolve_slash_or_skill(...)`, `_build_chat_messages(...)`
+   (memory + observer injection), `_stream_chat_response(...)`
+   (the `_stream_gen` body), `_finalize_nonstream(...)`. Target handler CC ≈ 15.
+5. **Mount** in `codec_dashboard.py`: `from routes.chat import router as chat_router; app.include_router(chat_router)` — same pattern already used for agents/skills/auth.
+6. Delete the now-moved definitions from `codec_dashboard.py`.
+
+## 5. Migration / compat
+
+- **No API change.** Path stays `/api/chat`; request/response/SSE shape
+  identical. The PWA is untouched.
+- **No new dependency.** Pure restructure.
+- Auth middleware, step budget, observer injection, skill hijack, post-LLM tag
+  resolution, auto-escalation all behave identically — they're moved, not
+  altered.
+- Import-order: `app.include_router` must run after `app` is created; place the
+  mount next to the existing `include_router` calls.
+
+## 6. Test plan
+
+- The existing chat + streaming tests are the behavior-preserving net:
+  `tests/test_chat_stream*.py`, `tests/test_skill_tag*.py`,
+  `tests/test_dashboard*.py`, `tests/test_step_budget*.py`,
+  `tests/test_*escalat*` (exact set enumerated at implementation start). **All
+  must pass unchanged** — no test edits beyond import paths.
+- Add `tests/test_routes_chat_smoke.py`: assert `routes.chat.router` exposes
+  `/api/chat` and that `chat_completion` is importable from the new module.
+- Full suite green before/after (diff = same pass count).
+
+## 7. Open decisions (need sign-off)
+
+**Decision A — shared module-level state:**
+- **A1 (Recommended):** move `_autoescalate_silence_set` + lock + escalation
+  consts into `routes/_shared.py` (or a new `routes/_chat_state.py`); both
+  modules import them. Cleanest break of the circular import.
+- A2: keep them in `codec_dashboard.py` and have `routes/chat.py` import the
+  dashboard module lazily inside the handler. Smaller diff, but re-introduces a
+  dashboard↔chat coupling the extraction was meant to reduce.
+
+**Decision B — scope of this slice:**
+- **B1 (Recommended):** chat cluster only (§2). Leave the other ~3,000 LOC for
+  later slices. Smallest reviewable unit.
+- B2: also pull the schedules/notifications routes in the same PR. Bigger blast
+  radius; rejected for a "first slice".
+
+## 8. Rollback
+
+Single revert of the extraction commit restores the inlined handler. No
+persisted state, no schema, no API change — rollback is clean.
+
+## 9. Risk
+
+Medium. The handler is hot (every chat turn) and the streaming path is subtle.
+Mitigation: behavior-preserving move only, existing stream/tag/budget tests as
+the gate, helper extraction is mechanical block-cutting. Recommend implementing
+on the existing `security-remediation` branch as its own commit so it can be
+reverted independently of the landed fixes.

--- a/docs/FIX9-JSONSTORE-STATE-REGISTRY-DESIGN.md
+++ b/docs/FIX9-JSONSTORE-STATE-REGISTRY-DESIGN.md
@@ -1,0 +1,137 @@
+# FIX9 — Promote `codec_jsonstore` to the mandatory state registry
+
+> Follow-on design note required by `docs/SECURITY-REMEDIATION-DESIGN.md` Fix #9
+> and CLAUDE.md §11 (large multi-module surface). **No code is written until
+> this note is approved.** Closes audit finding C8 (~25 ad-hoc `~/.codec/*.json`
+> writers).
+
+**Author:** audit follow-up · **Status:** AWAITING APPROVAL
+
+---
+
+## 1. What & why
+
+`codec_jsonstore.py` already provides the two correct primitives:
+`atomic_write_json(path, data)` (unique tmp + flush + **fsync** + atomic
+replace + 0600) and `file_lock(path)` (cross-process flock for a
+read-modify-write). Per PR-4C they were meant to be the single chokepoint for
+all `~/.codec/*.json` persistence. They are **not yet universal** — a survey of
+HEAD finds ~30 writer sites still doing raw `json.dump(f)` (no fsync, often no
+atomicity, sometimes a read-modify-write with no lock) plus 2 modules that
+hand-roll their own atomic helper.
+
+Consequences (all observed by the audit): partial-write corruption on crash,
+lost-update races between the 11 PM2 daemons, and inconsistent perms.
+
+**Goal:** migrate every ad-hoc writer onto the shared primitives, converge the
+duplicate helpers, add a `docs/STATE-FILES.md` registry, and add a CI guard
+(same shape as the Fix #10 A-12 guard) that fails when a NEW raw `json.dump`
+to a `~/.codec` path is introduced.
+
+## 2. Inventory (from HEAD survey — implementation step 1 produces the exact line list)
+
+**ALREADY-SAFE** (`codec_jsonstore`): `codec_jsonstore.py` itself; the Fix #5
+sites (grants.json via `grants_lock`, both notifications.json read-modify-writes
+in `codec_ask_user` now under `file_lock`); `codec_oauth_provider` fallback
+(migrated in Fix #1b).
+
+**HAS-OWN-ATOMIC** (hand-rolled tmp+fsync+replace — durable but duplicate code,
+candidates to converge):
+- `codec_ask_user._atomic_write_text` (uses `json.dumps(..., default=str)`)
+- `codec_agent_plan._atomic_write_json` (0600 + 0700 dir, `sort_keys=False`)
+
+**AD-HOC-UNSAFE** (raw `json.dump`, ~30 sites) — representative grouping:
+- **Full-overwrite, low risk:** `codec_alerts.py:48`, `codec_marketplace.py:51,74`,
+  `codec_memory_upgrade.py:235`, `codec_proactive.py:209`, `codec_agent.py:62`,
+  `skills/pomodoro.py:32`, `routes/skills.py:235` (custom_triggers.json),
+  `routes/agents.py:180` (custom agent save).
+- **Read-modify-write (NEED `file_lock`):** `routes/_shared.py:202,241`
+  (the shared notifications read/write — used by scheduler, heartbeat,
+  autopilot), `codec_heartbeat.py:404` (notifs), `codec_scheduler.py:127`
+  (notifications), `codec_heartbeat.py:258` (executed history).
+- **Daemon state files:** `codec_imessage.py:101`, `codec_heartbeat.py:371`,
+  `codec_scheduler.py:40`, `codec_voice.py:161` (voice_session.json),
+  `codec_agent_messaging.py:98`.
+- **Don't-touch / sensitive (migrate LAST, per-file sign-off):**
+  `codec_config.py:68,120,250` (config.json), `routes/auth.py:239,314,349`
+  (auth/TOTP config writes), `codec_google_auth.py:92` (Google OAuth token),
+  `codec_dashboard.py:652,693,3064,3375,3410` (config/schedules).
+
+(`codec_sandbox.py:202,205` are inside a generated wrapper string, not a live
+state write — excluded. `codec_core.py` likewise emits writes as script text.)
+
+## 3. Migration hazards (must be handled, NOT mechanical)
+
+1. **`default=str`.** `atomic_write_json` does `json.dump(data, f, indent=2)`
+   with **no `default=str`**. Any writer currently persisting non-JSON-native
+   values (e.g. `datetime`, `Path`) relies on `default=str` and will raise under
+   a naive swap. `codec_ask_user._atomic_write_text` does this deliberately.
+   → **Decision A:** add an optional `default` param to `atomic_write_json`, or
+   require callers to pre-serialize. (Recommended: add `default=None` passthrough
+   so the primitive subsumes the `_atomic_write_text` use case cleanly.)
+2. **`sort_keys`.** Some writers use `sort_keys=True` (memory_upgrade) for
+   stable diffs; the primitive uses insertion order. Where stability matters
+   (anything hashed/compared), preserve it. → `atomic_write_json` may need a
+   `sort_keys` passthrough.
+3. **Read-modify-write vs overwrite.** RMW sites need `file_lock` wrapping the
+   load→modify→write (like Fix #5), not just `atomic_write_json`. Misclassifying
+   an RMW as an overwrite re-opens the lost-update race.
+4. **Don't-touch zones** (config.json, oauth/Google tokens, auth) — these are
+   in the CLAUDE.md protected set. Migrate LAST, one file per commit, surfaced
+   to the operator (same protocol as Fix #1b's oauth surfacing).
+
+## 4. Proposed phased plan (each phase its own commit, suite green between)
+
+- **Phase 0 — primitive hardening:** add `default`/`sort_keys` passthrough to
+  `atomic_write_json` (TDD); add `file_lock`-aware `read_modify_write(path, fn)`
+  convenience if it reduces churn. No call-site change yet.
+- **Phase 1 — full-overwrite low-risk sites** → `atomic_write_json`. Mechanical,
+  one commit, regression by existing per-module tests.
+- **Phase 2 — read-modify-write sites** → `file_lock` + `atomic_write_json`
+  (notably `routes/_shared.py` notifications, heartbeat, scheduler). Add
+  concurrent-write no-clobber tests (Fix #5 pattern).
+- **Phase 3 — converge duplicate helpers:** replace `codec_ask_user.
+  _atomic_write_text` and `codec_agent_plan._atomic_write_json` bodies with calls
+  to the (now `default=`-aware) `codec_jsonstore` primitive; keep the thin
+  wrappers as named shims so call sites don't churn.
+- **Phase 4 — don't-touch zones**, one file per commit, operator sign-off each
+  (config.json, Google token, auth writes).
+- **Phase 5 — guardrails:** `docs/STATE-FILES.md` registry (path → writer →
+  reader → lock policy); `tests/test_jsonstore_invariant.py` CI guard that fails
+  on a NEW raw `json.dump`/`write_text(json.dumps(...))` targeting a `~/.codec`
+  path outside an allowlist (mirrors the Fix #10 A-12 guard).
+
+## 5. Test plan
+
+- Phase 0: unit tests for `atomic_write_json` `default`/`sort_keys` + fsync
+  (extend existing jsonstore tests).
+- Phases 1-4: each migrated file keeps its existing tests green; RMW sites add a
+  concurrent-writer no-clobber test.
+- Phase 5: the invariant guard test + a synthetic-violation test (proves it
+  catches a new raw writer), exactly like `tests/test_a12_invariant.py`.
+
+## 6. Rollback
+
+Per-phase, per-file reverts. No schema changes (same JSON shapes, same paths,
+same-or-better perms). The only behavior change is *durability + atomicity*,
+which is strictly safer.
+
+## 7. Open decisions (need sign-off)
+
+- **Decision A — primitive signature:** add `default=` + `sort_keys=`
+  passthrough to `atomic_write_json` (Recommended), vs. require callers to
+  pre-serialize to text. The former lets Phase 3 fully retire the duplicate
+  helpers.
+- **Decision B — scope of this fix:** Phases 0-3 + 5 now, Phase 4 (don't-touch
+  zones) deferred to a separate sign-off (Recommended), vs. all phases in one
+  PR. Phase 4 touches protected files and should not be bundled.
+- **Decision C — `read_modify_write` helper:** add a `codec_jsonstore.
+  read_modify_write(path, mutate_fn)` convenience (lock + load + mutate + atomic
+  write) to standardize RMW sites, vs. inline `file_lock` at each (as Fix #5
+  did). A helper reduces the chance a future RMW forgets the lock.
+
+## 8. Risk
+
+Medium-high by surface area, low per-site. The phasing keeps each commit small
+and independently revertible; the don't-touch zones are quarantined to Phase 4
+with explicit sign-off. The Phase 5 guard prevents regression once migrated.

--- a/docs/STATE-FILES.md
+++ b/docs/STATE-FILES.md
@@ -1,0 +1,66 @@
+# CODEC State-File Registry
+
+> Canonical map of every `~/.codec/*.json` (and related) state file: who writes
+> it, who reads it, and its persistence/locking policy. Introduced by Fix #9
+> (audit C8) to make the `codec_jsonstore` convergence trackable.
+
+## Persistence policy levels
+
+- **SAFE** — writes via `codec_jsonstore.atomic_write_json` / `file_lock` /
+  `read_modify_write` (tmp + fsync + atomic replace + 0600; cross-process lock
+  for read-modify-write). This is the target for every state file.
+- **OWN-ATOMIC** — a module-local hand-rolled tmp+fsync+replace helper
+  (durable, but duplicates the primitive; Phase 3 converges these).
+- **AD-HOC** — raw `json.dump(f)` / `write_text(json.dumps(...))`: no fsync,
+  often no cross-process lock. Phase 1/2 migration targets.
+
+## Registry
+
+| File | Writer(s) | RMW? | Policy | Status |
+|---|---|---|---|---|
+| `notifications.json` | `routes/_shared._save_notification`, `_write_notifications`; `codec_ask_user` (question + mark-read); `codec_agent_messaging.post_message` | yes | **SAFE** | `_write_notifications` atomic (C-3); RMW under `file_lock` — `_save_notification` (Fix #9 P2), ask_user (Fix #5), messaging (B-11) |
+| `pending_questions.json` | `codec_ask_user._save_pending_questions` | yes | OWN-ATOMIC (+`file_lock`) | RMW already under `file_lock` (C-4). Helper `_atomic_write_text` → converge in Phase 3. **Don't-touch zone.** |
+| `agents/<id>/grants.json` | `codec_agent_plan.save_grants` (+ `grants_lock`) | yes | OWN-ATOMIC (+`file_lock`) | RMW under `grants_lock` (Fix #5). Helper `_atomic_write_json` → Phase 3. **Tamper-hashed.** |
+| `agents/<id>/{plan,state,manifest}.json` | `codec_agent_plan.save_*` (manifest CAS under `_status_lock`) | manifest yes | OWN-ATOMIC | `_atomic_write_json` (0600/0700). Phase 3 convergence. **Don't-touch after approval.** |
+| `agents/<id>/messages.jsonl` | `codec_agent_messaging.post_message` | append | n/a (append) | append-only JSONL, not a JSON doc |
+| `agent_silence.json` | `codec_agent_messaging.set_silenced` | yes | review in Phase 2 | per-agent silence |
+| `oauth_state.json` | `codec_oauth_provider._save` (fallback) | no | **SAFE** | `atomic_write_json` (Fix #1b). Keychain-primary. **Don't-touch zone.** |
+| `audit.log` | `codec_audit` | append | bespoke (flock + HMAC) | PR-4E/PR-2E — its own contract, NOT json.dump. **Don't-touch zone.** |
+| `config.json` | `codec_config`, `routes/auth`, `codec_dashboard` | yes | AD-HOC | **Phase 4** (don't-touch: holds migrated-out secrets, auth/TOTP). Per-file sign-off. |
+| `custom_triggers.json` | `routes/skills.save_triggers` | yes | AD-HOC | Phase 1/2 |
+| `triggers.json` / `triggers_killed.json` | `codec_triggers` | yes | review | Phase 2 |
+| `schedules.json` | `codec_scheduler`, `codec_dashboard` | yes | AD-HOC | Phase 1/2 |
+| `voice_session.json` | `codec_voice` | no | AD-HOC | Phase 1 |
+| `<google token>.json` | `codec_google_auth` | no | AD-HOC | **Phase 4** (don't-touch: OAuth token). |
+| `.marketplace.json` | `codec_marketplace` | yes | AD-HOC | Phase 1 |
+| daemon state (`codec_alerts`, `codec_heartbeat`, `codec_imessage`, `codec_proactive`, `codec_agent_messaging`) | respective module | mixed | AD-HOC | Phase 1 |
+| `pomodoro` state | `skills/pomodoro` | no | AD-HOC | Phase 1 |
+| E2E keys / auth sessions (`routes/_shared`) | `_save_e2e_keys`, `_save_sessions` | no | AD-HOC (0600) | Phase 1 (sensitive — review) |
+
+## Migration backlog (Fix #9 follow-on)
+
+Done in the current PR: **Phase 0** (primitive hardening: `atomic_write_json`
+`default=`/`sort_keys=`, new `read_modify_write`) and **Phase 2**
+(`_save_notification` cross-process `file_lock`).
+
+Remaining, tracked for follow-on commits:
+- **Phase 1** — migrate the AD-HOC full-overwrite writers above to
+  `atomic_write_json` (mechanical durability upgrade; one batch).
+- **Phase 3** — converge the OWN-ATOMIC duplicate helpers
+  (`codec_ask_user._atomic_write_text`, `codec_agent_plan._atomic_write_json`)
+  onto the now-`default=`-aware `codec_jsonstore.atomic_write_json`, keeping the
+  named helpers as thin shims. NOTE: these write don't-touch files
+  (`pending_questions.json`, agent `grants/manifest`), so convergence is
+  byte-output-preserving and reviewed per-helper.
+- **Phase 4** — the **don't-touch** files (`config.json`, Google/OAuth tokens,
+  auth writes): migrate last, one file per commit, with operator sign-off
+  (same protocol as Fix #1b's `oauth_state.json` surfacing).
+
+## Why no broad "raw json.dump" CI guard
+
+Considered (the Fix #10 A-12 guard is the model) but rejected: `json.dump` has
+many legitimate non-state uses, so a repo-wide ratchet is low-signal /
+high-false-positive. Regression prevention instead relies on (a) this registry,
+(b) the existing source-level guards `test_json_write_safety.test_notifications_writer_atomic`
+and `test_ask_user_uses_file_lock`, and (c) per-RMW concurrency tests added with
+each migration phase.

--- a/routes/_shared.py
+++ b/routes/_shared.py
@@ -129,7 +129,12 @@ def _save_notification(title, body, status="success", schedule_id=None):
         "read": False,
         "schedule_id": schedule_id
     }
-    with _notif_lock:
+    # Fix #9: the notification writers run in separate PM2 daemons (dashboard,
+    # scheduler, heartbeat, autopilot) that don't share _notif_lock. Hold the
+    # cross-process file_lock across the load->insert->write so they can't
+    # clobber each other (matches the codec_ask_user notification pairing).
+    import codec_jsonstore
+    with _notif_lock, codec_jsonstore.file_lock(NOTIFICATIONS_PATH):
         notifications = _load_notifications()
         notifications.insert(0, notif)
         _write_notifications(notifications)

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -554,13 +554,17 @@ def grant_permission(agent_id: str, body: GrantBody, request: Request = None):
             detail=f"refused: '{body.value}' is a blocked, traversal, or over-broad path grant",
         )
 
-    grants = _cap.load_grants(agent_id)
-    if not grants:
-        raise HTTPException(status_code=409, detail="agent has no grants yet (not approved?)")
+    # C5 (Fix #5): hold the cross-process flock across the whole
+    # load -> modify -> save -> hash-sync so two concurrent /grant calls can't
+    # read the same grants, each add one value, and clobber each other's write.
+    with _cap.grants_lock(agent_id):
+        grants = _cap.load_grants(agent_id)
+        if not grants:
+            raise HTTPException(status_code=409, detail="agent has no grants yet (not approved?)")
 
-    grants[body.kind] = sorted(set(grants.get(body.kind, []) + [body.value]))
-    _cap.save_grants(agent_id, grants)
-    _cap.set_grants_hash(agent_id)  # B-4: keep the tamper hash in sync with the legit grant
+        grants[body.kind] = sorted(set(grants.get(body.kind, []) + [body.value]))
+        _cap.save_grants(agent_id, grants)
+        _cap.set_grants_hash(agent_id)  # B-4: keep the tamper hash in sync with the legit grant
 
     # If blocked, unblock
     if manifest.get("status") == "blocked_on_permission":

--- a/routes/skills.py
+++ b/routes/skills.py
@@ -26,6 +26,25 @@ from routes._shared import (
 router = APIRouter()
 
 
+def _pinned_builtin_names() -> set:
+    """Basenames (e.g. 'calculator.py') of hash-pinned built-in skills, read
+    from the committed <repo>/skills/.manifest.json. An approved user skill must
+    never take one of these names: doing so shadows the trusted built-in (or,
+    if the write dir is the repo skills dir, overwrites the hash-pinned file).
+    Fix #7b / H2·H6. Returns lowercased names so the guard also holds on
+    case-insensitive filesystems (macOS). Empty set on any read failure —
+    callers must treat empty as "couldn't verify", not "nothing pinned"."""
+    try:
+        repo_skills = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "skills"
+        )
+        with open(os.path.join(repo_skills, ".manifest.json"), encoding="utf-8") as f:
+            data = json.load(f)
+        return {str(n).lower() for n in (data.get("skills") or {}).keys()}
+    except Exception:
+        return set()
+
+
 @router.post("/api/skill/review")
 async def skill_review(request: Request):
     """Stage LLM-generated skill code for human review -- does NOT write to disk."""
@@ -54,6 +73,25 @@ async def skill_approve(request: Request):
     filename = pending["filename"]
     if "SKILL_DESCRIPTION" not in code or "def run(" not in code:
         return JSONResponse({"error": "Invalid skill: must contain SKILL_DESCRIPTION and def run()"}, status_code=400)
+    # Fix #7b (H2/H6): never let an approved skill take a hash-pinned built-in's
+    # name — that would shadow (or overwrite) the trusted built-in. The PR-1A
+    # load-time hash/AST gate is the last line of defense; this refuses at the
+    # write point so the trusted file is never displaced in the first place.
+    if filename.lower() in _pinned_builtin_names():
+        try:
+            from codec_audit import log_event
+            log_event(
+                "skill_approve_blocked", source="codec-routes-skills",
+                message=f"refused approve of pinned built-in name {filename}",
+                level="warning", outcome="denied",
+                extra={"filename": filename, "reason": "pinned_builtin_overwrite"},
+            )
+        except Exception:
+            pass
+        return JSONResponse(
+            {"error": f"Refused: '{filename}' is a protected built-in skill name and cannot be overwritten"},
+            status_code=400,
+        )
     from codec_config import is_dangerous_skill_code
     dangerous, reason = is_dangerous_skill_code(code)
     if dangerous:

--- a/skills/web_fetch.py
+++ b/skills/web_fetch.py
@@ -13,7 +13,16 @@ def run(task: str, context: str = "") -> str:
         if not m:
             return "web_fetch failed: no http(s) URL found in task"
         url = m.group(0).rstrip(").,;'\"")
-        
+
+        # Fix #7 (H1): SSRF guard BEFORE the request. Blocks fetches of internal
+        # / loopback / link-local / cloud-metadata addresses — the fetched body
+        # flows back into the chat/LLM transcript, so a read is an exfil path.
+        import codec_ssrf
+        try:
+            codec_ssrf.validate_url(url)
+        except codec_ssrf.SSRFError as e:
+            return f"web_fetch failed: blocked URL ({e})"
+
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         

--- a/tests/test_a12_invariant.py
+++ b/tests/test_a12_invariant.py
@@ -1,0 +1,75 @@
+"""Fix #10: CI guard for the A-12 invariant.
+
+A-12 (see AGENTS.md §2) routed every chat/completions *text* call site onto
+codec_llm. The only inline `requests.post(.../chat/completions)` calls left
+are vision sites (pending A-11 cleanup) and codec_core's generated session
+script. This guard fails if a NEW inline chat/completions POST appears
+anywhere else — i.e. someone bypassed codec_llm.
+
+The detector matches the precise anti-pattern: a `.post(` whose first argument
+literally contains `chat/completions`. URL-in-a-variable callers (codec_llm,
+codec_vision) don't match and don't need allowlisting; that's intended — the
+guard targets the literal inline-POST shape that bypasses the canonical caller.
+"""
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Files permitted to contain an inline `.post(...chat/completions...)`.
+# Every entry is a vision site (pending A-11 migration onto codec_vision) or
+# codec_core's build_session_script, which EMITS the call as a string into the
+# generated session script (not a live POST in codec_core itself).
+_ALLOWLIST = {
+    "codec_dashboard.py",        # screen-vision POSTs (A-11 pending)
+    "codec_watcher.py",          # screen-vision POST (A-11 pending)
+    "codec_imessage.py",         # bridge vision POST (A-11 pending)
+    "codec_telegram.py",         # bridge vision POST (A-11 pending)
+    "skills/screenshot_text.py",  # OCR vision POST (A-11 pending)
+    "codec_core.py",             # generated session-script string, not a live POST
+}
+
+_INLINE_POST_RE = re.compile(r"\.post\s*\([^)]*chat/completions")
+_SKIP_PREFIXES = ("tests/", ".claude/", "scripts/")
+
+
+def _scan(root: Path) -> set:
+    """Return the set of repo-relative .py paths containing an inline
+    chat/completions POST."""
+    found = set()
+    for p in root.rglob("*.py"):
+        rel = p.relative_to(root).as_posix()
+        if rel.startswith(_SKIP_PREFIXES) or "__pycache__" in rel:
+            continue
+        try:
+            text = p.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _INLINE_POST_RE.search(text):
+            found.add(rel)
+    return found
+
+
+def test_no_new_inline_llm_post_outside_codec_llm():
+    found = _scan(REPO)
+    offenders = found - _ALLOWLIST
+    assert not offenders, (
+        "New inline chat/completions POST(s) outside codec_llm "
+        f"(A-12 invariant violated): {sorted(offenders)}.\n"
+        "Route LLM text calls through codec_llm.call/stream/acall/astream. "
+        "If this is a legitimate vision site pending A-11, add it to the "
+        "documented _ALLOWLIST in this test with a reason."
+    )
+
+
+def test_a12_guard_actually_detects_a_violation(tmp_path):
+    # Proves the detector is not a no-op: a synthetic rogue inline POST is found.
+    (tmp_path / "rogue_skill.py").write_text(
+        "import requests\n"
+        "def run(t):\n"
+        '    return requests.post("http://127.0.0.1:8090/v1/chat/completions", json={}).text\n'
+    )
+    (tmp_path / "innocent.py").write_text("x = 1\n")
+    found = _scan(tmp_path)
+    assert "rogue_skill.py" in found, "guard failed to detect an inline chat/completions POST"
+    assert "innocent.py" not in found, "guard false-positived on an unrelated file"

--- a/tests/test_chat_helpers.py
+++ b/tests/test_chat_helpers.py
@@ -1,0 +1,45 @@
+"""Fix #8: unit tests for the chat-handler helpers extracted from
+chat_completion. The extraction (_build_chat_system_prompt, _chat_vision_response)
+made these independently testable in isolation — that testability is the point
+of reducing the god-module's hottest handler. Behavior is locked here; the
+broader /api/chat behavior stays covered by test_chat_stream / test_step_budget /
+test_chat_escalation / test_dashboard_api.
+"""
+import codec_dashboard as dash
+
+_LOCAL_CFG = {"llm_base_url": "http://localhost:8083/v1"}
+
+
+def _budget():
+    return dash._StepBudget(route="chat", correlation_id="abcdef123456")
+
+
+def test_vision_response_none_without_images():
+    assert dash._chat_vision_response({"messages": []}, []) is None
+
+
+def test_build_system_prompt_adds_attachment_note():
+    out = dash._build_chat_system_prompt(_LOCAL_CFG, _budget(), has_attachment=True,
+                                         last_user_text="look at this")
+    assert "attached a file or image" in out
+    assert "DO NOT emit [SKILL:...]" in out
+
+
+def test_build_system_prompt_adds_content_rewrite_note():
+    out = dash._build_chat_system_prompt(_LOCAL_CFG, _budget(), has_attachment=False,
+                                         last_user_text="please rewrite this email")
+    assert "rewritten content as plain prose" in out
+
+
+def test_build_system_prompt_plain_request_has_no_turn_overrides():
+    out = dash._build_chat_system_prompt(_LOCAL_CFG, _budget(), has_attachment=False,
+                                         last_user_text="what's the weather like?")
+    assert "attached a file or image" not in out
+    assert "rewritten content as plain prose" not in out
+
+
+def test_build_system_prompt_consumes_one_llm_call_step():
+    b = _budget()
+    assert b.count == 0
+    dash._build_chat_system_prompt(_LOCAL_CFG, b, has_attachment=False, last_user_text="hi")
+    assert b.count == 1, "the llm_call step must be consumed inside the prompt builder"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,80 @@
+"""Tests for codec_concurrency.run_with_timeout (Fix #4 / C4).
+
+The bug being fixed: `with ThreadPoolExecutor() as ex: fut.result(timeout=T)`
+defeats its own timeout — the context-manager __exit__ calls
+shutdown(wait=True), which blocks until the runaway task finishes. So a 50ms
+"timeout" on a 5s task actually takes ~5s.
+
+run_with_timeout must surface the timeout PROMPTLY and never block on the
+abandoned worker (daemon thread, no shutdown(wait=True)).
+"""
+import concurrent.futures
+import threading
+import time
+
+import pytest
+
+import codec_concurrency
+
+
+def test_returns_result_for_fast_fn():
+    assert codec_concurrency.run_with_timeout(lambda: 42, 1.0) == 42
+
+
+def test_passes_through_args_and_kwargs():
+    def add(a, b, c=0):
+        return a + b + c
+
+    assert codec_concurrency.run_with_timeout(add, 1.0, 2, 3, c=4) == 9
+
+
+def test_timeout_raises_TimeoutError():
+    def slow():
+        time.sleep(5)
+        return "should-not-return"
+
+    with pytest.raises(TimeoutError):
+        codec_concurrency.run_with_timeout(slow, 0.05)
+
+
+def test_timeout_returns_promptly_does_not_block_on_runaway():
+    # THE C4 regression guard: a 5s task with a 50ms timeout must surface the
+    # timeout in well under the task duration. If run_with_timeout blocked on
+    # shutdown(wait=True) like the old ThreadPoolExecutor pattern, this would
+    # take ~5s and the assertion would fail.
+    started = threading.Event()
+
+    def slow():
+        started.set()
+        time.sleep(5)
+
+    t0 = time.monotonic()
+    with pytest.raises(TimeoutError):
+        codec_concurrency.run_with_timeout(slow, 0.05)
+    elapsed = time.monotonic() - t0
+    assert started.is_set(), "worker thread should have started"
+    assert elapsed < 1.0, (
+        f"timeout took {elapsed:.2f}s — it blocked on the runaway task; "
+        "C4 (shutdown(wait=True)) not actually fixed"
+    )
+
+
+def test_reraises_fn_exception_with_type_and_message():
+    def boom():
+        raise ValueError("kaboom")
+
+    with pytest.raises(ValueError, match="kaboom"):
+        codec_concurrency.run_with_timeout(boom, 1.0)
+
+
+def test_timeouterror_is_caught_as_concurrent_futures_timeout():
+    # The migrated call sites catch concurrent.futures.TimeoutError. On
+    # py3.11+ that is an alias of builtin TimeoutError, so a helper raising
+    # builtin TimeoutError is still caught. Guard that contract explicitly.
+    assert concurrent.futures.TimeoutError is TimeoutError
+
+    def slow():
+        time.sleep(5)
+
+    with pytest.raises(concurrent.futures.TimeoutError):
+        codec_concurrency.run_with_timeout(slow, 0.05)

--- a/tests/test_jsonstore.py
+++ b/tests/test_jsonstore.py
@@ -1,0 +1,96 @@
+"""Fix #9 Phase 0: harden codec_jsonstore primitives.
+
+- atomic_write_json gains optional `default=` (custom JSON serializer, e.g.
+  str for datetime) and `sort_keys=` passthrough, so it can subsume the
+  hand-rolled helpers (codec_ask_user._atomic_write_text uses default=str).
+- new read_modify_write(path, fn) standardizes the lock+load+mutate+atomic-write
+  pattern so a future RMW site can't forget the file_lock.
+"""
+import json
+import os
+import stat
+import threading
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+import codec_jsonstore
+
+
+def test_atomic_write_json_roundtrip_and_0600(tmp_path):
+    p = tmp_path / "x.json"
+    codec_jsonstore.atomic_write_json(p, {"a": 1})
+    assert json.loads(p.read_text()) == {"a": 1}
+    assert stat.S_IMODE(os.stat(p).st_mode) == 0o600
+
+
+def test_atomic_write_json_default_serializer(tmp_path):
+    p = tmp_path / "dt.json"
+    dt = datetime(2026, 5, 29, tzinfo=timezone.utc)
+    codec_jsonstore.atomic_write_json(p, {"when": dt}, default=str)
+    assert "2026-05-29" in p.read_text()
+
+
+def test_atomic_write_json_raises_without_default_and_leaves_no_file(tmp_path):
+    p = tmp_path / "bad.json"
+    with pytest.raises(TypeError):
+        codec_jsonstore.atomic_write_json(p, {"when": datetime(2026, 5, 29)})
+    assert not p.exists(), "a failed write must not leave a partial target file"
+
+
+def test_atomic_write_json_sort_keys(tmp_path):
+    p = tmp_path / "s.json"
+    codec_jsonstore.atomic_write_json(p, {"b": 1, "a": 2}, sort_keys=True)
+    text = p.read_text()
+    assert text.index('"a"') < text.index('"b"')
+
+
+def test_read_modify_write_applies_and_persists(tmp_path):
+    p = tmp_path / "rmw.json"
+    codec_jsonstore.atomic_write_json(p, {"n": 0})
+
+    def bump(d):
+        d["n"] += 1
+        return d
+
+    out = codec_jsonstore.read_modify_write(p, bump)
+    assert out == {"n": 1}
+    assert json.loads(p.read_text()) == {"n": 1}
+
+
+def test_read_modify_write_missing_file_uses_default_factory(tmp_path):
+    p = tmp_path / "missing.json"
+
+    def add(d):
+        d["k"] = "v"
+        return d
+
+    out = codec_jsonstore.read_modify_write(p, add, default_factory=dict)
+    assert out == {"k": "v"}
+
+
+def test_read_modify_write_no_clobber_under_concurrency(tmp_path):
+    p = tmp_path / "conc.json"
+    codec_jsonstore.atomic_write_json(p, {"items": []})
+    n = 16
+    barrier = threading.Barrier(n)
+
+    def worker(i):
+        barrier.wait()
+
+        def add(d):
+            time.sleep(0.005)  # widen the read-modify-write window
+            d["items"] = d.get("items", []) + [i]
+            return d
+
+        codec_jsonstore.read_modify_write(p, add)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    items = json.loads(p.read_text())["items"]
+    assert sorted(items) == list(range(n)), f"read_modify_write clobbered: {sorted(items)}"

--- a/tests/test_notifications_lock.py
+++ b/tests/test_notifications_lock.py
@@ -1,0 +1,55 @@
+"""Fix #9 Phase 2: _save_notification cross-process safety.
+
+routes/_shared._save_notification does a load->insert->write RMW under the
+in-process `_notif_lock` only. The notification writers run in SEPARATE PM2
+daemons (dashboard, scheduler, heartbeat, autopilot), which do NOT share that
+threading lock — so concurrent saves across processes clobber each other.
+
+This test simulates separate processes by neutralizing the in-process lock,
+then asserts no notification is lost. It fails before the cross-process
+file_lock is added and passes after.
+"""
+import contextlib
+import json
+import threading
+import time
+
+import codec_jsonstore
+import routes._shared as shared
+
+
+def test_save_notification_no_clobber_across_processes(tmp_path, monkeypatch):
+    notifs_path = tmp_path / "notifications.json"
+    monkeypatch.setattr(shared, "NOTIFICATIONS_PATH", str(notifs_path))
+    codec_jsonstore.atomic_write_json(notifs_path, [])  # start empty (no sample seed)
+
+    # Simulate independent processes: each daemon has its OWN process, so the
+    # in-process _notif_lock does not serialize them. nullcontext models that.
+    monkeypatch.setattr(shared, "_notif_lock", contextlib.nullcontext())
+
+    # Widen the read-modify-write window so an unlocked path reliably clobbers.
+    real_write = shared._write_notifications
+
+    def slow_write(notifs):
+        time.sleep(0.01)
+        return real_write(notifs)
+
+    monkeypatch.setattr(shared, "_write_notifications", slow_write)
+
+    n = 12
+    barrier = threading.Barrier(n)
+
+    def worker(i):
+        barrier.wait()
+        shared._save_notification(f"t{i}", "body")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    titles = {x["title"] for x in json.loads(notifs_path.read_text())}
+    assert titles == {f"t{i}" for i in range(n)}, (
+        f"notifications clobbered across processes: {len(titles)}/{n} survived"
+    )

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -154,6 +154,60 @@ def test_fallback_write_is_fsync_durable(tmp_path, monkeypatch):
     assert mode == 0o600, f"fallback file must be 0600; got {oct(mode)}"
 
 
+# ── Fix #10: OAuth scope-escalation regression coverage ──────────────────────
+def test_refresh_rejects_scope_escalation(tmp_path):
+    """A refresh token issued for ['read'] must NOT be exchangeable for
+    ['read','write'] — exchange_refresh_token enforces requested ⊆ original.
+    Pins the scope-escalation defense (codec_oauth_provider.py:244-249) so a
+    future refactor that drops the subset check fails CI."""
+    import time
+
+    from mcp.server.auth.provider import RefreshToken, TokenError
+
+    p = PersistentOAuthProvider(
+        base_url="https://test.example.com",
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        state_path=tmp_path / "state.json",
+    )
+    client = _make_client("escal")
+    asyncio.run(p.register_client(client))
+    rt = RefreshToken(
+        token="codec_rt_orig",
+        client_id="escal",
+        scopes=["read"],
+        expires_at=int(time.time() + 3600),
+    )
+    with pytest.raises(TokenError) as exc:
+        asyncio.run(p.exchange_refresh_token(client, rt, ["read", "write"]))
+    assert "scope" in str(exc.value).lower()
+
+
+def test_refresh_allows_subset_scopes(tmp_path):
+    """A refresh for a SUBSET of the original scopes succeeds, and the new
+    access token carries only the narrowed scopes (no silent widening)."""
+    import time
+
+    from mcp.server.auth.provider import RefreshToken
+
+    p = PersistentOAuthProvider(
+        base_url="https://test.example.com",
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        state_path=tmp_path / "state.json",
+    )
+    client = _make_client("narrow")
+    asyncio.run(p.register_client(client))
+    rt = RefreshToken(
+        token="codec_rt_orig2",
+        client_id="narrow",
+        scopes=["read", "write"],
+        expires_at=int(time.time() + 3600),
+    )
+    p.refresh_tokens[rt.token] = rt  # register so the internal revoke is clean
+    token = asyncio.run(p.exchange_refresh_token(client, rt, ["read"]))
+    assert "read" in (token.scope or ""), "narrowed scope must include the requested scope"
+    assert "write" not in (token.scope or ""), "new token must not carry the dropped scope"
+
+
 if __name__ == "__main__":
     import tempfile
     with tempfile.TemporaryDirectory() as d:

--- a/tests/test_skill_overwrite.py
+++ b/tests/test_skill_overwrite.py
@@ -1,0 +1,52 @@
+"""Fix #7b (H2/H6): skill approve must not overwrite/shadow a hash-pinned built-in.
+
+The review-and-approve flow (routes/skills.py) writes an approved skill to the
+skills dir by basename. Without a guard, an approved skill named after a
+manifest-pinned built-in (e.g. calculator.py, file_write.py) takes that
+trusted name — shadowing the real built-in (or overwriting it if the write
+dir is the repo skills dir). The approve gate must refuse pinned names.
+"""
+import asyncio
+
+import routes.skills as skills_routes
+
+
+class _FakeReq:
+    def __init__(self, payload):
+        self._p = payload
+
+    async def json(self):
+        return self._p
+
+
+_BENIGN = (
+    'SKILL_NAME = "x"\n'
+    'SKILL_DESCRIPTION = "x"\n'
+    'SKILL_TRIGGERS = []\n'
+    'def run(task, app="", ctx=""):\n'
+    '    return "ok"\n'
+)
+
+
+def _approve(payload):
+    return asyncio.run(skills_routes.skill_approve(_FakeReq(payload)))
+
+
+def test_skill_approve_refuses_pinned_builtin_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(skills_routes, "_get_skills_dir", lambda: str(tmp_path))
+    rid = "rev_pinned"
+    skills_routes._pending_skills[rid] = {"code": _BENIGN, "filename": "calculator.py"}
+    resp = _approve({"review_id": rid})
+    status = getattr(resp, "status_code", 200)
+    assert status == 400, f"approving a pinned built-in name must be 400, got {status}: {resp}"
+    assert not (tmp_path / "calculator.py").exists(), "a pinned built-in was written to disk"
+
+
+def test_skill_approve_allows_non_pinned_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(skills_routes, "_get_skills_dir", lambda: str(tmp_path))
+    rid = "rev_ok"
+    skills_routes._pending_skills[rid] = {"code": _BENIGN, "filename": "my_unique_helper.py"}
+    resp = _approve({"review_id": rid})
+    status = getattr(resp, "status_code", 200)
+    assert status == 200, f"a non-pinned skill should approve, got {status}: {resp}"
+    assert (tmp_path / "my_unique_helper.py").exists()

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1,0 +1,112 @@
+"""Fix #7a (H1/H2/H6): SSRF guard for outbound URL fetches.
+
+codec_ssrf.validate_url(url) must reject URLs that would let an
+attacker-supplied link (chat injection / clipboard / crew task) reach
+internal services or the cloud metadata endpoint, while allowing ordinary
+public hosts.
+
+Network-free by design: IP-literal + bad-scheme cases need no DNS; the
+allow / mixed-resolution cases monkeypatch socket.getaddrinfo.
+"""
+import pytest
+
+import codec_ssrf
+
+
+# IP literals + bad schemes — no DNS lookup needed, fully deterministic.
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://10.0.0.5/internal",
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+        "http://[::1]/",
+        "http://0.0.0.0/",
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "gopher://evil/",
+        "",
+        "not-a-url",
+    ],
+)
+def test_validate_url_rejects_unsafe(url):
+    with pytest.raises(codec_ssrf.SSRFError):
+        codec_ssrf.validate_url(url)
+
+
+def test_validate_url_allows_public_host(monkeypatch):
+    monkeypatch.setattr(
+        codec_ssrf.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+    assert codec_ssrf.validate_url("https://example.com/page") == "https://example.com/page"
+
+
+def test_validate_url_rejects_when_any_resolved_ip_is_internal(monkeypatch):
+    # DNS-rebinding-style defense: a hostname that resolves to BOTH a public
+    # and an internal address must be rejected (ANY blocked → reject).
+    monkeypatch.setattr(
+        codec_ssrf.socket,
+        "getaddrinfo",
+        lambda *a, **k: [
+            (2, 1, 6, "", ("93.184.216.34", 80)),
+            (2, 1, 6, "", ("169.254.169.254", 80)),
+        ],
+    )
+    with pytest.raises(codec_ssrf.SSRFError):
+        codec_ssrf.validate_url("http://rebind.example/")
+
+
+def test_validate_url_rejects_dns_failure(monkeypatch):
+    import socket as _socket
+
+    def _boom(*a, **k):
+        raise _socket.gaierror("name does not resolve")
+
+    monkeypatch.setattr(codec_ssrf.socket, "getaddrinfo", _boom)
+    with pytest.raises(codec_ssrf.SSRFError):
+        codec_ssrf.validate_url("http://nonexistent.invalid/")
+
+
+# ── Wiring: the guard must run BEFORE the HTTP client at every fetch site ────
+def _load_web_fetch_skill():
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parent.parent / "skills" / "web_fetch.py"
+    spec = importlib.util.spec_from_file_location("_wf_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_web_fetch_skill_does_not_request_blocked_url(monkeypatch):
+    web_fetch = _load_web_fetch_skill()
+    calls = {"n": 0}
+
+    def _boom(*a, **k):
+        calls["n"] += 1
+        raise AssertionError("requests.get must not be called for a blocked URL")
+
+    monkeypatch.setattr(web_fetch.requests, "get", _boom)
+    result = web_fetch.run("fetch http://169.254.169.254/latest/meta-data/")
+    assert calls["n"] == 0, "web_fetch reached the network for an SSRF-blocked URL"
+    assert "block" in result.lower(), f"expected an SSRF-block message, got: {result!r}"
+
+
+def test_agents_web_fetch_tool_does_not_request_blocked_url(monkeypatch):
+    import codec_agents
+
+    calls = {"n": 0}
+
+    def _boom(*a, **k):
+        calls["n"] += 1
+        raise AssertionError("_sync_http.get must not be called for a blocked URL")
+
+    monkeypatch.setattr(codec_agents._sync_http, "get", _boom)
+    result = codec_agents._web_fetch("http://127.0.0.1/internal")
+    assert calls["n"] == 0, "_web_fetch reached the network for an SSRF-blocked URL"
+    assert "block" in result.lower(), f"expected an SSRF-block message, got: {result!r}"

--- a/tests/test_state_locking.py
+++ b/tests/test_state_locking.py
@@ -1,0 +1,151 @@
+"""Fix #5 (C5 / H14 / M6): SQLite + JSON state locking.
+
+Two race classes the audit flagged:
+
+1. CodecMemory shares one sqlite3 connection across threads
+   (`check_same_thread=False`) with no app-level lock — concurrent save()
+   calls interleave on the same connection.
+2. read-modify-write of ~/.codec JSON state without a cross-process
+   file_lock — concurrent writers clobber each other (grant_permission on
+   grants.json; _write_question_notification on notifications.json).
+
+Each test below fails against the pre-fix code for the RIGHT reason (observed
+overlap / lost write), and passes once the lock is added.
+"""
+import threading
+import time
+
+import codec_agent_plan
+import codec_memory
+
+
+# ── 1. SQLite connection serialization ──────────────────────────────────────
+def test_concurrent_save_serializes_db_access(tmp_path):
+    # NOTE: a fully MOCK connection is used deliberately. Letting real
+    # concurrent execute() calls hit the same sqlite3 connection segfaults the
+    # interpreter (that crash IS the C5 bug) — which would kill the test runner
+    # rather than produce a clean assertion. The mock measures whether
+    # CodecMemory.save serializes access to the connection object, which is
+    # exactly what the RLock fix provides, without invoking the C layer.
+    mem = codec_memory.CodecMemory(db_path=str(tmp_path / "mem.db"))
+
+    class _OverlapProbe:
+        """Stands in for the live connection. Flags any concurrent re-entry of
+        execute(); a widened window (sleep) makes overlap observable when the
+        caller is NOT serializing access."""
+
+        def __init__(self):
+            self._n = 0
+            self.max_concurrent = 0
+            self._rowid = 0
+            self._cl = threading.Lock()
+
+        def execute(self, *a, **k):
+            with self._cl:
+                self._n += 1
+                self.max_concurrent = max(self.max_concurrent, self._n)
+                self._rowid += 1
+                rowid = self._rowid
+            try:
+                time.sleep(0.003)
+            finally:
+                with self._cl:
+                    self._n -= 1
+            return type("_Cur", (), {"lastrowid": rowid})()
+
+        def commit(self):
+            pass
+
+    probe = _OverlapProbe()
+    mem._conn = probe  # _get_conn() returns this since it's non-None
+
+    def worker(i):
+        for j in range(4):
+            mem.save(f"s{i}", "user", f"m{i}-{j}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert probe.max_concurrent == 1, (
+        f"CodecMemory.save overlapped on the shared connection "
+        f"(max concurrent execute={probe.max_concurrent}); not serialized (C5)"
+    )
+
+
+# ── 2. grants.json read-modify-write under file_lock ─────────────────────────
+def test_concurrent_grant_permission_no_clobber(tmp_path, monkeypatch):
+    from routes.agents import GrantBody, grant_permission
+
+    agents_dir = tmp_path / "agents"
+    monkeypatch.setattr(codec_agent_plan, "_AGENTS_DIR", agents_dir)
+
+    # Widen the read-modify-write window so an unlocked path reliably clobbers.
+    real_save = codec_agent_plan.save_grants
+
+    def slow_save(agent_id, grants):
+        time.sleep(0.02)
+        return real_save(agent_id, grants)
+
+    monkeypatch.setattr(codec_agent_plan, "save_grants", slow_save)
+
+    aid = "agent_test"
+    codec_agent_plan.save_manifest(aid, {"id": aid, "status": "running", "title": "t"})
+    codec_agent_plan.save_grants(
+        aid,
+        {"skills": ["web_search"], "network_domains": [], "read_paths": [], "write_paths": []},
+    )
+
+    n = 12
+    barrier = threading.Barrier(n)
+    errors = []
+
+    def worker(i):
+        try:
+            barrier.wait()  # maximize contention on the load->modify->save window
+            grant_permission(
+                aid, GrantBody(kind="network_domains", value=f"d{i}.example.com"), request=None
+            )
+        except Exception as e:  # noqa: BLE001
+            errors.append(repr(e))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"grant_permission raised: {errors}"
+    final = codec_agent_plan.load_grants(aid)["network_domains"]
+    assert sorted(final) == sorted(f"d{i}.example.com" for i in range(n)), (
+        f"grants clobbered: expected {n} domains, got {len(final)}: {sorted(final)}"
+    )
+
+
+# ── 3. notifications.json write holds the cross-process file_lock ────────────
+def test_question_notification_uses_cross_process_file_lock(tmp_path, monkeypatch):
+    import codec_ask_user
+
+    notifs_path = tmp_path / "notifications.json"
+    monkeypatch.setattr(codec_ask_user, "NOTIFICATIONS_PATH", notifs_path)
+
+    locked_paths = []
+    real_file_lock = codec_ask_user.codec_jsonstore.file_lock
+
+    def spy_file_lock(path):
+        locked_paths.append(str(path))
+        return real_file_lock(path)
+
+    monkeypatch.setattr(codec_ask_user.codec_jsonstore, "file_lock", spy_file_lock)
+
+    codec_ask_user._write_question_notification(
+        {"id": "q_abc", "question": "proceed?", "agent": None, "options": None,
+         "deadline": None, "consent_strict": False}
+    )
+
+    assert str(notifs_path) in locked_paths, (
+        "_write_question_notification must hold codec_jsonstore.file_lock on "
+        "notifications.json across its read-modify-write (cross-process safety)"
+    )


### PR DESCRIPTION
Continuation of the top-10 audit remediation. **Phase A (#1·#2·#3, C1/C2/C3/C6/C7) already merged** via PR #152 (squash → `main`). This PR carries the Phase B/C work that was pushed after that merge.

All TDD'd; **490 tests green** across touched modules; ruff clean; rebased cleanly onto current `main`.

| Commit | Fix | Findings |
|---|---|---|
| `run_with_timeout` | #4 | **C4** — kill the hanging ThreadPoolExecutor in mcp/observer |
| state locking | #5 | **C5·H14·M6** — SQLite RLock + cross-process file_lock (grants/notifications) |
| SSRF guard | #7a | **H1** — block internal/metadata URLs in web_fetch + crew fetch |
| skill-overwrite | #7b | **H2·H6** — approve refuses shadowing a pinned built-in |
| A-12 guard + OAuth scope tests | #10 | test coverage |
| jsonstore core | #9 | **C8** — atomic_write_json `default=`/`sort_keys=` + `read_modify_write`; notifications RMW lock; `docs/STATE-FILES.md` |
| chat helper extraction | #8 | **C9 (start)** — `chat_completion` 356→252 lines, behavior-preserving |

### Partial / deferred (documented)
- **#8** module split → deferred (`chat_completion` shares prompt helpers with the prompt-override endpoints → circular import; intra-file CC reduction landed instead). See `docs/FIX8-…`.
- **#9** Phases 1/3/4 → deferred (mass swaps; helper convergence touches don't-touch `pending_questions`/`grants`; don't-touch files need per-file sign-off). See `docs/STATE-FILES.md`.
- **#6** (deps + PM2 interpreter pin) → not started; needs the live venv path + a watched `pm2 restart`.

### Reviewer notes
- **C5:** the new test reproduced a hard **segfault** from concurrent unserialized sqlite access pre-fix.
- **C3 sandbox** (in Phase A): broad `allow file-read*` retained + layered `(deny …)` after it (SBPL last-match-wins) to avoid breaking stdlib imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)