### PR TITLE
arch: B6 refactor — split 4 large modules + 1 route group + 29 regression tests

### DIFF
--- a/codec_chat_pipeline.py
+++ b/codec_chat_pipeline.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from pathlib import Path
 from typing import Optional
 
 from codec_audit import STEP_BUDGET_EXHAUSTED, log_event

--- a/codec_chat_pipeline.py
+++ b/codec_chat_pipeline.py
@@ -1,0 +1,173 @@
+"""CODEC Chat Pipeline — extractable building blocks for the chat handler.
+
+B6-P2 / SR-33: extracted from codec_dashboard.py. The full FastAPI
+handler (`chat_completion`, ~608 LOC) stays in codec_dashboard for now
+because it threads many implicit module-level state dependencies; this
+module hosts the testable, side-effect-light helpers so unit tests can
+exercise them without standing up the dashboard.
+
+Today this owns:
+  - `_StepBudget`            per-turn step counter + warn / exhaustion logic
+  - `_step_budget_enabled`   env-var read for the global kill switch
+  - `_step_budget_for_route` config-driven per-route cap
+  - `_is_conversational`     fast heuristic for routing chat→LLM vs chat→skill
+
+codec_dashboard re-exports each as a private member so any external
+reader that imported from there before the split keeps working.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from codec_audit import STEP_BUDGET_EXHAUSTED, log_event
+
+log = logging.getLogger("codec_chat_pipeline")
+
+# Match codec_dashboard's CONFIG_PATH resolution so reads land on the same file
+# (routes/_shared.CONFIG_PATH is the canonical home).
+CONFIG_PATH = os.path.expanduser("~/.codec/config.json")
+
+
+def _is_conversational(text: str) -> bool:
+    """Detect if a message is conversational rather than a direct command.
+    Conversational messages should go to the LLM, not trigger skills."""
+    low = text.lower().strip()
+    words = low.split()
+    # Very short messages (1-3 words) are likely commands
+    if len(words) <= 3:
+        return False
+    # Long messages (>15 words) are almost always conversational
+    if len(words) > 15:
+        return True
+    # Messages with question-like patterns about CODEC/features/capabilities
+    _CONV_PATTERNS = [
+        "what do you think", "what's your", "whats your", "are we",
+        "can you check", "can u check", "please check", "take a look",
+        "what happened", "what is happening", "why did you", "why you",
+        "do you have", "do u have", "have you", "did you",
+        "here is", "here's", "check this", "check it",
+        "read this", "read the", "now read", "please read",
+        "save to", "save this", "your thought", "your thoughts",
+        "what say you", "agreed", "let's", "lets", "revise",
+        "should we", "how about", "im testing", "i'm testing",
+        "i just tested", "i was testing", "something off",
+        "something wrong", "not working", "doesn't work",
+    ]
+    if any(p in low for p in _CONV_PATTERNS):
+        return True
+    # URLs in messages are usually sharing links, not commands
+    if "http://" in low or "https://" in low or ".com" in low or ".org" in low:
+        return True
+    # Multi-sentence messages are conversational
+    if text.count('.') >= 2 or text.count('?') >= 1 or text.count('!') >= 2:
+        return True
+    return False
+
+
+def _step_budget_enabled() -> bool:
+    """Read STEP_BUDGET_ENABLED env var. Default true. Read each call so
+    tests can monkeypatch."""
+    val = (os.environ.get("STEP_BUDGET_ENABLED") or "true").strip().lower()
+    return val not in ("false", "0", "no", "off")
+
+
+def _step_budget_for_route(route: str) -> Optional[int]:
+    """Return the budget cap for the given route, or None for "no cap"
+    (MCP). Read each call so config edits take effect on PM2 restart.
+
+    Defaults per design §3.2:
+        chat:  5
+        voice: 5
+        mcp:   None  (no turn budget — each MCP call is its own turn)
+    """
+    try:
+        with open(CONFIG_PATH) as f:
+            cfg = json.load(f).get("step_budget", {})
+    except (OSError, ValueError):
+        cfg = {}
+    if route == "mcp":
+        return None  # MCP path has no turn concept; SKILL_TIMEOUT_SEC governs.
+    default = 5
+    v = cfg.get(route, default)
+    if v is None:
+        return None
+    if isinstance(v, int) and v > 0:
+        return v
+    return default
+
+
+class _StepBudget:
+    """Per-request counter + warn / exhaustion logic. Construct at request
+    entry; call ``consume(kind)`` before each step; check ``warn_now()``
+    to decide whether to append the "1 step remaining" prompt suffix.
+
+    Threadsafe-friendly: each request has its own instance (no shared
+    state). Audit emits go through log_event so concurrent requests
+    serialise via codec_audit's existing _LOCK.
+    """
+    __slots__ = ("route", "limit", "count", "enabled", "exhausted_emitted",
+                 "correlation_id")
+
+    def __init__(self, route: str = "chat", correlation_id: Optional[str] = None):
+        self.route = route
+        self.limit = _step_budget_for_route(route) if _step_budget_enabled() else None
+        self.count = 0
+        self.enabled = self.limit is not None
+        self.exhausted_emitted = False
+        self.correlation_id = correlation_id
+
+    def consume(self, kind: str = "step") -> bool:
+        """Try to consume one budget step. Returns True if OK to proceed,
+        False if budget would be exhausted by this consumption.
+
+        ``kind`` is a free-form label for telemetry (e.g. "skill_hijack",
+        "llm_call", "post_llm_skill_tag", "crew_spawn"). Logged on the
+        ``step_budget_exhausted`` audit event when the cap is hit.
+        """
+        if not self.enabled:
+            return True
+        self.count += 1
+        if self.count > self.limit:
+            self._emit_exhausted(kind)
+            return False
+        return True
+
+    def warn_now(self) -> bool:
+        """True when we're at limit-1 and the next step would cap. Used
+        by the LLM-call path to inject "⚠ 1 step remaining" into the
+        prompt suffix."""
+        if not self.enabled:
+            return False
+        return self.count == max(0, self.limit - 1)
+
+    def at_limit(self) -> bool:
+        """True if we've already hit the cap (consume returned False)."""
+        if not self.enabled:
+            return False
+        return self.count >= self.limit
+
+    def _emit_exhausted(self, kind: str):
+        if self.exhausted_emitted:
+            return
+        self.exhausted_emitted = True
+        try:
+            log_event(
+                STEP_BUDGET_EXHAUSTED,
+                "codec-dashboard",
+                f"chat step budget exhausted at {self.count} (kind={kind})",
+                extra={
+                    "budget_type": "chat_turn",
+                    "limit": self.limit,
+                    "actual": self.count,
+                    "kind": kind,
+                },
+                outcome="warning",
+                level="warning",
+                correlation_id=self.correlation_id,
+            )
+        except Exception as e:
+            log.warning("[step_budget] emit failed: %s", e)

--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -10,7 +10,6 @@ import uuid
 import asyncio
 import secrets
 from datetime import datetime, timedelta
-from typing import Optional
 
 from pathlib import Path
 from fastapi import FastAPI, Request
@@ -35,7 +34,7 @@ from routes._shared import (
 
 # Audit emits route through the unified log_event adapter (real, not no-op)
 # per docs/PHASE1-STEP1-DESIGN.md.
-from codec_audit import log_event, STEP_BUDGET_EXHAUSTED
+from codec_audit import log_event  # STEP_BUDGET_EXHAUSTED moved with _StepBudget to codec_chat_pipeline (B6-P2)
 from codec_chat_stream import SkillTagBuffer, SKILL_TAG_RE  # A-6 (PR-3D-c)
 import codec_llm  # A-12 (PR-3E-dashboard)
 

--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -328,6 +328,8 @@ from routes.skills import router as skills_router
 from routes.agents import router as agents_router
 from routes.memory import router as memory_router
 from routes.websocket import router as websocket_router
+# B6-P3 / SR-34: notification endpoints extracted from codec_dashboard.
+from routes.notifications import router as notifications_router
 # Phase 2 Step 6 — Trigger System PWA endpoints (auth-gated by /api/* middleware).
 try:
     from routes.triggers import router as triggers_router
@@ -341,6 +343,7 @@ app.include_router(skills_router)
 app.include_router(agents_router)
 app.include_router(memory_router)
 app.include_router(websocket_router)
+app.include_router(notifications_router)
 if _has_triggers:
     app.include_router(triggers_router)
 
@@ -2459,40 +2462,10 @@ provided."""
 
 CHAT_SYSTEM_PROMPT = _BASE_CHAT_PROMPT + _DASHBOARD_ADDON
 
-def _is_conversational(text: str) -> bool:
-    """Detect if a message is conversational rather than a direct command.
-    Conversational messages should go to the LLM, not trigger skills."""
-    low = text.lower().strip()
-    words = low.split()
-    # Very short messages (1-3 words) are likely commands
-    if len(words) <= 3:
-        return False
-    # Long messages (>15 words) are almost always conversational
-    if len(words) > 15:
-        return True
-    # Messages with question-like patterns about CODEC/features/capabilities
-    _CONV_PATTERNS = [
-        "what do you think", "what's your", "whats your", "are we",
-        "can you check", "can u check", "please check", "take a look",
-        "what happened", "what is happening", "why did you", "why you",
-        "do you have", "do u have", "have you", "did you",
-        "here is", "here's", "check this", "check it",
-        "read this", "read the", "now read", "please read",
-        "save to", "save this", "your thought", "your thoughts",
-        "what say you", "agreed", "let's", "lets", "revise",
-        "should we", "how about", "im testing", "i'm testing",
-        "i just tested", "i was testing", "something off",
-        "something wrong", "not working", "doesn't work",
-    ]
-    if any(p in low for p in _CONV_PATTERNS):
-        return True
-    # URLs in messages are usually sharing links, not commands
-    if "http://" in low or "https://" in low or ".com" in low or ".org" in low:
-        return True
-    # Multi-sentence messages are conversational
-    if text.count('.') >= 2 or text.count('?') >= 1 or text.count('!') >= 2:
-        return True
-    return False
+# B6-P2 / SR-33: _is_conversational, _step_budget_enabled,
+# _step_budget_for_route, _StepBudget moved to codec_chat_pipeline.
+# Re-exported via the import below for back-compat with any test or
+# external caller that imported them from codec_dashboard.
 
 
 # ── Phase 1 Step 3 §3 — chat-handler step budget ──────────────────────────
@@ -2501,109 +2474,13 @@ def _is_conversational(text: str) -> bool:
 # 8-step budget is independent. Defaults: chat=5, voice=5, MCP exempt.
 # Bumping to 8 or 10 is a single ~/.codec/config.json edit ("tune up
 # before tuning out" per Q3 reviewer guidance).
-def _step_budget_enabled() -> bool:
-    """Read STEP_BUDGET_ENABLED env var. Default true. Read each call so
-    tests can monkeypatch."""
-    val = (os.environ.get("STEP_BUDGET_ENABLED") or "true").strip().lower()
-    return val not in ("false", "0", "no", "off")
-
-
-def _step_budget_for_route(route: str) -> Optional[int]:
-    """Return the budget cap for the given route, or None for "no cap"
-    (MCP). Read each call so config edits take effect on PM2 restart.
-
-    Defaults per design §3.2:
-        chat:  5
-        voice: 5
-        mcp:   None  (no turn budget — each MCP call is its own turn)
-    """
-    try:
-        with open(CONFIG_PATH) as f:
-            cfg = json.load(f).get("step_budget", {})
-    except Exception:
-        cfg = {}
-    if route == "mcp":
-        return None  # MCP path has no turn concept; SKILL_TIMEOUT_SEC governs.
-    default = 5
-    v = cfg.get(route, default)
-    if v is None:
-        return None
-    if isinstance(v, int) and v > 0:
-        return v
-    return default
-
-
-class _StepBudget:
-    """Per-request counter + warn / exhaustion logic. Construct at request
-    entry; call ``consume(kind)`` before each step; check ``warn_now()``
-    to decide whether to append the "1 step remaining" prompt suffix.
-
-    Threadsafe-friendly: each request has its own instance (no shared
-    state). Audit emits go through log_event so concurrent requests
-    serialise via codec_audit's existing _LOCK.
-    """
-    __slots__ = ("route", "limit", "count", "enabled", "exhausted_emitted",
-                 "correlation_id")
-
-    def __init__(self, route: str = "chat", correlation_id: Optional[str] = None):
-        self.route = route
-        self.limit = _step_budget_for_route(route) if _step_budget_enabled() else None
-        self.count = 0
-        self.enabled = self.limit is not None
-        self.exhausted_emitted = False
-        self.correlation_id = correlation_id
-
-    def consume(self, kind: str = "step") -> bool:
-        """Try to consume one budget step. Returns True if OK to proceed,
-        False if budget would be exhausted by this consumption.
-
-        ``kind`` is a free-form label for telemetry (e.g. "skill_hijack",
-        "llm_call", "post_llm_skill_tag", "crew_spawn"). Logged on the
-        ``step_budget_exhausted`` audit event when the cap is hit.
-        """
-        if not self.enabled:
-            return True
-        self.count += 1
-        if self.count > self.limit:
-            self._emit_exhausted(kind)
-            return False
-        return True
-
-    def warn_now(self) -> bool:
-        """True when we're at limit-1 and the next step would cap. Used
-        by the LLM-call path to inject "⚠ 1 step remaining" into the
-        prompt suffix."""
-        if not self.enabled:
-            return False
-        return self.count == max(0, self.limit - 1)
-
-    def at_limit(self) -> bool:
-        """True if we've already hit the cap (consume returned False)."""
-        if not self.enabled:
-            return False
-        return self.count >= self.limit
-
-    def _emit_exhausted(self, kind: str):
-        if self.exhausted_emitted:
-            return
-        self.exhausted_emitted = True
-        try:
-            log_event(
-                STEP_BUDGET_EXHAUSTED,
-                "codec-dashboard",
-                f"chat step budget exhausted at {self.count} (kind={kind})",
-                extra={
-                    "budget_type": "chat_turn",
-                    "limit": self.limit,
-                    "actual": self.count,
-                    "kind": kind,
-                },
-                outcome="warning",
-                level="warning",
-                correlation_id=self.correlation_id,
-            )
-        except Exception as e:
-            log.warning("[step_budget] emit failed: %s", e)
+# B6-P2 / SR-33: re-export _StepBudget + helpers from codec_chat_pipeline.
+from codec_chat_pipeline import (  # noqa: E402,F401  (back-compat re-exports)
+    _is_conversational,
+    _step_budget_enabled,
+    _step_budget_for_route,
+    _StepBudget,
+)
 
 
 def _try_skill(user_text: str):
@@ -3429,56 +3306,9 @@ async def run_schedule_now(sched_id: str):
     return {"status": "running", "notification_id": notif_id, "id": sched_id, "crew": crew}
 
 
-# ── Notification endpoints ──
-
-@app.get("/api/notifications")
-async def get_notifications(request: Request):
-    """Return all notifications, newest first. Use ?unread=true to filter."""
-    notifications = _load_notifications()
-    unread_filter = request.query_params.get("unread", "").lower()
-    if unread_filter == "true":
-        notifications = [n for n in notifications if not n.get("read", False)]
-    # Sort newest first by created timestamp
-    notifications.sort(key=lambda n: n.get("created", ""), reverse=True)
-    return {"notifications": notifications}
-
-
-@app.get("/api/notifications/count")
-async def get_notification_count():
-    """Return unread notification count for badge display.
-    Only counts completed notifications (success/error), not 'running' ones."""
-    notifications = _load_notifications()
-    unread = sum(1 for n in notifications
-                 if not n.get("read", False)
-                 and n.get("status", "success") != "running")
-    return {"unread": unread}
-
-
-@app.post("/api/notifications/{notif_id}/read")
-async def mark_notification_read(notif_id: str):
-    """Mark a single notification as read."""
-    with _notif_lock:
-        notifications = _load_notifications()
-        for n in notifications:
-            if n["id"] == notif_id:
-                n["read"] = True
-                _write_notifications(notifications)
-                return {"status": "ok", "id": notif_id}
-    return JSONResponse({"error": "Notification not found"}, status_code=404)
-
-
-@app.post("/api/notifications/read-all")
-async def mark_all_notifications_read():
-    """Mark all notifications as read."""
-    with _notif_lock:
-        notifications = _load_notifications()
-        count = 0
-        for n in notifications:
-            if not n.get("read", False):
-                n["read"] = True
-                count += 1
-        _write_notifications(notifications)
-    return {"status": "ok", "marked": count}
+# B6-P3 / SR-34: notification endpoints moved to routes/notifications.py.
+# See codec_dashboard's router-include block at the bottom of the file
+# for where they get re-attached to the FastAPI app.
 
 
 # ── Remote Command Approval (dashboard / phone) ──────────────────────────────

--- a/codec_hooks.py
+++ b/codec_hooks.py
@@ -22,13 +22,10 @@ See docs/PHASE1-STEP2-DESIGN.md for the full contract.
 from __future__ import annotations
 
 import ast
-import hashlib
 import importlib.util
-import json
 import logging
 import os
 import queue
-import stat
 import threading
 import time
 from dataclasses import dataclass, field, replace
@@ -37,12 +34,25 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from codec_audit import log_event as _log_event, _PREVIEW_MAX, _truncate
+# B6-P1 / SR-32: trust-store primitives moved to codec_plugin_trust. Re-
+# exported here so external callers (tests, skills/plugin_approve) that
+# imported from codec_hooks before the split keep working.
+from codec_plugin_trust import (
+    _PLUGINS_DIR_DEFAULT,
+    _PLUGINS_ALLOWLIST_DEFAULT,
+    _PLUGIN_FILE_SUFFIX,
+    _ALLOWLIST_LOCK,
+    _default_allowlist_path_for,
+    _allowlist_path_for,
+    _read_allowlist,
+    _write_allowlist,
+    _file_sha256,
+    _maybe_grandfather_existing_plugins,
+    _is_plugin_allowed,
+    _emit_plugin_load_blocked,
+)
 
 log = logging.getLogger("codec_hooks")
-
-# ── Storage ────────────────────────────────────────────────────────────────────
-_PLUGINS_DIR_DEFAULT = os.path.expanduser("~/.codec/plugins")
-_PLUGINS_ALLOWLIST_DEFAULT = os.path.expanduser("~/.codec/plugins.allowlist")
 
 # PR-2F (D-18): hook timeout default. Set high enough not to false-positive on
 # legitimate hooks (self_improve.py's on_operation_end does a buffer snapshot +
@@ -91,193 +101,13 @@ _IMMUTABLE_IDENTITY_FIELDS = (
 
 _DEFAULT_PRIORITY = 100
 
-# Default identifier used when a plugin omits PLUGIN_NAME — the file stem.
-_PLUGIN_FILE_SUFFIX = ".py"
-
-
-# ── PR-2F (D-18): SHA-256 allowlist + AST gate ────────────────────────────────
-#
-# Plugins are local Python with full process privileges. Before PR-2F, any
-# file dropped into ~/.codec/plugins/*.py would auto-load on next restart.
-# Now a plugin's SHA-256 must be in `~/.codec/plugins.allowlist` (operator-
-# managed) before `spec.loader.exec_module` runs. Mirrors PR-1A's hash-pinned
-# `skills/.manifest.json` chokepoint: hash-pinned trust IS the security
-# decision, not the AST check.
-#
-# AST check (via `codec_config.is_dangerous_skill_code`) is still run when
-# the file is NOT in the allowlist — but only to enrich the `plugin_load_blocked`
-# audit event with a specific reason ("ast_dangerous: subprocess.run" vs
-# "not_in_allowlist"). Either reason → refuse. Both checks must pass for a
-# plugin to load — hash match OR (well, the hash match alone is sufficient;
-# AST is only run when hash misses, for forensic clarity).
-#
-# Migration: existing plugins at `~/.codec/plugins/*.py` on first run after
-# PR-2F are grandfathered — their current hashes are written to the
-# allowlist with `approved_by: "initial_migration"` and an `info`-level
-# audit event. This avoids surprising the operator on upgrade.
-
-_ALLOWLIST_LOCK = threading.Lock()
-
-
-def _default_allowlist_path_for(plugins_dir: str) -> str:
-    """Derive the allowlist path from the plugins dir. Production:
-    `~/.codec/plugins/` → `~/.codec/plugins.allowlist`. Tests pointing
-    at a tmp plugins dir get a sibling allowlist in the same tmp tree,
-    so they don't touch the operator's real allowlist file."""
-    parent = os.path.dirname(os.path.abspath(plugins_dir.rstrip(os.sep)))
-    return os.path.join(parent, "plugins.allowlist")
-
-
-def _allowlist_path_for(plugins_dir: str) -> Path:
-    """Resolved allowlist path for a given plugins dir."""
-    return Path(_default_allowlist_path_for(plugins_dir))
-
-
-def _read_allowlist(path: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:
-    """Load the allowlist as a dict keyed by plugin filename. Returns {} on
-    any error (missing file, parse error, wrong shape) — fail-closed: no
-    file = no allowed plugins."""
-    p = path if path is not None else Path(_PLUGINS_ALLOWLIST_DEFAULT)
-    if not p.exists():
-        return {}
-    try:
-        raw = p.read_text(encoding="utf-8")
-        obj = json.loads(raw)
-        if not isinstance(obj, dict):
-            log.warning("[plugins] allowlist root is not a dict; treating as empty")
-            return {}
-        # Validate shape — each entry must have a sha256 hex string.
-        clean: Dict[str, Dict[str, Any]] = {}
-        for fname, entry in obj.items():
-            if not isinstance(entry, dict):
-                continue
-            h = entry.get("sha256")
-            if isinstance(h, str) and len(h) == 64 and all(c in "0123456789abcdef" for c in h.lower()):
-                clean[fname] = entry
-        return clean
-    except (OSError, json.JSONDecodeError) as e:
-        log.warning("[plugins] allowlist read failed: %s", e)
-        return {}
-
-
-def _write_allowlist(allowlist: Dict[str, Dict[str, Any]],
-                     path: Optional[Path] = None) -> bool:
-    """Atomic-write the allowlist with 0600 perms. Returns True on success."""
-    p = path if path is not None else Path(_PLUGINS_ALLOWLIST_DEFAULT)
-    try:
-        p.parent.mkdir(parents=True, exist_ok=True)
-        tmp = p.with_suffix(p.suffix + ".tmp")
-        tmp.write_text(json.dumps(allowlist, indent=2, sort_keys=True),
-                       encoding="utf-8")
-        os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
-        os.replace(tmp, p)
-        try:
-            os.chmod(p, stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
-        return True
-    except OSError as e:
-        log.warning("[plugins] allowlist write failed: %s", e)
-        return False
-
-
-def _file_sha256(path: str) -> Optional[str]:
-    """SHA-256 hex digest of file contents. None on read error."""
-    try:
-        with open(path, "rb") as f:
-            return hashlib.sha256(f.read()).hexdigest()
-    except OSError:
-        return None
-
-
-def _maybe_grandfather_existing_plugins(plugins_dir: str,
-                                          allowlist_path: Optional[Path] = None) -> None:
-    """One-shot migration: if no allowlist file exists yet AND the plugins
-    dir has .py files, write their current hashes to the allowlist with
-    `approved_by: "initial_migration"`. Idempotent — runs once at the
-    upgrade boundary, then becomes a no-op.
-
-    `allowlist_path` defaults to the sibling of `plugins_dir` (i.e.
-    `<dirname(plugins_dir)>/plugins.allowlist`) so tests pointing at a
-    tmp plugins dir get a tmp allowlist, not the real one."""
-    if allowlist_path is None:
-        allowlist_path = _allowlist_path_for(plugins_dir)
-    if allowlist_path.exists():
-        return
-    if not os.path.isdir(plugins_dir):
-        return
-    pys = [f for f in os.listdir(plugins_dir)
-           if f.endswith(_PLUGIN_FILE_SUFFIX) and not f.startswith("_")]
-    if not pys:
-        # No plugins to grandfather — still create an empty allowlist so
-        # subsequent loads don't re-attempt migration on every restart.
-        _write_allowlist({}, allowlist_path)
-        return
-    seed: Dict[str, Dict[str, Any]] = {}
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    for fname in pys:
-        fpath = os.path.join(plugins_dir, fname)
-        h = _file_sha256(fpath)
-        if h is None:
-            continue
-        seed[fname] = {
-            "sha256": h,
-            "approved_at": now,
-            "approved_by": "initial_migration",
-        }
-    if _write_allowlist(seed, allowlist_path):
-        log.info("[plugins] grandfathered %d existing plugin(s) into allowlist", len(seed))
-        try:
-            _log_event(
-                "plugin_allowlist_migrated", "codec-hooks",
-                f"grandfathered {len(seed)} plugin(s)",
-                extra={"plugin_count": len(seed), "filenames": sorted(seed.keys())},
-                level="info", outcome="ok",
-            )
-        except Exception:
-            pass
-
-
-def _is_plugin_allowed(filepath: str,
-                       allowlist_path: Optional[Path] = None) -> tuple[bool, str]:
-    """Return (allowed, reason). `allowed` True only if the file's current
-    SHA-256 matches an entry in the allowlist keyed by basename. Tamper
-    detection: a previously-approved plugin whose content changed will
-    have a hash mismatch and be refused until re-approved."""
-    if allowlist_path is None:
-        allowlist_path = _allowlist_path_for(os.path.dirname(filepath))
-    fname = os.path.basename(filepath)
-    h = _file_sha256(filepath)
-    if h is None:
-        return False, "file_unreadable"
-    allowlist = _read_allowlist(allowlist_path)
-    entry = allowlist.get(fname)
-    if entry is None:
-        return False, "not_in_allowlist"
-    if entry.get("sha256") != h:
-        return False, "hash_mismatch"
-    return True, ""
-
-
-def _emit_plugin_load_blocked(plugin_name: str, filepath: str,
-                              reason: str, extra_detail: str = "") -> None:
-    """Audit emit for plugin load refusal. Fire-and-forget."""
-    extra: Dict[str, Any] = {
-        "plugin_name": plugin_name,
-        "plugin_path": filepath,
-        "reason": reason,
-    }
-    if extra_detail:
-        extra["detail"] = extra_detail[:200]
-    try:
-        _log_event(
-            "plugin_load_blocked", "codec-hooks",
-            f"Plugin {plugin_name!r} refused: {reason}",
-            extra=extra,
-            level="warning", outcome="error",
-        )
-    except Exception:
-        pass
+# B6-P1: trust-store primitives (_ALLOWLIST_LOCK, _read_allowlist,
+# _write_allowlist, _file_sha256, _is_plugin_allowed,
+# _maybe_grandfather_existing_plugins, _emit_plugin_load_blocked,
+# _default_allowlist_path_for, _allowlist_path_for, _PLUGINS_DIR_DEFAULT,
+# _PLUGINS_ALLOWLIST_DEFAULT, _PLUGIN_FILE_SUFFIX) live in
+# codec_plugin_trust now and are re-imported at the top of this file.
+# See codec_plugin_trust.py docstring for the PR-2F design.
 
 
 # ── PR-2F (D-18): thread-with-timeout for hook execution ───────────────────────

--- a/codec_hooks.py
+++ b/codec_hooks.py
@@ -37,7 +37,7 @@ from codec_audit import log_event as _log_event, _PREVIEW_MAX, _truncate
 # B6-P1 / SR-32: trust-store primitives moved to codec_plugin_trust. Re-
 # exported here so external callers (tests, skills/plugin_approve) that
 # imported from codec_hooks before the split keep working.
-from codec_plugin_trust import (
+from codec_plugin_trust import (  # noqa: F401 — back-compat re-exports for tests / external callers
     _PLUGINS_DIR_DEFAULT,
     _PLUGINS_ALLOWLIST_DEFAULT,
     _PLUGIN_FILE_SUFFIX,

--- a/codec_plugin_trust.py
+++ b/codec_plugin_trust.py
@@ -1,0 +1,212 @@
+"""CODEC Plugin Trust Store — SHA-256 allowlist for ~/.codec/plugins/*.py.
+
+B6-P1 / SR-32: extracted from codec_hooks.py. The trust-store layer is
+purely stateless data — allowlist read/write, hash compute, refusal
+audit. The runtime layer (lifecycle dispatcher, PluginRegistry, hook
+fire orchestration, approve_plugin operator entry) stays in codec_hooks.
+
+Why split: codec_hooks.py was 1,097 LOC doing two clearly separable
+concerns: (a) a 5-event lifecycle dispatcher with mutation/veto
+semantics, and (b) a SHA-256 allowlist trust store. The two move at
+different speeds (lifecycle is contract-stable, the trust store gets
+new audit fields per audit pass) and a future reader wants to know
+which subsystem each change touches.
+
+Back-compat: codec_hooks re-exports everything below as private members
+so any test or external caller doing `codec_hooks._read_allowlist` (or
+similar) keeps working without changes.
+
+See `docs/PHASE1-STEP2-DESIGN.md` for the PR-2F (D-18) trust-model
+design that introduced these primitives.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import stat
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from codec_audit import log_event as _log_event
+
+log = logging.getLogger("codec_plugin_trust")
+
+# ── Storage ────────────────────────────────────────────────────────────────────
+_PLUGINS_DIR_DEFAULT = os.path.expanduser("~/.codec/plugins")
+_PLUGINS_ALLOWLIST_DEFAULT = os.path.expanduser("~/.codec/plugins.allowlist")
+
+# Default identifier suffix used when a plugin omits PLUGIN_NAME — the
+# file stem. Lives here because allowlist keys + grandfather migration
+# both reference it; codec_hooks re-exports for back-compat.
+_PLUGIN_FILE_SUFFIX = ".py"
+
+# Cross-thread serialization of allowlist writes. approve_plugin grabs
+# this BEFORE read-modify-write so two concurrent approvals can't lose
+# each other's changes. Single-process scope (codec-dashboard is the
+# only writer); the read path is lock-free.
+_ALLOWLIST_LOCK = threading.Lock()
+
+
+def _default_allowlist_path_for(plugins_dir: str) -> str:
+    """Derive the allowlist path from the plugins dir. Production:
+    `~/.codec/plugins/` → `~/.codec/plugins.allowlist`. Tests pointing
+    at a tmp plugins dir get a sibling allowlist in the same tmp tree,
+    so they don't touch the operator's real allowlist file."""
+    parent = os.path.dirname(os.path.abspath(plugins_dir.rstrip(os.sep)))
+    return os.path.join(parent, "plugins.allowlist")
+
+
+def _allowlist_path_for(plugins_dir: str) -> Path:
+    """Resolved allowlist path for a given plugins dir."""
+    return Path(_default_allowlist_path_for(plugins_dir))
+
+
+def _read_allowlist(path: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:
+    """Load the allowlist as a dict keyed by plugin filename. Returns {} on
+    any error (missing file, parse error, wrong shape) — fail-closed: no
+    file = no allowed plugins."""
+    p = path if path is not None else Path(_PLUGINS_ALLOWLIST_DEFAULT)
+    if not p.exists():
+        return {}
+    try:
+        raw = p.read_text(encoding="utf-8")
+        obj = json.loads(raw)
+        if not isinstance(obj, dict):
+            log.warning("[plugins] allowlist root is not a dict; treating as empty")
+            return {}
+        # Validate shape — each entry must have a sha256 hex string.
+        clean: Dict[str, Dict[str, Any]] = {}
+        for fname, entry in obj.items():
+            if not isinstance(entry, dict):
+                continue
+            h = entry.get("sha256")
+            if isinstance(h, str) and len(h) == 64 and all(c in "0123456789abcdef" for c in h.lower()):
+                clean[fname] = entry
+        return clean
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning("[plugins] allowlist read failed: %s", e)
+        return {}
+
+
+def _write_allowlist(allowlist: Dict[str, Dict[str, Any]],
+                     path: Optional[Path] = None) -> bool:
+    """Atomic-write the allowlist with 0600 perms. Returns True on success."""
+    p = path if path is not None else Path(_PLUGINS_ALLOWLIST_DEFAULT)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(p.suffix + ".tmp")
+        tmp.write_text(json.dumps(allowlist, indent=2, sort_keys=True),
+                       encoding="utf-8")
+        os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
+        os.replace(tmp, p)
+        try:
+            os.chmod(p, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+        return True
+    except OSError as e:
+        log.warning("[plugins] allowlist write failed: %s", e)
+        return False
+
+
+def _file_sha256(path: str) -> Optional[str]:
+    """SHA-256 hex digest of file contents. None on read error."""
+    try:
+        with open(path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return None
+
+
+def _maybe_grandfather_existing_plugins(plugins_dir: str,
+                                          allowlist_path: Optional[Path] = None) -> None:
+    """One-shot migration: if no allowlist file exists yet AND the plugins
+    dir has .py files, write their current hashes to the allowlist with
+    `approved_by: "initial_migration"`. Idempotent — runs once at the
+    upgrade boundary, then becomes a no-op.
+
+    `allowlist_path` defaults to the sibling of `plugins_dir` (i.e.
+    `<dirname(plugins_dir)>/plugins.allowlist`) so tests pointing at a
+    tmp plugins dir get a tmp allowlist, not the real one."""
+    if allowlist_path is None:
+        allowlist_path = _allowlist_path_for(plugins_dir)
+    if allowlist_path.exists():
+        return
+    if not os.path.isdir(plugins_dir):
+        return
+    pys = [f for f in os.listdir(plugins_dir)
+           if f.endswith(_PLUGIN_FILE_SUFFIX) and not f.startswith("_")]
+    if not pys:
+        # No plugins to grandfather — still create an empty allowlist so
+        # subsequent loads don't re-attempt migration on every restart.
+        _write_allowlist({}, allowlist_path)
+        return
+    seed: Dict[str, Dict[str, Any]] = {}
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    for fname in pys:
+        fpath = os.path.join(plugins_dir, fname)
+        h = _file_sha256(fpath)
+        if h is None:
+            continue
+        seed[fname] = {
+            "sha256": h,
+            "approved_at": now,
+            "approved_by": "initial_migration",
+        }
+    if _write_allowlist(seed, allowlist_path):
+        log.info("[plugins] grandfathered %d existing plugin(s) into allowlist", len(seed))
+        try:
+            _log_event(
+                "plugin_allowlist_migrated", "codec-plugin-trust",
+                f"grandfathered {len(seed)} plugin(s)",
+                extra={"plugin_count": len(seed), "filenames": sorted(seed.keys())},
+                level="info", outcome="ok",
+            )
+        except Exception:
+            pass
+
+
+def _is_plugin_allowed(filepath: str,
+                       allowlist_path: Optional[Path] = None) -> tuple[bool, str]:
+    """Return (allowed, reason). `allowed` True only if the file's current
+    SHA-256 matches an entry in the allowlist keyed by basename. Tamper
+    detection: a previously-approved plugin whose content changed will
+    have a hash mismatch and be refused until re-approved."""
+    if allowlist_path is None:
+        allowlist_path = _allowlist_path_for(os.path.dirname(filepath))
+    fname = os.path.basename(filepath)
+    h = _file_sha256(filepath)
+    if h is None:
+        return False, "file_unreadable"
+    allowlist = _read_allowlist(allowlist_path)
+    entry = allowlist.get(fname)
+    if entry is None:
+        return False, "not_in_allowlist"
+    if entry.get("sha256") != h:
+        return False, "hash_mismatch"
+    return True, ""
+
+
+def _emit_plugin_load_blocked(plugin_name: str, filepath: str,
+                              reason: str, extra_detail: str = "") -> None:
+    """Audit emit for plugin load refusal. Fire-and-forget."""
+    extra: Dict[str, Any] = {
+        "plugin_name": plugin_name,
+        "plugin_path": filepath,
+        "reason": reason,
+    }
+    if extra_detail:
+        extra["detail"] = extra_detail[:200]
+    try:
+        _log_event(
+            "plugin_load_blocked", "codec-plugin-trust",
+            f"Plugin {plugin_name!r} refused: {reason}",
+            extra=extra,
+            level="warning", outcome="error",
+        )
+    except Exception:
+        pass

--- a/codec_voice.py
+++ b/codec_voice.py
@@ -257,46 +257,10 @@ MIN_SPEECH_BYTES       = int(SAMPLE_RATE * BYTES_PER_SAMPLE * VAD_MIN_SPEECH_SEC
 INTERRUPT_THRESHOLD = 1500  # raised from 600 — too sensitive to background noise
 
 # ── Whisper noise filter ──────────────────────────────────────────────────
-NOISE_WORDS = {
-    "you", "thank you", "thanks", "thanks for watching", "bye", "goodbye",
-    "see you", "see you next time", "please subscribe", "like and subscribe",
-    "", "hmm", "uh", "oh", "hm", "um", "yeah", "yep", "mm", "mhm",
-    "okay", "ok", "right", "sure", "yes", "no", "hey", "hi", "hello",
-    "so", "well", "um hmm", "uh huh", "ah", "er",
-}
-
-# Common Whisper hallucination phrases (YouTube outros, annotations, artifacts)
-WHISPER_HALLUCINATIONS = {
-    "thank you for watching",
-    "thanks for watching",
-    "please subscribe",
-    "like and subscribe",
-    "see you next time",
-    "see you in the next video",
-    "thanks for listening",
-    "thank you for listening",
-    "please like and subscribe",
-    "don't forget to subscribe",
-    "hit the bell icon",
-    "thank you very much",
-    "thanks for your support",
-    "subtitles by",
-    "transcribed by",
-    "translated by",
-    "copyright",
-    "all rights reserved",
-    "music playing",
-    "applause",
-    "laughter",
-    "silence",
-    "inaudible",
-    "foreign language",
-    "speaking foreign language",
-    "you",
-    "bye",
-    "okay bye",
-    "so",
-}
+# B6-P4 / SR-35: NOISE_WORDS + WHISPER_HALLUCINATIONS moved to
+# codec_voice_filters. Re-exported here for back-compat with any
+# external import that grabbed them from codec_voice.
+from codec_voice_filters import NOISE_WORDS, WHISPER_HALLUCINATIONS  # noqa: F401,E402
 
 # Max conversation turns to keep in context (prevents bloat → keeps LLM fast)
 MAX_CONTEXT_TURNS = 20
@@ -505,12 +469,12 @@ class VoicePipeline:
 
     # ── VAD ───────────────────────────────────────────────────────────────
 
+    # B6-P4 / SR-35: _rms delegates to codec_voice_filters.rms_int16 so
+    # the function is testable without instantiating VoicePipeline.
     @staticmethod
     def _rms(chunk: bytes) -> float:
-        if len(chunk) < 2:
-            return 0.0
-        samples = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
-        return float(np.sqrt(np.mean(samples ** 2)))
+        from codec_voice_filters import rms_int16
+        return rms_int16(chunk)
 
     def feed_audio(self, chunk: bytes) -> Optional[bytes]:
         rms = self._rms(chunk)

--- a/codec_voice.py
+++ b/codec_voice.py
@@ -22,7 +22,9 @@ import base64
 import subprocess
 
 import httpx
-import numpy as np
+# B6-P4: numpy use moved with rms_int16 to codec_voice_filters. Kept as
+# noqa here in case downstream code references numpy via `codec_voice.np`.
+import numpy as np  # noqa: F401 — re-exported indirectly via filters helpers
 
 log = logging.getLogger("codec_voice")
 

--- a/codec_voice_filters.py
+++ b/codec_voice_filters.py
@@ -1,0 +1,96 @@
+"""CODEC Voice — pure-function filters + signal helpers.
+
+B6-P4 / SR-35: extracted from codec_voice.py. These are stateless data
++ helpers used by the voice pipeline:
+
+  - `NOISE_WORDS`           common conversational fillers Whisper produces
+                            on near-silence (very high false-positive risk
+                            otherwise).
+  - `WHISPER_HALLUCINATIONS` YouTube outros, annotations, artifacts that
+                            Whisper hallucinates from silence / background
+                            noise (~30 phrases).
+  - `is_noise(text)`        True if `text.strip().lower()` is in NOISE_WORDS.
+  - `is_hallucination(text)`True if `text.lower()` contains any
+                            WHISPER_HALLUCINATIONS phrase.
+  - `rms_int16(chunk)`      Root-mean-square of an int16 PCM byte buffer.
+                            Drives VAD silence detection.
+
+codec_voice re-exports each name so any existing import keeps working.
+Splitting these out lets the filter sets be tested + tuned without
+standing up the full WebSocket pipeline.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+# Whisper noise filter — short utterances Whisper produces on near-
+# silence. Comparing case-insensitively against the full stripped string.
+NOISE_WORDS = {
+    "you", "thank you", "thanks", "thanks for watching", "bye", "goodbye",
+    "see you", "see you next time", "please subscribe", "like and subscribe",
+    "", "hmm", "uh", "oh", "hm", "um", "yeah", "yep", "mm", "mhm",
+    "okay", "ok", "right", "sure", "yes", "no", "hey", "hi", "hello",
+    "so", "well", "um hmm", "uh huh", "ah", "er",
+}
+
+# Common Whisper hallucination phrases (YouTube outros, annotations,
+# artifacts produced when the model receives silence or background
+# noise). Substring match against the lowercased transcript.
+WHISPER_HALLUCINATIONS = {
+    "thank you for watching",
+    "thanks for watching",
+    "please subscribe",
+    "like and subscribe",
+    "see you next time",
+    "see you in the next video",
+    "thanks for listening",
+    "thank you for listening",
+    "please like and subscribe",
+    "don't forget to subscribe",
+    "hit the bell icon",
+    "thank you very much",
+    "thanks for your support",
+    "subtitles by",
+    "transcribed by",
+    "translated by",
+    "copyright",
+    "all rights reserved",
+    "music playing",
+    "applause",
+    "laughter",
+    "silence",
+    "inaudible",
+    "foreign language",
+    "speaking foreign language",
+    "you",
+    "bye",
+    "okay bye",
+    "so",
+}
+
+
+def is_noise(text: str) -> bool:
+    """True if `text` is a Whisper noise-word artifact (full match)."""
+    if text is None:
+        return False
+    return text.strip().lower() in NOISE_WORDS
+
+
+def is_hallucination(text: str) -> bool:
+    """True if `text` contains any known Whisper hallucination phrase
+    (substring match against the lowercased text)."""
+    if not text:
+        return False
+    low = text.lower()
+    return any(p in low for p in WHISPER_HALLUCINATIONS)
+
+
+def rms_int16(chunk: bytes) -> float:
+    """Root-mean-square of an int16 PCM byte buffer. Returns 0.0 for an
+    empty / undersized buffer (avoids numpy noise on a half-sample edge).
+    """
+    if len(chunk) < 2:
+        return 0.0
+    samples = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+    return float(np.sqrt(np.mean(samples ** 2)))

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,0 +1,77 @@
+"""CODEC Notifications API routes.
+
+B6-P3 / SR-34: extracted from codec_dashboard.py. The 4 notification
+endpoints are well-isolated (no implicit module-level state beyond what
+routes/_shared.py already exposes — _notif_lock, _load_notifications,
+_write_notifications), so they make the cleanest first extraction
+target after the agents / auth / skills route groups that already
+moved.
+
+Pattern for future route-group extractions:
+  1. Move the @app.<verb> decorators to @router.<verb> in this file.
+  2. Re-import any shared state (locks, helpers) from routes/_shared.
+  3. Add `app.include_router(notifications_router)` in codec_dashboard.
+  4. Tests that hit the URL still work via TestClient — no code change.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from routes._shared import (
+    _notif_lock,
+    _load_notifications,
+    _write_notifications,
+)
+
+router = APIRouter()
+
+
+@router.get("/api/notifications")
+async def get_notifications(request: Request):
+    """Return all notifications, newest first. Use ?unread=true to filter."""
+    notifications = _load_notifications()
+    unread_filter = request.query_params.get("unread", "").lower()
+    if unread_filter == "true":
+        notifications = [n for n in notifications if not n.get("read", False)]
+    # Sort newest first by created timestamp
+    notifications.sort(key=lambda n: n.get("created", ""), reverse=True)
+    return {"notifications": notifications}
+
+
+@router.get("/api/notifications/count")
+async def get_notification_count():
+    """Return unread notification count for badge display.
+    Only counts completed notifications (success/error), not 'running' ones."""
+    notifications = _load_notifications()
+    unread = sum(1 for n in notifications
+                 if not n.get("read", False)
+                 and n.get("status", "success") != "running")
+    return {"unread": unread}
+
+
+@router.post("/api/notifications/{notif_id}/read")
+async def mark_notification_read(notif_id: str):
+    """Mark a single notification as read."""
+    with _notif_lock:
+        notifications = _load_notifications()
+        for n in notifications:
+            if n["id"] == notif_id:
+                n["read"] = True
+                _write_notifications(notifications)
+                return {"status": "ok", "id": notif_id}
+    return JSONResponse({"error": "Notification not found"}, status_code=404)
+
+
+@router.post("/api/notifications/read-all")
+async def mark_all_notifications_read():
+    """Mark all notifications as read."""
+    with _notif_lock:
+        notifications = _load_notifications()
+        count = 0
+        for n in notifications:
+            if not n.get("read", False):
+                n["read"] = True
+                count += 1
+        _write_notifications(notifications)
+    return {"status": "ok", "marked": count}

--- a/tests/test_b6_refactor.py
+++ b/tests/test_b6_refactor.py
@@ -1,0 +1,157 @@
+"""B6 architecture refactor regression tests.
+
+Pins:
+  - B6-P1: codec_plugin_trust split + codec_hooks back-compat re-exports
+  - B6-P2: codec_chat_pipeline split + codec_dashboard back-compat re-exports
+  - B6-P3: routes/notifications.py — endpoints reachable
+  - B6-P4: codec_voice_filters split + codec_voice back-compat re-exports
+"""
+import pytest
+
+
+# ── B6-P1: codec_plugin_trust ──────────────────────────────────────────────
+class TestB6P1HooksTrustSplit:
+    """codec_hooks re-exports must be identity-equal to codec_plugin_trust."""
+
+    def test_read_allowlist_identity(self):
+        import codec_hooks
+        import codec_plugin_trust
+        assert codec_hooks._read_allowlist is codec_plugin_trust._read_allowlist
+
+    def test_write_allowlist_identity(self):
+        import codec_hooks
+        import codec_plugin_trust
+        assert codec_hooks._write_allowlist is codec_plugin_trust._write_allowlist
+
+    def test_file_sha256_identity(self):
+        import codec_hooks
+        import codec_plugin_trust
+        assert codec_hooks._file_sha256 is codec_plugin_trust._file_sha256
+
+    def test_is_plugin_allowed_identity(self):
+        import codec_hooks
+        import codec_plugin_trust
+        assert codec_hooks._is_plugin_allowed is codec_plugin_trust._is_plugin_allowed
+
+    def test_allowlist_lock_identity(self):
+        import codec_hooks
+        import codec_plugin_trust
+        assert codec_hooks._ALLOWLIST_LOCK is codec_plugin_trust._ALLOWLIST_LOCK
+
+    def test_grandfather_migration_writes_empty_allowlist(self, tmp_path):
+        """End-to-end: empty plugins dir → empty allowlist file gets written."""
+        import codec_plugin_trust
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        allowlist_path = tmp_path / "plugins.allowlist"
+        codec_plugin_trust._maybe_grandfather_existing_plugins(
+            str(plugins_dir), allowlist_path)
+        # Empty dir → empty allowlist file created.
+        assert allowlist_path.exists()
+        assert allowlist_path.read_text() in ("{}", "{}\n")
+
+
+# ── B6-P2: codec_chat_pipeline ─────────────────────────────────────────────
+class TestB6P2ChatPipelineSplit:
+    """codec_dashboard re-exports must be identity-equal to codec_chat_pipeline."""
+
+    def test_step_budget_class_identity(self):
+        import codec_dashboard
+        import codec_chat_pipeline
+        assert codec_dashboard._StepBudget is codec_chat_pipeline._StepBudget
+
+    def test_is_conversational_identity(self):
+        import codec_dashboard
+        import codec_chat_pipeline
+        assert codec_dashboard._is_conversational is codec_chat_pipeline._is_conversational
+
+    def test_step_budget_enabled_identity(self):
+        import codec_dashboard
+        import codec_chat_pipeline
+        assert codec_dashboard._step_budget_enabled is codec_chat_pipeline._step_budget_enabled
+
+    @pytest.mark.parametrize("text,expected", [
+        ("delete file", False),       # 2 words → not conversational
+        ("what do you think?", True), # conv pattern
+        ("here is the link", True),   # conv pattern
+        ("hi", False),                # 1 word
+        ("set timer", False),         # 2 words
+    ])
+    def test_is_conversational_behavior(self, text, expected):
+        from codec_chat_pipeline import _is_conversational
+        assert _is_conversational(text) is expected
+
+    def test_step_budget_consume_and_warn(self):
+        from codec_chat_pipeline import _StepBudget
+        budget = _StepBudget(route="chat")
+        # If not enabled (mocked off via env), we get a trivial pass through
+        if not budget.enabled:
+            pytest.skip("step budget disabled in this env")
+        assert budget.consume("step") is True
+        # warn_now flips at limit-1
+        for _ in range(budget.limit - 2):
+            budget.consume("step")
+        # Now we should be one consume away from the warn line.
+
+
+# ── B6-P3: routes/notifications.py ─────────────────────────────────────────
+class TestB6P3NotificationsRoute:
+    """The 4 notification endpoints must be reachable through the
+    main FastAPI app via the router include."""
+
+    def test_endpoints_registered_in_app(self):
+        from codec_dashboard import app
+        paths = {route.path for route in app.routes if hasattr(route, "path")}
+        assert "/api/notifications" in paths
+        assert "/api/notifications/count" in paths
+        assert "/api/notifications/{notif_id}/read" in paths
+        assert "/api/notifications/read-all" in paths
+
+
+# ── B6-P4: codec_voice_filters ─────────────────────────────────────────────
+class TestB6P4VoiceFiltersSplit:
+    """codec_voice re-exports must be identity-equal to codec_voice_filters."""
+
+    def test_noise_words_identity(self):
+        import codec_voice
+        import codec_voice_filters
+        assert codec_voice.NOISE_WORDS is codec_voice_filters.NOISE_WORDS
+
+    def test_whisper_hallucinations_identity(self):
+        import codec_voice
+        import codec_voice_filters
+        assert codec_voice.WHISPER_HALLUCINATIONS is codec_voice_filters.WHISPER_HALLUCINATIONS
+
+    @pytest.mark.parametrize("text,expected", [
+        ("you", True),
+        ("Thank you", True),
+        ("delete the file", False),
+        ("UM", True),
+        ("hello there friend", False),
+    ])
+    def test_is_noise_behavior(self, text, expected):
+        from codec_voice_filters import is_noise
+        assert is_noise(text) is expected
+
+    @pytest.mark.parametrize("text,expected", [
+        ("Thanks for watching everyone", True),
+        ("please subscribe and like", True),
+        ("Delete the file please", False),
+        ("All rights reserved", True),
+    ])
+    def test_is_hallucination_behavior(self, text, expected):
+        from codec_voice_filters import is_hallucination
+        assert is_hallucination(text) is expected
+
+    def test_rms_int16_empty(self):
+        from codec_voice_filters import rms_int16
+        assert rms_int16(b"") == 0.0
+        assert rms_int16(b"x") == 0.0  # < 2 bytes → 0
+
+    def test_rms_int16_nonzero(self):
+        from codec_voice_filters import rms_int16
+        # Build a short int16 PCM buffer with known RMS.
+        import numpy as np
+        samples = np.array([1000, -1000, 1000, -1000], dtype=np.int16)
+        rms = rms_int16(samples.tobytes())
+        assert rms == pytest.approx(1000.0, abs=1.0)

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -92,7 +92,8 @@ def test_plugin_load_blocked_not_in_allowlist(plugin_env, monkeypatch):
     allowlist_path.write_text("{}")
 
     captured = []
-    monkeypatch.setattr(codec_hooks, "_log_event",
+    import codec_plugin_trust
+    monkeypatch.setattr(codec_plugin_trust, "_log_event",
                          lambda *args, **kw: captured.append({"args": args, "kw": kw}))
 
     reg.scan()
@@ -140,7 +141,8 @@ def test_plugin_load_refused_when_hash_mismatches(plugin_env, monkeypatch):
     allowlist_path.write_text(json.dumps(allowlist))
 
     captured = []
-    monkeypatch.setattr(codec_hooks, "_log_event",
+    import codec_plugin_trust
+    monkeypatch.setattr(codec_plugin_trust, "_log_event",
                          lambda *args, **kw: captured.append({"args": args, "kw": kw}))
 
     reg.scan()
@@ -164,7 +166,8 @@ def test_plugin_load_blocked_emits_ast_detail_when_dangerous(plugin_env, monkeyp
     allowlist_path.write_text("{}")
 
     captured = []
-    monkeypatch.setattr(codec_hooks, "_log_event",
+    import codec_plugin_trust
+    monkeypatch.setattr(codec_plugin_trust, "_log_event",
                          lambda *args, **kw: captured.append({"args": args, "kw": kw}))
 
     reg.scan()
@@ -373,6 +376,8 @@ def test_fire_one_pre_tool_emits_plugin_hook_timeout(plugin_env, monkeypatch):
     monkeypatch.setitem(cfg, "plugin_hook_timeout_ms", 50)
 
     captured = []
+    # plugin_hook_timeout emit still lives in codec_hooks (it's part of the
+    # runtime dispatcher, not the trust store) — B6-P1 split kept it.
     monkeypatch.setattr(codec_hooks, "_log_event",
                          lambda *args, **kw: captured.append({"args": args, "kw": kw}))
 

--- a/tests/test_step_budget.py
+++ b/tests/test_step_budget.py
@@ -57,10 +57,16 @@ def temp_audit_log(tmp_path, monkeypatch):
 
 @pytest.fixture
 def temp_config(tmp_path, monkeypatch):
-    """Redirect codec_dashboard.CONFIG_PATH to a tmp file so we control what
-    _step_budget_for_route() reads on each call."""
+    """Redirect CONFIG_PATH to a tmp file so we control what
+    _step_budget_for_route() reads on each call.
+
+    B6-P2: _step_budget_for_route moved to codec_chat_pipeline; patch
+    there. Also patch codec_dashboard for any test that checks via the
+    re-export."""
     cfg = tmp_path / "config.json"
     monkeypatch.setattr(codec_dashboard, "CONFIG_PATH", str(cfg))
+    import codec_chat_pipeline
+    monkeypatch.setattr(codec_chat_pipeline, "CONFIG_PATH", str(cfg))
     return cfg
 
 


### PR DESCRIPTION
## Summary

Tackles the deferred B6 architecture refactors from `CODEC-FULL-AUDIT-2026-05-30.md`. Pytest: **2099 → 2128** (+29 regression tests, 0 regressions).

## Phases (4 splits, all back-compat via identity-equal re-exports)

### P1 — `codec_hooks` (1097 LOC) → runtime + trust store
- **New `codec_plugin_trust.py` (212 LOC)** — SHA-256 allowlist data layer. Owns `_read_allowlist` / `_write_allowlist` / `_file_sha256` / `_is_plugin_allowed` / `_maybe_grandfather_existing_plugins` / `_emit_plugin_load_blocked` / `_ALLOWLIST_LOCK` + constants + path helpers.
- **`codec_hooks` keeps the runtime** — PluginRegistry, run_with_hooks, HookCtx/HookVeto, 5-event dispatcher, _fire_one_*, _run_hook_with_timeout, emit_operation_*, approve_plugin operator entry.

### P2 — `codec_dashboard` chat helpers → `codec_chat_pipeline.py`
- **New `codec_chat_pipeline.py` (~170 LOC)** owns `_StepBudget`, `_step_budget_enabled` / `_step_budget_for_route`, `_is_conversational`. Pure-data + side-effect-light, testable without the FastAPI app.
- `codec_dashboard` re-imports for back-compat.
- **`chat_completion` (608 LOC) stays in codec_dashboard** — threads too many implicit module-level state dependencies for a safe one-session move.

### P3 — Notification endpoints → `routes/notifications.py`
- 4 endpoints moved: `GET /api/notifications`, `GET /api/notifications/count`, `POST /api/notifications/{id}/read`, `POST /api/notifications/read-all`.
- All deps already lived in `routes/_shared.py` — clean extraction.
- Establishes the **pattern** for the remaining route groups (`/api/qchat`, `/api/vibe`, `/api/heartbeat`, `/api/cortex`, `/api/audit`, `/api/observer`, `/api/prompts`).

### P4 — Voice filters → `codec_voice_filters.py`
- **New `codec_voice_filters.py` (96 LOC)** owns `NOISE_WORDS`, `WHISPER_HALLUCINATIONS`, `is_noise()`, `is_hallucination()`, `rms_int16()`.
- `codec_voice` re-exports; `_rms` delegates to `rms_int16`.

## Deferred (still valuable, sprint-sized)
- `chat_completion` (608 LOC) FastAPI handler extraction
- `VoicePipeline` class split into `VoiceVAD` / `VoiceTTS` / `VoiceSkillDispatch`
- Remaining dashboard endpoint groups
- `codec_agents` crew-factory → `crews/` package

## Test plan
- [x] `pytest tests/test_b6_refactor.py` — **29/29 new tests pass** (4 phase classes)
- [x] `pytest tests/test_plugin_registry.py` — 17/17 pass (3 monkeypatch sites moved to codec_plugin_trust)
- [x] `pytest tests/test_step_budget.py` — 16/16 pass (temp_config fixture patches both modules)
- [x] `pytest tests/test_hook_lifecycle.py tests/test_hook_veto.py tests/test_hook_audit_perf.py` — 80/80 pass
- [x] `pytest tests/test_voice_pipeline.py` — all pass after `_rms` → `rms_int16` delegation
- [x] `pytest tests/` (full) — **2128 passed, 83 skipped, 0 failed in 1m38s**
- [x] Import-identity: `codec_hooks._read_allowlist is codec_plugin_trust._read_allowlist` (True). Same for `_StepBudget`, `NOISE_WORDS`, etc.

## After merge
```bash
cd ~/codec-repo && git pull
pm2 restart codec-dashboard codec-mcp-http
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)