### PR TITLE
security: jsonstore Phase 2 — notifications RMW lock in scheduler + heartbeat

### DIFF
--- a/codec_heartbeat.py
+++ b/codec_heartbeat.py
@@ -383,25 +383,28 @@ def check_alerts():
                     capture_output=True, timeout=5)
             except Exception:
                 pass
-            # Save to notifications.json for dashboard bell icon
+            # Save to notifications.json for dashboard bell icon. Fix #9 Phase 2:
+            # hold the cross-process file_lock across the load→insert→write so
+            # this daemon can't clobber a concurrent dashboard / scheduler write.
             try:
-                try:
-                    with open(notif_path) as f:
-                        notifs = json.load(f)
-                except (FileNotFoundError, json.JSONDecodeError):
-                    notifs = []
-                notifs.insert(0, {
-                    "id": f"notif_{_uuid.uuid4().hex[:10]}",
-                    "type": "task_report",
-                    "title": "Heartbeat Alert",
-                    "body": msg,
-                    "status": "warning",
-                    "created": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
-                    "read": False,
-                    "schedule_id": "heartbeat",
-                })
-                with open(notif_path, "w") as f:
-                    json.dump(notifs, f, indent=2)
+                import codec_jsonstore
+                with codec_jsonstore.file_lock(notif_path):
+                    try:
+                        with open(notif_path) as f:
+                            notifs = json.load(f)
+                    except (FileNotFoundError, json.JSONDecodeError):
+                        notifs = []
+                    notifs.insert(0, {
+                        "id": f"notif_{_uuid.uuid4().hex[:10]}",
+                        "type": "task_report",
+                        "title": "Heartbeat Alert",
+                        "body": msg,
+                        "status": "warning",
+                        "created": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        "read": False,
+                        "schedule_id": "heartbeat",
+                    })
+                    codec_jsonstore.atomic_write_json(notif_path, notifs)
             except Exception:
                 pass
     return triggered

--- a/codec_scheduler.py
+++ b/codec_scheduler.py
@@ -105,27 +105,30 @@ def _notify(title, body, status="success", schedule_id=None):
     # 1. Save to notifications.json (same format as dashboard)
     notif_path = os.path.expanduser("~/.codec/notifications.json")
     try:
-        try:
-            with open(notif_path) as f:
-                notifications = json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError):
-            notifications = []
-        notif = {
-            "id": f"notif_{_uuid.uuid4().hex[:10]}",
-            "type": "task_report",
-            "title": title,
-            "body": body[:2000],
-            "status": status,
-            "created": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
-            "read": False,
-            "schedule_id": schedule_id,
-        }
-        if doc_url:
-            notif["doc_url"] = doc_url
-        notifications.insert(0, notif)
-        os.makedirs(os.path.dirname(notif_path), exist_ok=True)
-        with open(notif_path, "w") as f:
-            json.dump(notifications, f, indent=2)
+        # Fix #9 Phase 2: hold the cross-process file_lock across the whole
+        # load→insert→write so this daemon can't clobber a concurrent
+        # dashboard / ask_user / heartbeat write of notifications.json.
+        import codec_jsonstore
+        with codec_jsonstore.file_lock(notif_path):
+            try:
+                with open(notif_path) as f:
+                    notifications = json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                notifications = []
+            notif = {
+                "id": f"notif_{_uuid.uuid4().hex[:10]}",
+                "type": "task_report",
+                "title": title,
+                "body": body[:2000],
+                "status": status,
+                "created": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+                "read": False,
+                "schedule_id": schedule_id,
+            }
+            if doc_url:
+                notif["doc_url"] = doc_url
+            notifications.insert(0, notif)
+            codec_jsonstore.atomic_write_json(notif_path, notifications)
     except Exception as e:
         log.warning(f"  Failed to save notification: {e}")
     # 2. macOS notification

--- a/tests/test_phase2_notif_lock.py
+++ b/tests/test_phase2_notif_lock.py
@@ -1,0 +1,38 @@
+"""Fix #9 Phase 2: the secondary notifications.json writers (codec_scheduler,
+codec_heartbeat) did a load→insert→write RMW with no cross-process lock, so they
+clobbered the now-locked dashboard/ask_user writers. They must hold
+codec_jsonstore.file_lock across the RMW like every other notifications writer.
+"""
+import contextlib
+import json
+
+
+def test_scheduler_notify_holds_file_lock(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".codec").mkdir(parents=True, exist_ok=True)
+    # don't fire a real macOS notification during the test
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+
+    import codec_jsonstore
+    import codec_scheduler
+
+    calls = []
+    real = codec_jsonstore.file_lock
+
+    @contextlib.contextmanager
+    def spy(path):
+        calls.append(str(path))
+        with real(path):
+            yield
+
+    monkeypatch.setattr(codec_jsonstore, "file_lock", spy)
+
+    codec_scheduler._notify("Test", "body text", status="success", schedule_id="x")
+
+    notif_path = tmp_path / ".codec" / "notifications.json"
+    assert any("notifications.json" in c for c in calls), (
+        "scheduler._notify must hold the cross-process flock on notifications.json (Phase 2)"
+    )
+    # and it actually persisted a valid, atomic notification
+    data = json.loads(notif_path.read_text())
+    assert data and data[0]["title"] == "Test"


### PR DESCRIPTION
Fix #9 Phase 2. The dashboard + ask_user notifications writers already hold `codec_jsonstore.file_lock` across their read-modify-write (Fix #5 / B-11), but the **codec-scheduler** and **codec-heartbeat** daemons wrote `notifications.json` directly with no lock — racing/clobbering concurrent writes. Both now hold `file_lock(notif_path)` across the load→insert→write + use `atomic_write_json`. **Every notifications.json writer is now serialized.**

Tested: `codec_scheduler._notify` spy-asserts the flock is held + persists atomically; notification/state suites green (19); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)