### PR TITLE
security: re-audit tail — traversal guard, step-budget parity, jsonstore Phase 1

### DIFF
--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -230,6 +230,13 @@ def _read_json(path: Path) -> Optional[Dict[str, Any]]:
 
 
 def _agent_dir(agent_id: str) -> Path:
+    # re-audit: reject path-traversal. The path-param endpoints pass agent_id
+    # raw; create_agent slugs are always [\w-]. A '/', '\\', '..', or a leading
+    # '.'/'~' could escape _AGENTS_DIR (read/shape JSON outside it). Readers
+    # below catch this and degrade to empty so the endpoints return 404, not 500.
+    if (not agent_id or "/" in agent_id or "\\" in agent_id or ".." in agent_id
+            or agent_id.startswith(".") or agent_id.startswith("~")):
+        raise ValueError(f"unsafe agent_id: {agent_id!r}")
     return _AGENTS_DIR / agent_id
 
 
@@ -239,7 +246,10 @@ def save_plan(plan: Plan) -> None:
 
 
 def load_plan(agent_id: str) -> Optional[Plan]:
-    d = _read_json(_agent_dir(agent_id) / "plan.json")
+    try:
+        d = _read_json(_agent_dir(agent_id) / "plan.json")
+    except ValueError:
+        return None  # unsafe agent_id → treat as not found
     return plan_from_dict(d) if d else None
 
 
@@ -249,7 +259,10 @@ def save_state(agent_id: str, state: Dict[str, Any]) -> None:
 
 
 def load_state(agent_id: str) -> Dict[str, Any]:
-    return _read_json(_agent_dir(agent_id) / "state.json") or {}
+    try:
+        return _read_json(_agent_dir(agent_id) / "state.json") or {}
+    except ValueError:
+        return {}
 
 
 # ── Manifest R/W ──────────────────────────────────────────────────────────────
@@ -258,7 +271,10 @@ def save_manifest(agent_id: str, manifest: Dict[str, Any]) -> None:
 
 
 def load_manifest(agent_id: str) -> Dict[str, Any]:
-    return _read_json(_agent_dir(agent_id) / "manifest.json") or {}
+    try:
+        return _read_json(_agent_dir(agent_id) / "manifest.json") or {}
+    except ValueError:
+        return {}
 
 
 # ── Grants R/W ────────────────────────────────────────────────────────────────
@@ -267,7 +283,10 @@ def save_grants(agent_id: str, grants: Dict[str, Any]) -> None:
 
 
 def load_grants(agent_id: str) -> Dict[str, Any]:
-    return _read_json(_agent_dir(agent_id) / "grants.json") or {}
+    try:
+        return _read_json(_agent_dir(agent_id) / "grants.json") or {}
+    except ValueError:
+        return {}
 
 
 def compute_grants_hash(agent_id: str) -> str:

--- a/codec_alerts.py
+++ b/codec_alerts.py
@@ -43,9 +43,10 @@ def _load_state() -> dict:
 
 
 def _save_state(state: dict):
-    os.makedirs(os.path.dirname(ALERT_STATE_PATH), exist_ok=True)
-    with open(ALERT_STATE_PATH, "w") as f:
-        json.dump(state, f, indent=2)
+    # Fix #9 Phase 1: atomic write (tmp+fsync+replace) so a crash mid-write
+    # can't truncate the alert state.
+    import codec_jsonstore
+    codec_jsonstore.atomic_write_json(ALERT_STATE_PATH, state)
 
 
 # ── Alert Channels ──────────────────────────────────────────────────────

--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -3014,7 +3014,14 @@ async def chat_completion(request: Request):
         skill_tag = re.search(r'\[SKILL:(\w+):([^\]]+)\]', answer)
         if skill_tag:
             s_name, s_query = skill_tag.group(1), skill_tag.group(2)
-            if s_name in CHAT_SKILL_ALLOWLIST:
+            if s_name in CHAT_SKILL_ALLOWLIST and not _budget.consume("post_llm_skill_tag"):
+                # re-audit medium: the non-streaming path previously skipped the
+                # step budget that the streaming _resolve_skill_tag enforces, so
+                # stream:false could run skills past the per-turn cap. Mirror the
+                # stream path: budget exhausted → drop the tag.
+                log.info("[Chat] step_budget exhausted — dropping [SKILL:...] tag (non-stream)")
+                answer = answer.replace(skill_tag.group(0), "")
+            elif s_name in CHAT_SKILL_ALLOWLIST:
                 try:
                     _, s_result = await asyncio.to_thread(_try_skill_by_name, s_name, s_query)
                     if s_result:

--- a/codec_imessage.py
+++ b/codec_imessage.py
@@ -96,9 +96,9 @@ def load_state():
 
 
 def save_state(state):
-    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
-    with open(STATE_FILE, "w") as f:
-        json.dump(state, f)
+    # Fix #9 Phase 1: atomic write.
+    import codec_jsonstore
+    codec_jsonstore.atomic_write_json(STATE_FILE, state)
 
 
 # ── Audit logging ────────────────────────────────────────────────────────────

--- a/codec_marketplace.py
+++ b/codec_marketplace.py
@@ -47,8 +47,9 @@ def _load_marketplace_meta() -> dict:
 
 
 def _save_marketplace_meta(meta: dict) -> None:
-    with open(MARKETPLACE_META, "w") as f:
-        json.dump(meta, f, indent=2)
+    # Fix #9 Phase 1: atomic write.
+    import codec_jsonstore
+    codec_jsonstore.atomic_write_json(MARKETPLACE_META, meta)
 
 
 def _load_cached_registry() -> dict:
@@ -70,8 +71,8 @@ def _fetch_registry(silent: bool = False) -> dict:
         r = requests.get(REGISTRY_URL, timeout=15)
         if r.status_code == 200:
             data = r.json()
-            with open(os.path.join(CACHE_DIR, "registry.json"), "w") as f:
-                json.dump(data, f, indent=2)
+            import codec_jsonstore
+            codec_jsonstore.atomic_write_json(os.path.join(CACHE_DIR, "registry.json"), data)
             return data
         if not silent:
             print(f"Registry fetch failed: HTTP {r.status_code} — using cached registry")

--- a/codec_memory_upgrade.py
+++ b/codec_memory_upgrade.py
@@ -231,8 +231,9 @@ def _load_entity_map() -> dict:
 
 
 def _save_entity_map(m: dict) -> None:
-    with open(ENTITY_MAP_PATH, "w") as f:
-        json.dump(m, f, indent=2, sort_keys=True)
+    # Fix #9 Phase 1: atomic write (sort_keys preserved for stable diffs).
+    import codec_jsonstore
+    codec_jsonstore.atomic_write_json(ENTITY_MAP_PATH, m, sort_keys=True)
 
 
 def compress_rule_based(text: str, entity_map: Optional[dict] = None) -> str:

--- a/codec_scheduler.py
+++ b/codec_scheduler.py
@@ -36,8 +36,9 @@ def load_schedules() -> list:
 
 
 def save_schedules(schedules: list):
-    with open(SCHEDULE_PATH, "w") as f:
-        json.dump(schedules, f, indent=2)
+    # Fix #9 Phase 1: atomic write (was truncate-then-write, racing readers).
+    import codec_jsonstore
+    codec_jsonstore.atomic_write_json(SCHEDULE_PATH, schedules)
 
 
 # ── Management ──────────────────────────────────────────────────────────────

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -57,7 +57,7 @@
     "pilot.py": "ded952504f8d44c3c6ea5b1da1ef2f09f0bbf1b771e2ad9dd90db6cd1701c3fb",
     "plugin_approve.py": "c93861353be2a9ebe08df212ca167bea646962dbeafe704b1864cd78a8cf57cc",
     "pm2_control.py": "53d34a9ddb7689b86f192694d6ccc18b154538626cbc72992445d0b74f2e5662",
-    "pomodoro.py": "07b04b5f06a7b20ced396d4d10a377b8e7e6c9e97e39b4bbbfa626c9c5ad02b1",
+    "pomodoro.py": "462142327a8c1e61668275c444816a09868cac9d44db231ba37727eb609c46d6",
     "process_manager.py": "742126eb470b89f91231b58d6e30da6a6683fdb435a2b05f6b070954853a19f9",
     "python_exec.py": "e3e5bc4fe55b260858d7b510cd6ccd7dcb43958c2828200130af9e51db0fa7e8",
     "qr_generator.py": "e261a47efc0f85b3773879fdd481fb7a7eae450d61a93ba85701b41c916a0054",

--- a/skills/pomodoro.py
+++ b/skills/pomodoro.py
@@ -27,9 +27,9 @@ def _read_state():
 
 
 def _write_state(state):
-    os.makedirs(os.path.dirname(_STATE_FILE), exist_ok=True)
-    with open(_STATE_FILE, "w") as f:
-        json.dump(state, f)
+    # Fix #9 Phase 1: atomic write.
+    import codec_jsonstore
+    codec_jsonstore.atomic_write_json(_STATE_FILE, state)
 
 
 def _clear_state():

--- a/tests/test_agent_id_traversal.py
+++ b/tests/test_agent_id_traversal.py
@@ -1,0 +1,37 @@
+"""re-audit MEDIUM: routes/agents.py path-param endpoints pass {agent_id} raw to
+codec_agent_plan._agent_dir(_AGENTS_DIR / agent_id) with no sanitization, so an
+authenticated caller could traverse (../) to read/shape JSON outside the agents
+dir. create_agent slugs are safe; the path-param endpoints are not. _agent_dir
+must reject traversal, and the load_* readers must degrade to empty (→ the
+endpoints return 404, not 500).
+"""
+import pytest
+
+import codec_agent_plan
+
+
+@pytest.mark.parametrize("bad", [
+    "../../etc/passwd",
+    "..",
+    "a/b",
+    "a\\b",
+    ".hidden",
+    "~root",
+    "",
+])
+def test_agent_dir_rejects_traversal(bad):
+    with pytest.raises(ValueError):
+        codec_agent_plan._agent_dir(bad)
+
+
+def test_agent_dir_allows_normal_slug():
+    p = codec_agent_plan._agent_dir("agent_abc-123")
+    assert p.name == "agent_abc-123"
+
+
+def test_load_manifest_graceful_on_traversal():
+    # readers must not raise on a hostile id — endpoints rely on {}/None → 404.
+    assert codec_agent_plan.load_manifest("../../etc/passwd") == {}
+    assert codec_agent_plan.load_grants("../../etc") == {}
+    assert codec_agent_plan.load_state("..") == {}
+    assert codec_agent_plan.load_plan("../x") is None


### PR DESCRIPTION
Post-#154 cleanup. Three concerns, all TDD'd / verified, ruff clean, manifest current.

| Item | What |
|---|---|
| **agent_id traversal** (Medium) | `_agent_dir` rejects `/`,`\`,`..`,leading `.`/`~`; loaders degrade to empty → 404 not 500. |
| **non-stream `[SKILL:]` step-budget** (Medium) | non-streaming post-LLM tag path now consumes the budget the streaming path enforces. |
| **jsonstore Phase 1** (C8) | atomic-write migration of 6 ad-hoc state writers: alerts, marketplace (meta+registry), memory_upgrade (entity_map), imessage, scheduler (schedules), pomodoro. Manifest regenerated for pomodoro. |

Deferred (documented): #9 Phase 2 (notifications-RMW writers in heartbeat/scheduler → file_lock), Phase 3 (converge codec_proactive/agent_messaging own atomic helpers), Phase 4 (don't-touch config/token files); the #8 routes/chat.py split (hot-path move, complexity value already shipped in #154); codec_voice marker (working pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)