### PR TITLE
refactor(dashboard): F-series — extract 12 endpoints into 7 route modules

### DIFF
--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -348,6 +348,15 @@ from routes.update import router as update_router
 from routes.health import router as health_router
 # E4 / SR-49: upload + upload_image + save_file extracted (with B1 helpers).
 from routes.upload import router as upload_router
+# F-series (SR-51..56): config, history+conversations, tts+response, vision,
+# vibe IDE preview+run_code, web_search, cdp status.
+from routes.config import router as config_router
+from routes.history import router as history_router
+from routes.tts import router as tts_router
+from routes.vision import router as vision_router
+from routes.vibe_exec import router as vibe_exec_router
+from routes.web_search import router as web_search_router
+from routes.cdp import router as cdp_router
 # Phase 2 Step 6 — Trigger System PWA endpoints (auth-gated by /api/* middleware).
 try:
     from routes.triggers import router as triggers_router
@@ -375,6 +384,13 @@ app.include_router(media_router)
 app.include_router(update_router)
 app.include_router(health_router)
 app.include_router(upload_router)
+app.include_router(config_router)
+app.include_router(history_router)
+app.include_router(tts_router)
+app.include_router(vision_router)
+app.include_router(vibe_exec_router)
+app.include_router(web_search_router)
+app.include_router(cdp_router)
 if _has_triggers:
     app.include_router(triggers_router)
 
@@ -471,147 +487,11 @@ def _validate_config_updates(flat: dict) -> list:
     return errors
 
 
-@app.get("/api/config")
-async def get_config():
-    """Return full editable config for Settings UI (sensitive fields masked)."""
-    config = {}
-    try:
-        with open(CONFIG_PATH) as f:
-            config = json.load(f)
-    except Exception:
-        pass
-    # Group into sections for the UI
-    result = {
-        "llm": {
-            "llm_provider": config.get("llm_provider", "mlx"),
-            "llm_model": config.get("llm_model", ""),
-            "llm_base_url": config.get("llm_base_url", "http://localhost:8083/v1"),
-            "llm_api_key": config.get("llm_api_key", ""),
-            "streaming": config.get("streaming", True),
-        },
-        "vision": {
-            "vision_base_url": config.get("vision_base_url", "http://localhost:8083/v1"),
-            "vision_model": config.get("vision_model", ""),
-        },
-        "tts": {
-            "tts_engine": config.get("tts_engine", "kokoro"),
-            "tts_url": config.get("tts_url", "http://localhost:8085/v1/audio/speech"),
-            "tts_model": config.get("tts_model", ""),
-            "tts_voice": config.get("tts_voice", "am_adam"),
-        },
-        "stt": {
-            "stt_engine": config.get("stt_engine", "whisper_http"),
-            "stt_url": config.get("stt_url", "http://localhost:8084/v1/audio/transcriptions"),
-        },
-        "keys": {
-            "key_toggle": config.get("key_toggle", "f13"),
-            "key_voice": config.get("key_voice", "f18"),
-            "key_text": config.get("key_text", "f16"),
-        },
-        "wake": {
-            "wake_word_enabled": config.get("wake_word_enabled", True),
-            "wake_phrases": config.get("wake_phrases", []),
-            "wake_energy": config.get("wake_energy", 200),
-        },
-        "auth": {
-            "auth_enabled": config.get("auth_enabled", False),
-            "auth_session_hours": config.get("auth_session_hours", 24),
-            "dashboard_token": config.get("dashboard_token", ""),
-        },
-        "identity": {
-            "agent_name": config.get("agent_name", "C"),
-        },
-    }
-    # Mask sensitive fields before sending to the client
-    for section in result.values():
-        if isinstance(section, dict):
-            for key in section:
-                if key in _SENSITIVE_FIELDS:
-                    section[key] = _mask_sensitive(section[key])
-    return result
-
-
-@app.put("/api/config")
-async def update_config(request: Request):
-    """Update config.json from Settings UI with input validation."""
-    try:
-        updates = await request.json()
-        config = {}
-        try:
-            with open(CONFIG_PATH) as f:
-                config = json.load(f)
-        except Exception:
-            pass
-
-        # Flatten sections for validation and merge
-        flat = {}
-        for section_vals in updates.values():
-            if isinstance(section_vals, dict):
-                for k, v in section_vals.items():
-                    flat[k] = v
-
-        # Validate all incoming values
-        errors = _validate_config_updates(flat)
-        if errors:
-            return JSONResponse({"error": "Validation failed", "details": errors}, status_code=422)
-
-        # Merge validated values, skipping masked sensitive fields
-        changed_keys = []
-        for k, v in flat.items():
-            # If a sensitive field is still masked, the user did not change it — skip
-            if k in _SENSITIVE_FIELDS and isinstance(v, str) and v.startswith("*"):
-                continue
-            config[k] = v
-            changed_keys.append(k)
-
-        with open(CONFIG_PATH, "w") as f:
-            json.dump(config, f, indent=2)
-        return {
-            "saved": True,
-            "message": f"Configuration saved successfully ({len(changed_keys)} field(s) updated).",
-            "updated_fields": changed_keys,
-        }
-    except json.JSONDecodeError:
-        return JSONResponse({"error": "Invalid JSON in request body"}, status_code=400)
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-
-
-@app.get("/api/history")
-async def history(limit: int = 50):
-    """Get recent task history"""
-    limit = min(limit, 500)
-    try:
-        c = get_db()
-        rows = c.execute(
-            "SELECT id, timestamp, task, app, response FROM sessions ORDER BY id DESC LIMIT ?",
-            (limit,)
-        ).fetchall()
-        return [{"id": r[0], "timestamp": r[1], "task": r[2], "app": r[3], "response": r[4]} for r in rows]
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-
+# F1 config GET → moved to routes/*.py
+# F1 config PUT → moved to routes/*.py
+# F2 history → moved to routes/*.py
 # D4 / SR-45: prompt endpoints + helpers moved to routes/prompts.py.
-@app.get("/api/conversations")
-async def conversations(limit: int = 100, source: str = ""):
-    """Get recent conversations. source=flash filters to Flash Chat only."""
-    limit = min(limit, 500)
-    try:
-        c = get_db()
-        if source == "flash":
-            rows = c.execute(
-                "SELECT id, session_id, timestamp, role, content FROM conversations WHERE session_id LIKE 'flash-%' ORDER BY id DESC LIMIT ?",
-                (limit,)
-            ).fetchall()
-        else:
-            rows = c.execute(
-                "SELECT id, session_id, timestamp, role, content FROM conversations ORDER BY id DESC LIMIT ?",
-                (limit,)
-            ).fetchall()
-        return [{"id": r[0], "session_id": r[1], "timestamp": r[2], "role": r[3], "content": r[4]} for r in rows]
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-
+# F2 conversations → moved to routes/*.py
 # C4 / SR-39: audit endpoints moved to routes/audit.py.
 
 
@@ -837,136 +717,9 @@ async def send_command(request: Request):
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
-@app.post("/api/vision")
-async def vision_analyze(request: Request):
-    """Send image to Qwen Vision model for analysis.
-
-    If `session_id` is provided, the user prompt + assistant response are
-    persisted to the conversations table so the chat panel renders them.
-    A small `thumb` (base64 jpeg, max ~256px on the client side) can be
-    embedded inline in the user message via a `[CODEC_IMG_THUMB:...]`
-    sentinel — loadChat() in codec_dashboard.html parses the sentinel
-    and renders the thumbnail. Storage cost: ~10–20 KB per image message.
-    """
-    body = await request.json()
-    image_b64 = body.get("image", "")
-    prompt = body.get("prompt", "Describe and analyze this image in detail.")
-    session_id = (body.get("session_id") or "").strip()
-    thumb_b64 = body.get("thumb", "")
-    if not image_b64:
-        return JSONResponse({"error": "No image data"}, status_code=400)
-    try:
-        import requests as rq
-        config = {}
-        try:
-            with open(CONFIG_PATH) as f: config = json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
-            log.warning(f"Config read failed; proceeding without overrides: {e}")
-        vision_url = config.get("vision_base_url", "http://localhost:8083/v1")
-        vision_model = config.get("vision_model", "mlx-community/Qwen2.5-VL-7B-Instruct-4bit")
-        payload = {
-            "model": vision_model,
-            "messages": [{
-                "role": "user",
-                "content": [
-                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
-                    {"type": "text", "text": prompt}
-                ]
-            }],
-            "max_tokens": 4000,
-            "temperature": 0.7
-        }
-        headers = {"Content-Type": "application/json"}
-        r = rq.post(f"{vision_url}/chat/completions", json=payload, headers=headers, timeout=120)
-        data = r.json()
-        answer = data["choices"][0]["message"]["content"].strip()
-        _audit_write(f"[{datetime.now().isoformat()}] VISION: {prompt[:100]}\n")
-        log_event("chat_vision", "codec-dashboard",
-                  f"Vision analysis: {prompt[:60]}",
-                  extra={"prompt_preview": prompt[:200]})
-
-        # Persist user msg (with thumbnail sentinel) + assistant msg so the
-        # image appears in the chat panel. Defensive: never let a save error
-        # break the vision response — log + return the answer regardless.
-        if session_id:
-            try:
-                now_iso = datetime.now().isoformat()
-                # Cap thumbnail size to ~60KB of base64 (about a 256x256 jpeg
-                # @ q=0.4); silently drop if larger to keep DB rows lean.
-                # Validate the whole string is base64 so any injection attempt
-                # (e.g. ']<script>') falls through to the no-thumb branch.
-                import re as _re_b64
-                _is_b64 = bool(thumb_b64) and len(thumb_b64) <= 60_000 \
-                    and _re_b64.fullmatch(r'[A-Za-z0-9+/]+={0,2}', thumb_b64) is not None
-                if _is_b64:
-                    user_content = (
-                        (prompt or "Analyze this image")[:2000]
-                        + f"\n[CODEC_IMG_THUMB:data:image/jpeg;base64,{thumb_b64}]"
-                    )
-                else:
-                    user_content = (prompt or "Analyze this image")[:2000]
-                c = get_db()
-                c.execute(
-                    "INSERT INTO conversations (session_id, timestamp, role, content) VALUES (?,?,?,?)",
-                    (session_id, now_iso, "user", user_content),
-                )
-                c.execute(
-                    "INSERT INTO conversations (session_id, timestamp, role, content) VALUES (?,?,?,?)",
-                    (session_id, now_iso, "assistant", answer[:5000]),
-                )
-                c.commit()
-            except Exception as save_err:
-                log.warning(f"[Vision] save to conversations failed: {save_err}")
-
-        return {"response": answer, "model": vision_model}
-    except Exception as e:
-        import traceback; traceback.print_exc()
-        return JSONResponse({"error": str(e)}, status_code=500)
-
-@app.get("/api/response")
-async def get_response(session_id: str = "", after: str = "", after_id: str = ""):
-    """Get the PWA command response from the conversations DB (C-2 / PR-4B).
-
-    Correlation is server-authoritative via `after_id` (= the request_id the
-    /api/command response carried = the user row's conversations.id). `after`
-    (legacy wall-clock timestamp) is kept only as a fallback for an un-refreshed
-    PWA tab. The old ~/.codec/pwa_response.json file path is gone."""
-    headers = {"Cache-Control": "no-cache, no-store, must-revalidate", "Pragma": "no-cache"}
-    try:
-        ans = _latest_response_for_session(get_db(), session_id, after_id=after_id, after_ts=after)
-        if ans:
-            log.info(f"[Response] Delivered (db): {str(ans)[:80]}")
-            return JSONResponse(content={"response": ans}, headers=headers)
-        return JSONResponse(content={"response": None}, headers=headers)
-    except Exception as e:
-        log.warning(f"[Response] Error reading response: {e}")
-        return JSONResponse(content={"response": None}, headers=headers)
-
-@app.get("/api/tts")
-async def tts(text: str = ""):
-    """Generate speech and return audio file"""
-    if not text:
-        return JSONResponse({"error": "No text"}, status_code=400)
-    try:
-        import requests as rq
-        config = {}
-        try:
-            with open(CONFIG_PATH) as f: config = json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
-            log.warning(f"Config read failed; proceeding without overrides: {e}")
-        tts_url = config.get("tts_url", "http://localhost:8085/v1/audio/speech")
-        tts_model = config.get("tts_model", "mlx-community/Kokoro-82M-bf16")
-        tts_voice = config.get("tts_voice", "am_adam")
-        r = rq.post(tts_url, json={"model": tts_model, "input": text[:500], "voice": tts_voice, "speed": 1.1}, timeout=30)
-        if r.status_code == 200:
-            audio_path = os.path.expanduser("~/.codec/pwa_audio.mp3")
-            with open(audio_path, "wb") as f:
-                f.write(r.content)
-            return FileResponse(audio_path, media_type="audio/mpeg")
-        return JSONResponse({"error": "TTS failed"}, status_code=500)
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-
+# F4 vision → moved to routes/*.py
+# F3 response → moved to routes/*.py
+# F3 tts → moved to routes/*.py
 # D5 / SR-46: webcam + screenshot + clipboard endpoints moved to routes/media.py.
 
 
@@ -1136,79 +889,9 @@ async def vibe_page():
     with open(vibe_path) as f:
         return HTMLResponse(f.read(), headers=_NO_CACHE)
 
-@app.post("/api/preview")
-async def preview_code(request: Request):
-    body = await request.json()
-    code = body.get("code", "")
-    preview_path = os.path.expanduser("~/.codec/preview.html")
-    with open(preview_path, "w") as f:
-        f.write(code)
-    return {"url": "/preview_frame", "path": preview_path}
-
-@app.get("/preview_frame", response_class=HTMLResponse)
-async def preview_frame():
-    try:
-        with open(os.path.expanduser("~/.codec/preview.html")) as f:
-            content = f.read()
-        # Restrict preview with CSP — no access to dashboard APIs or external resources
-        return HTMLResponse(content, headers={
-            "Content-Security-Policy": "default-src 'self' 'unsafe-inline' data: blob:; connect-src 'none'; form-action 'none'",
-            "X-Frame-Options": "SAMEORIGIN",
-        })
-    except OSError as e:
-        log.warning(f"Preview file read failed; showing placeholder: {e}")
-        return HTMLResponse("<html><body style='background:#0a0a0a;color:#888;padding:40px;font-family:sans-serif'><h2>No preview available</h2><p>Write some HTML and click Preview.</p></body></html>")
-
-@app.post("/api/run_code")
-async def run_code(request: Request):
-    import asyncio
-    import time as _time
-    body = await request.json()
-    code = body.get("code", "")
-    language = body.get("language", "python")
-    body.get("filename", "script.py")
-    if not code.strip():
-        return JSONResponse({"error": "No code"}, status_code=400)
-    from codec_config import is_dangerous
-    if is_dangerous(code):
-        return JSONResponse({"error": "Blocked: code contains dangerous pattern"}, status_code=403)
-    import tempfile
-    ext_map = {"python": ".py", "javascript": ".js", "typescript": ".ts", "bash": ".sh", "go": ".go", "rust": ".rs", "java": ".java", "cpp": ".cpp", "swift": ".swift", "ruby": ".rb", "sql": ".sql"}
-    ext = ext_map.get(language, ".txt")
-    tmp = tempfile.NamedTemporaryFile(suffix=ext, delete=False, mode="w")
-    tmp.write(code); tmp.close()
-    cmd_map = {
-        "python": ["python3.13", tmp.name],
-        "javascript": ["node", tmp.name],
-        "typescript": ["npx", "ts-node", tmp.name],
-        "bash": ["bash", tmp.name],
-        "go": ["go", "run", tmp.name],
-        "rust": ["rustc", tmp.name, "-o", tmp.name + ".out", "&&", tmp.name + ".out"],
-        "swift": ["swift", tmp.name],
-        "ruby": ["ruby", tmp.name],
-    }
-    cmd = cmd_map.get(language, ["python3.13", tmp.name])
-    # For rust, compile+run in one shell command
-    if language == "rust":
-        cmd = ["bash", "-c", f"rustc {tmp.name} -o {tmp.name}.out 2>&1 && {tmp.name}.out"]
-    start = _time.time()
-    try:
-        proc = await asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=os.path.expanduser("~"))
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-        return {"stdout": stdout.decode(errors="replace")[:10000], "stderr": stderr.decode(errors="replace")[:5000], "exit_code": proc.returncode, "elapsed": round(_time.time()-start,1)}
-    except asyncio.TimeoutError:
-        return {"stdout":"","stderr":"Timed out (30s)","exit_code":-1,"elapsed":30}
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-    finally:
-        # H-8: also unlink the Rust-compiled `<tmp>.out` binary (only created for
-        # rust; for other langs the path doesn't exist → FileNotFoundError is
-        # caught). The source tmp was already cleaned here; the .out leaked.
-        for _p in (tmp.name, tmp.name + ".out"):
-            try: os.unlink(_p)
-            except OSError as e:
-                log.debug(f"Temp file cleanup failed for {_p}: {e}")
-
+# F5 preview → moved to routes/*.py
+# F5 preview_frame → moved to routes/*.py
+# F5 run_code → moved to routes/*.py
 # /api/save_file safety check — mirrors PR-1C's `file_write` skill blocklist.
 # A1 / SR-8: previously `~/.codec` was in the allowlist, which let any
 # authenticated POST drop a malicious plugin into ~/.codec/plugins/ + add its
@@ -1438,26 +1121,7 @@ def _enrich_messages(messages: list, config: dict, force_search: bool = False) -
     return enriched
 
 
-@app.post("/api/web_search")
-async def web_search_endpoint(request: Request):
-    """Standalone web search endpoint for the chat UI."""
-    body = await request.json()
-    query = body.get("query", "").strip()
-    if not query:
-        return JSONResponse({"error": "query required"}, status_code=400)
-    try:
-        import sys
-        import os as _os
-        repo_dir = _os.path.dirname(_os.path.abspath(__file__))
-        if repo_dir not in sys.path:
-            sys.path.insert(0, repo_dir)
-        from codec_search import search, format_results
-        results = search(query, max_results=8)
-        return {"results": results, "formatted": format_results(results, max_snippets=8)}
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-
-
+# F6 web_search → moved to routes/*.py
 # ── Chat Tool Calling: safe skills available from Chat ──
 CHAT_SKILL_ALLOWLIST = {
     # Core utilities
@@ -2264,24 +1928,7 @@ async def audit_page():
 # (Memory endpoints moved to routes/memory.py)
 # (Skills list endpoint moved to routes/skills.py)
 
-@app.get("/api/cdp/status")
-async def cdp_status():
-    """Check if Chrome is running with CDP enabled."""
-    try:
-        import httpx as _httpx
-        r = _httpx.get("http://localhost:9222/json", timeout=2)
-        tabs = r.json()
-        page_tabs = [t for t in tabs if t.get("type") == "page"]
-        return {
-            "connected": True,
-            "total_tabs": len(tabs),
-            "page_tabs": len(page_tabs),
-            "tabs": [{"title": t.get("title", "")[:60], "url": t.get("url", "")[:80]}
-                     for t in page_tabs[:5]]
-        }
-    except Exception:
-        return {"connected": False, "total_tabs": 0, "page_tabs": 0, "tabs": []}
-
+# F7 cdp_status → moved to routes/*.py
 # ═══════════════════════════════════════════════════════════════
 # BACKGROUND SERVICES (scheduler, heartbeat, watcher)
 # ═══════════════════════════════════════════════════════════════

--- a/routes/cdp.py
+++ b/routes/cdp.py
@@ -1,0 +1,30 @@
+"""CODEC CDP (Chrome DevTools Protocol) status API.
+
+F7 / SR-56: extracted from codec_dashboard.py. Single read-only endpoint
+that probes localhost:9222 (Chrome with --remote-debugging-port) and
+returns the tab summary. Used by the Pilot status pill in the dashboard.
+"""
+from __future__ import annotations
+
+import httpx as _httpx
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/api/cdp/status")
+async def cdp_status():
+    """Check if Chrome is running with CDP enabled."""
+    try:
+        r = _httpx.get("http://localhost:9222/json", timeout=2)
+        tabs = r.json()
+        page_tabs = [t for t in tabs if t.get("type") == "page"]
+        return {
+            "connected": True,
+            "total_tabs": len(tabs),
+            "page_tabs": len(page_tabs),
+            "tabs": [{"title": t.get("title", "")[:60], "url": t.get("url", "")[:80]}
+                     for t in page_tabs[:5]]
+        }
+    except Exception:
+        return {"connected": False, "total_tabs": 0, "page_tabs": 0, "tabs": []}

--- a/routes/config.py
+++ b/routes/config.py
@@ -1,0 +1,187 @@
+"""CODEC config API — Settings UI backing.
+
+F1 / SR-50: extracted from codec_dashboard.py. The 22-rule validation
+matrix + sensitive-field masking helpers move with the GET/PUT endpoints
+so the whole config-surface lives in one place.
+
+  - GET /api/config  returns grouped sections with sensitive fields masked
+  - PUT /api/config  validates per-rule + merges, skipping masked values
+"""
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from routes._shared import CONFIG_PATH
+
+router = APIRouter()
+
+
+def _mask_sensitive(value: str) -> str:
+    """Mask sensitive field values, showing only last 4 characters."""
+    if not value or not isinstance(value, str):
+        return ""
+    if len(value) <= 4:
+        return "****"
+    return "*" * (len(value) - 4) + value[-4:]
+
+
+# Fields that contain secrets and must be masked in GET responses
+_SENSITIVE_FIELDS = {"llm_api_key", "dashboard_token", "auth_pin_hash"}
+
+# Validation rules: field -> (type, required, extra_checks)
+# extra_checks is a callable returning (ok, error_msg)
+_VALIDATION_RULES = {
+    "agent_name":          (str,  True,  lambda v: (len(v.strip()) > 0, "agent_name cannot be empty")),
+    "llm_provider":        (str,  True,  lambda v: (len(v.strip()) > 0, "llm_provider cannot be empty")),
+    "llm_model":           (str,  False, None),
+    "llm_base_url":        (str,  False, lambda v: (v == "" or v.startswith("http"), "llm_base_url must be a valid URL")),
+    "llm_api_key":         (str,  False, None),
+    "streaming":           (bool, False, None),
+    "vision_base_url":     (str,  False, lambda v: (v == "" or v.startswith("http"), "vision_base_url must be a valid URL")),
+    "vision_model":        (str,  False, None),
+    "tts_engine":          (str,  False, None),
+    "tts_url":             (str,  False, lambda v: (v == "" or v.startswith("http"), "tts_url must be a valid URL")),
+    "tts_model":           (str,  False, None),
+    "tts_voice":           (str,  False, None),
+    "stt_engine":          (str,  False, None),
+    "stt_url":             (str,  False, lambda v: (v == "" or v.startswith("http"), "stt_url must be a valid URL")),
+    "key_toggle":          (str,  True,  lambda v: (len(v.strip()) > 0, "key_toggle cannot be empty")),
+    "key_voice":           (str,  True,  lambda v: (len(v.strip()) > 0, "key_voice cannot be empty")),
+    "key_text":            (str,  True,  lambda v: (len(v.strip()) > 0, "key_text cannot be empty")),
+    "wake_word_enabled":   (bool, False, None),
+    "wake_phrases":        (list, False, None),
+    "wake_energy":         ((int, float), False, lambda v: (v >= 0, "wake_energy cannot be negative")),
+    "auth_enabled":        (bool, False, None),
+    "auth_session_hours":  ((int, float), False, lambda v: (v > 0, "auth_session_hours must be positive")),
+    "dashboard_token":     (str,  False, None),
+}
+
+
+def _validate_config_updates(flat: dict) -> list:
+    """Validate flattened config values. Returns list of error strings."""
+    errors = []
+    for key, value in flat.items():
+        rule = _VALIDATION_RULES.get(key)
+        if not rule:
+            continue  # allow unknown keys through (forward compat)
+        expected_type, required, check_fn = rule
+        # Skip masked sensitive values (client didn't change them)
+        if key in _SENSITIVE_FIELDS and isinstance(value, str) and value.startswith("*"):
+            continue
+        if not isinstance(value, expected_type):
+            errors.append(f"{key}: expected {expected_type.__name__ if isinstance(expected_type, type) else 'number'}, got {type(value).__name__}")
+            continue
+        if check_fn:
+            ok, msg = check_fn(value)
+            if not ok:
+                errors.append(msg)
+    return errors
+
+
+@router.get("/api/config")
+async def get_config():
+    """Return full editable config for Settings UI (sensitive fields masked)."""
+    config = {}
+    try:
+        with open(CONFIG_PATH) as f:
+            config = json.load(f)
+    except Exception:
+        pass
+    # Group into sections for the UI
+    result = {
+        "llm": {
+            "llm_provider": config.get("llm_provider", "mlx"),
+            "llm_model": config.get("llm_model", ""),
+            "llm_base_url": config.get("llm_base_url", "http://localhost:8083/v1"),
+            "llm_api_key": config.get("llm_api_key", ""),
+            "streaming": config.get("streaming", True),
+        },
+        "vision": {
+            "vision_base_url": config.get("vision_base_url", "http://localhost:8083/v1"),
+            "vision_model": config.get("vision_model", ""),
+        },
+        "tts": {
+            "tts_engine": config.get("tts_engine", "kokoro"),
+            "tts_url": config.get("tts_url", "http://localhost:8085/v1/audio/speech"),
+            "tts_model": config.get("tts_model", ""),
+            "tts_voice": config.get("tts_voice", "am_adam"),
+        },
+        "stt": {
+            "stt_engine": config.get("stt_engine", "whisper_http"),
+            "stt_url": config.get("stt_url", "http://localhost:8084/v1/audio/transcriptions"),
+        },
+        "keys": {
+            "key_toggle": config.get("key_toggle", "f13"),
+            "key_voice": config.get("key_voice", "f18"),
+            "key_text": config.get("key_text", "f16"),
+        },
+        "wake": {
+            "wake_word_enabled": config.get("wake_word_enabled", True),
+            "wake_phrases": config.get("wake_phrases", []),
+            "wake_energy": config.get("wake_energy", 200),
+        },
+        "auth": {
+            "auth_enabled": config.get("auth_enabled", False),
+            "auth_session_hours": config.get("auth_session_hours", 24),
+            "dashboard_token": config.get("dashboard_token", ""),
+        },
+        "identity": {
+            "agent_name": config.get("agent_name", "C"),
+        },
+    }
+    # Mask sensitive fields before sending to the client
+    for section in result.values():
+        if isinstance(section, dict):
+            for key in section:
+                if key in _SENSITIVE_FIELDS:
+                    section[key] = _mask_sensitive(section[key])
+    return result
+
+
+@router.put("/api/config")
+async def update_config(request: Request):
+    """Update config.json from Settings UI with input validation."""
+    try:
+        updates = await request.json()
+        config = {}
+        try:
+            with open(CONFIG_PATH) as f:
+                config = json.load(f)
+        except Exception:
+            pass
+
+        # Flatten sections for validation and merge
+        flat = {}
+        for section_vals in updates.values():
+            if isinstance(section_vals, dict):
+                for k, v in section_vals.items():
+                    flat[k] = v
+
+        # Validate all incoming values
+        errors = _validate_config_updates(flat)
+        if errors:
+            return JSONResponse({"error": "Validation failed", "details": errors}, status_code=422)
+
+        # Merge validated values, skipping masked sensitive fields
+        changed_keys = []
+        for k, v in flat.items():
+            # If a sensitive field is still masked, the user did not change it — skip
+            if k in _SENSITIVE_FIELDS and isinstance(v, str) and v.startswith("*"):
+                continue
+            config[k] = v
+            changed_keys.append(k)
+
+        with open(CONFIG_PATH, "w") as f:
+            json.dump(config, f, indent=2)
+        return {
+            "saved": True,
+            "message": f"Configuration saved successfully ({len(changed_keys)} field(s) updated).",
+            "updated_fields": changed_keys,
+        }
+    except json.JSONDecodeError:
+        return JSONResponse({"error": "Invalid JSON in request body"}, status_code=400)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/routes/history.py
+++ b/routes/history.py
@@ -1,0 +1,49 @@
+"""CODEC history + conversations API routes.
+
+F2 / SR-51: extracted from codec_dashboard.py. Two read-only endpoints
+that browse the sessions / conversations tables for the dashboard UI.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from routes._shared import get_db
+
+router = APIRouter()
+
+
+@router.get("/api/history")
+async def history(limit: int = 50):
+    """Get recent task history."""
+    limit = min(limit, 500)
+    try:
+        c = get_db()
+        rows = c.execute(
+            "SELECT id, timestamp, task, app, response FROM sessions ORDER BY id DESC LIMIT ?",
+            (limit,)
+        ).fetchall()
+        return [{"id": r[0], "timestamp": r[1], "task": r[2], "app": r[3], "response": r[4]} for r in rows]
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@router.get("/api/conversations")
+async def conversations(limit: int = 100, source: str = ""):
+    """Get recent conversations. source=flash filters to Flash Chat only."""
+    limit = min(limit, 500)
+    try:
+        c = get_db()
+        if source == "flash":
+            rows = c.execute(
+                "SELECT id, session_id, timestamp, role, content FROM conversations WHERE session_id LIKE 'flash-%' ORDER BY id DESC LIMIT ?",
+                (limit,)
+            ).fetchall()
+        else:
+            rows = c.execute(
+                "SELECT id, session_id, timestamp, role, content FROM conversations ORDER BY id DESC LIMIT ?",
+                (limit,)
+            ).fetchall()
+        return [{"id": r[0], "session_id": r[1], "timestamp": r[2], "role": r[3], "content": r[4]} for r in rows]
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/routes/tts.py
+++ b/routes/tts.py
@@ -1,0 +1,114 @@
+"""CODEC TTS + response polling API routes.
+
+F3 / SR-52: extracted from codec_dashboard.py. /api/tts proxies to
+Kokoro; /api/response is the long-poll endpoint for the Flash Chat
+request_id correlation (C-2 / PR-4B).
+
+The _latest_response_for_session helper lives here too — it's only
+called from /api/response.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Optional
+
+import requests as rq
+from fastapi import APIRouter
+from fastapi.responses import FileResponse, JSONResponse
+
+from routes._shared import CONFIG_PATH, get_db
+
+router = APIRouter()
+log = logging.getLogger("codec_dashboard")
+
+
+def _latest_response_for_session(db, session_id, after_id="", after_ts="") -> Optional[str]:
+    """Newest assistant reply for the caller's turn, or None. (C-2 / PR-4B.)
+
+    Correlation is server-authoritative via conversations.id (`after_id` = the
+    user row's autoincrement id, returned to the client as request_id). The
+    turn's assistant row always has id > after_id, so `id > after_id ORDER BY id
+    ASC LIMIT 1` selects the immediate-next assistant reply — no client-clock dep,
+    exactly correct for the dominant single-tab + sequential flows. This
+    replaces the racy ~/.codec/pwa_response.json file (non-atomic write, no
+    writer mutex, no correlation, racy mtime/unlink) AND the latent
+    clock/RTT-skew miss of the old `timestamp > after` query.
+
+    `after_ts` (a wall-clock string) is a backward-compat fallback for an
+    un-refreshed PWA tab that predates after_id. Never raises."""
+    if not session_id:
+        return None
+    try:
+        aid = int(after_id or 0)
+    except (TypeError, ValueError):
+        aid = 0
+    try:
+        if aid > 0:
+            row = db.execute(
+                "SELECT content FROM conversations "
+                "WHERE session_id=? AND role='assistant' AND id>? "
+                "ORDER BY id ASC LIMIT 1",
+                (session_id, aid),
+            ).fetchone()
+        elif after_ts:
+            row = db.execute(
+                "SELECT content FROM conversations "
+                "WHERE session_id=? AND role='assistant' AND timestamp>? "
+                "ORDER BY timestamp DESC LIMIT 1",
+                (session_id, after_ts),
+            ).fetchone()
+        else:
+            return None
+        if row and row[0]:
+            return row[0]
+        return None
+    except Exception:
+        return None
+
+
+@router.get("/api/response")
+async def get_response(session_id: str = "", after: str = "", after_id: str = ""):
+    """Get the PWA command response from the conversations DB (C-2 / PR-4B).
+
+    Correlation is server-authoritative via `after_id` (= the request_id the
+    /api/command response carried = the user row's conversations.id). `after`
+    (legacy wall-clock timestamp) is kept only as a fallback for an un-refreshed
+    PWA tab. The old ~/.codec/pwa_response.json file path is gone."""
+    headers = {"Cache-Control": "no-cache, no-store, must-revalidate", "Pragma": "no-cache"}
+    try:
+        ans = _latest_response_for_session(get_db(), session_id, after_id=after_id, after_ts=after)
+        if ans:
+            log.info(f"[Response] Delivered (db): {str(ans)[:80]}")
+            return JSONResponse(content={"response": ans}, headers=headers)
+        return JSONResponse(content={"response": None}, headers=headers)
+    except Exception as e:
+        log.warning(f"[Response] Error reading response: {e}")
+        return JSONResponse(content={"response": None}, headers=headers)
+
+
+@router.get("/api/tts")
+async def tts(text: str = ""):
+    """Generate speech and return audio file."""
+    if not text:
+        return JSONResponse({"error": "No text"}, status_code=400)
+    try:
+        config = {}
+        try:
+            with open(CONFIG_PATH) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning(f"Config read failed; proceeding without overrides: {e}")
+        tts_url = config.get("tts_url", "http://localhost:8085/v1/audio/speech")
+        tts_model = config.get("tts_model", "mlx-community/Kokoro-82M-bf16")
+        tts_voice = config.get("tts_voice", "am_adam")
+        r = rq.post(tts_url, json={"model": tts_model, "input": text[:500], "voice": tts_voice, "speed": 1.1}, timeout=30)
+        if r.status_code == 200:
+            audio_path = os.path.expanduser("~/.codec/pwa_audio.mp3")
+            with open(audio_path, "wb") as f:
+                f.write(r.content)
+            return FileResponse(audio_path, media_type="audio/mpeg")
+        return JSONResponse({"error": "TTS failed"}, status_code=500)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/routes/vibe_exec.py
+++ b/routes/vibe_exec.py
@@ -1,0 +1,100 @@
+"""CODEC Vibe IDE execution API — preview + run_code.
+
+F5 / SR-54 (was E5): extracted from codec_dashboard.py. The 3 endpoints
+that back the Vibe IDE's live-preview + code-execution panel.
+
+  - /api/preview      writes user HTML to ~/.codec/preview.html
+  - /preview_frame    serves it inside a sandboxed iframe
+                      (CSP restricted: no dashboard APIs, no external resources)
+  - /api/run_code     spawns a language-specific compiler/interpreter on a
+                      tempfile, gates the source through `is_dangerous`,
+                      cleans up the Rust `.out` binary in finally (H-8 fix).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+import time as _time
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+router = APIRouter()
+log = logging.getLogger("codec_dashboard")
+
+
+@router.post("/api/preview")
+async def preview_code(request: Request):
+    body = await request.json()
+    code = body.get("code", "")
+    preview_path = os.path.expanduser("~/.codec/preview.html")
+    with open(preview_path, "w") as f:
+        f.write(code)
+    return {"url": "/preview_frame", "path": preview_path}
+
+
+@router.get("/preview_frame", response_class=HTMLResponse)
+async def preview_frame():
+    try:
+        with open(os.path.expanduser("~/.codec/preview.html")) as f:
+            content = f.read()
+        # Restrict preview with CSP — no access to dashboard APIs or external resources
+        return HTMLResponse(content, headers={
+            "Content-Security-Policy": "default-src 'self' 'unsafe-inline' data: blob:; connect-src 'none'; form-action 'none'",
+            "X-Frame-Options": "SAMEORIGIN",
+        })
+    except OSError as e:
+        log.warning(f"Preview file read failed; showing placeholder: {e}")
+        return HTMLResponse("<html><body style='background:#0a0a0a;color:#888;padding:40px;font-family:sans-serif'><h2>No preview available</h2><p>Write some HTML and click Preview.</p></body></html>")
+
+
+@router.post("/api/run_code")
+async def run_code(request: Request):
+    body = await request.json()
+    code = body.get("code", "")
+    language = body.get("language", "python")
+    body.get("filename", "script.py")
+    if not code.strip():
+        return JSONResponse({"error": "No code"}, status_code=400)
+    from codec_config import is_dangerous
+    if is_dangerous(code):
+        return JSONResponse({"error": "Blocked: code contains dangerous pattern"}, status_code=403)
+    ext_map = {"python": ".py", "javascript": ".js", "typescript": ".ts", "bash": ".sh", "go": ".go", "rust": ".rs", "java": ".java", "cpp": ".cpp", "swift": ".swift", "ruby": ".rb", "sql": ".sql"}
+    ext = ext_map.get(language, ".txt")
+    tmp = tempfile.NamedTemporaryFile(suffix=ext, delete=False, mode="w")
+    tmp.write(code)
+    tmp.close()
+    cmd_map = {
+        "python": ["python3.13", tmp.name],
+        "javascript": ["node", tmp.name],
+        "typescript": ["npx", "ts-node", tmp.name],
+        "bash": ["bash", tmp.name],
+        "go": ["go", "run", tmp.name],
+        "rust": ["rustc", tmp.name, "-o", tmp.name + ".out", "&&", tmp.name + ".out"],
+        "swift": ["swift", tmp.name],
+        "ruby": ["ruby", tmp.name],
+    }
+    cmd = cmd_map.get(language, ["python3.13", tmp.name])
+    # For rust, compile+run in one shell command
+    if language == "rust":
+        cmd = ["bash", "-c", f"rustc {tmp.name} -o {tmp.name}.out 2>&1 && {tmp.name}.out"]
+    start = _time.time()
+    try:
+        proc = await asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=os.path.expanduser("~"))
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        return {"stdout": stdout.decode(errors="replace")[:10000], "stderr": stderr.decode(errors="replace")[:5000], "exit_code": proc.returncode, "elapsed": round(_time.time() - start, 1)}
+    except asyncio.TimeoutError:
+        return {"stdout": "", "stderr": "Timed out (30s)", "exit_code": -1, "elapsed": 30}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+    finally:
+        # H-8: also unlink the Rust-compiled `<tmp>.out` binary (only created for
+        # rust; for other langs the path doesn't exist → FileNotFoundError is
+        # caught). The source tmp was already cleaned here; the .out leaked.
+        for _p in (tmp.name, tmp.name + ".out"):
+            try:
+                os.unlink(_p)
+            except OSError as e:
+                log.debug(f"Temp file cleanup failed for {_p}: {e}")

--- a/routes/vision.py
+++ b/routes/vision.py
@@ -1,0 +1,110 @@
+"""CODEC vision API route — Qwen Vision model proxy with chat persistence.
+
+F4 / SR-53: extracted from codec_dashboard.py. Sends an image to the
+local vision model, returns the description, and optionally persists
+both the user prompt (with a thumbnail sentinel) and the assistant
+reply to the conversations table so the chat panel renders them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re as _re_b64
+from datetime import datetime
+
+import requests as rq
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from codec_audit import log_event
+from routes._shared import CONFIG_PATH, _audit_write, get_db
+
+router = APIRouter()
+log = logging.getLogger("codec_dashboard")
+
+
+@router.post("/api/vision")
+async def vision_analyze(request: Request):
+    """Send image to Qwen Vision model for analysis.
+
+    If `session_id` is provided, the user prompt + assistant response are
+    persisted to the conversations table so the chat panel renders them.
+    A small `thumb` (base64 jpeg, max ~256px on the client side) can be
+    embedded inline in the user message via a `[CODEC_IMG_THUMB:...]`
+    sentinel — loadChat() in codec_dashboard.html parses the sentinel
+    and renders the thumbnail. Storage cost: ~10–20 KB per image message.
+    """
+    body = await request.json()
+    image_b64 = body.get("image", "")
+    prompt = body.get("prompt", "Describe and analyze this image in detail.")
+    session_id = (body.get("session_id") or "").strip()
+    thumb_b64 = body.get("thumb", "")
+    if not image_b64:
+        return JSONResponse({"error": "No image data"}, status_code=400)
+    try:
+        config = {}
+        try:
+            with open(CONFIG_PATH) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning(f"Config read failed; proceeding without overrides: {e}")
+        vision_url = config.get("vision_base_url", "http://localhost:8083/v1")
+        vision_model = config.get("vision_model", "mlx-community/Qwen2.5-VL-7B-Instruct-4bit")
+        payload = {
+            "model": vision_model,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
+                    {"type": "text", "text": prompt}
+                ]
+            }],
+            "max_tokens": 4000,
+            "temperature": 0.7
+        }
+        headers = {"Content-Type": "application/json"}
+        r = rq.post(f"{vision_url}/chat/completions", json=payload, headers=headers, timeout=120)
+        data = r.json()
+        answer = data["choices"][0]["message"]["content"].strip()
+        _audit_write(f"[{datetime.now().isoformat()}] VISION: {prompt[:100]}\n")
+        log_event("chat_vision", "codec-dashboard",
+                  f"Vision analysis: {prompt[:60]}",
+                  extra={"prompt_preview": prompt[:200]})
+
+        # Persist user msg (with thumbnail sentinel) + assistant msg so the
+        # image appears in the chat panel. Defensive: never let a save error
+        # break the vision response — log + return the answer regardless.
+        if session_id:
+            try:
+                now_iso = datetime.now().isoformat()
+                # Cap thumbnail size to ~60KB of base64 (about a 256x256 jpeg
+                # @ q=0.4); silently drop if larger to keep DB rows lean.
+                # Validate the whole string is base64 so any injection attempt
+                # (e.g. ']<script>') falls through to the no-thumb branch.
+                _is_b64 = bool(thumb_b64) and len(thumb_b64) <= 60_000 \
+                    and _re_b64.fullmatch(r'[A-Za-z0-9+/]+={0,2}', thumb_b64) is not None
+                if _is_b64:
+                    user_content = (
+                        (prompt or "Analyze this image")[:2000]
+                        + f"\n[CODEC_IMG_THUMB:data:image/jpeg;base64,{thumb_b64}]"
+                    )
+                else:
+                    user_content = (prompt or "Analyze this image")[:2000]
+                c = get_db()
+                c.execute(
+                    "INSERT INTO conversations (session_id, timestamp, role, content) VALUES (?,?,?,?)",
+                    (session_id, now_iso, "user", user_content),
+                )
+                c.execute(
+                    "INSERT INTO conversations (session_id, timestamp, role, content) VALUES (?,?,?,?)",
+                    (session_id, now_iso, "assistant", answer[:5000]),
+                )
+                c.commit()
+            except Exception as save_err:
+                log.warning(f"[Vision] save to conversations failed: {save_err}")
+
+        return {"response": answer, "model": vision_model}
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/routes/web_search.py
+++ b/routes/web_search.py
@@ -1,0 +1,32 @@
+"""CODEC web_search API route — standalone search for the chat UI.
+
+F6 / SR-55: extracted from codec_dashboard.py. One small endpoint
+proxying to codec_search.search() with a formatted result block.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+@router.post("/api/web_search")
+async def web_search_endpoint(request: Request):
+    """Standalone web search endpoint for the chat UI."""
+    body = await request.json()
+    query = body.get("query", "").strip()
+    if not query:
+        return JSONResponse({"error": "query required"}, status_code=400)
+    try:
+        repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        if repo_dir not in sys.path:
+            sys.path.insert(0, repo_dir)
+        from codec_search import search, format_results
+        results = search(query, max_results=8)
+        return {"results": results, "formatted": format_results(results, max_snippets=8)}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/tests/test_a12_invariant.py
+++ b/tests/test_a12_invariant.py
@@ -30,6 +30,7 @@ _ALLOWLIST = {
     "pilot/pilot_agent.py",      # vendored CODEC Pilot module — uses its own LLM client
     "routes/media.py",           # webcam vision POST (A-11 pending) — D5 extraction
     "routes/upload.py",          # /api/upload_image vision POST (A-11 pending) — E4 extraction
+    "routes/vision.py",          # /api/vision Qwen-VL POST (A-11 pending) — F4 extraction
 }
 
 _INLINE_POST_RE = re.compile(r"\.post\s*\([^)]*chat/completions")

--- a/tests/test_dashboard_llm.py
+++ b/tests/test_dashboard_llm.py
@@ -63,13 +63,15 @@ def test_dashboard_uses_codec_llm_call():
 
 def test_dashboard_only_vision_posts_remain():
     # After PR-3E-chat-stream migrated the chat stream + non-stream fallback,
-    # the ONLY inline /chat/completions occurrences left are the vision sites
-    # (A-11 / codec_vision territory, not A-12). D5/E4 extractions moved
-    # the webcam + upload_image vision POSTs to routes/media.py + routes/
-    # upload.py — pinning the count at 3 here; the route-side sites are
+    # the ONLY inline /chat/completions occurrences left are vision sites
+    # (A-11 / codec_vision territory, not A-12). D5/E4/F4 extractions moved
+    # the webcam + upload_image + /api/vision vision POSTs to
+    # routes/media.py + routes/upload.py + routes/vision.py — pinning the
+    # count at 2 here (only /api/command's classifier sys-prompt body
+    # mentions /chat/completions in a comment); the route-side sites are
     # covered by the A-12 allowlist in test_a12_invariant.
     src = (REPO / "codec_dashboard.py").read_text()
-    assert src.count("/chat/completions") == 3
+    assert src.count("/chat/completions") == 2
 
 
 def test_chat_handler_uses_codec_llm_stream():

--- a/tests/test_route_extractions.py
+++ b/tests/test_route_extractions.py
@@ -104,11 +104,62 @@ class TestC5Observer:
 
 # ── Smoke: codec_dashboard.py is shrinking ────────────────────────────────
 def test_dashboard_loc_below_3700():
-    """B6 + C1..C5 shaved codec_dashboard.py from 3,912 → 3,618 LOC
-    (~300 LOC moved to route groups). Floor: < 3,700.
-
-    Future route extractions (qchat, vibe, schedules, prompts) will
-    keep dropping this number — tighten the floor as those land."""
+    """B6 + C1..F7 shaved codec_dashboard.py from 3,912 → ~2,187 LOC.
+    Floor stays loose here; the tighter floor lives in
+    test_dashboard_loc_below_2300 below."""
     from pathlib import Path
     lines = (Path(__file__).resolve().parent.parent / "codec_dashboard.py").read_text().count("\n")
     assert lines < 3700, f"codec_dashboard.py still has {lines} lines"
+
+
+# ── F-series (SR-51..56): config/history/tts/vision/vibe_exec/web_search/cdp
+class TestFSeriesRouteExtractions:
+    @pytest.mark.parametrize("path", [
+        "/api/config",
+        "/api/history",
+        "/api/conversations",
+        "/api/tts",
+        "/api/response",
+        "/api/vision",
+        "/api/preview",
+        "/preview_frame",
+        "/api/run_code",
+        "/api/web_search",
+        "/api/cdp/status",
+    ])
+    def test_endpoint_registered(self, path):
+        assert path in _registered_paths()
+
+    def test_modules_exist_and_export_router(self):
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent / "routes"
+        for name in ("config", "history", "tts", "vision", "vibe_exec",
+                     "web_search", "cdp"):
+            text = (root / f"{name}.py").read_text()
+            assert "router = APIRouter()" in text, f"{name}.py must export router"
+
+    def test_dashboard_does_not_redefine_endpoints(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "codec_dashboard.py").read_text()
+        # All 11 endpoints below must NOT have an `@app.<method>("<path>")`
+        # decorator inside codec_dashboard.py — they live in routes/*.py only.
+        moved = [
+            '/api/config")', '/api/history")', '/api/conversations")',
+            '/api/tts")', '/api/response")', '/api/vision")',
+            '/api/preview")', '/preview_frame"', '/api/run_code")',
+            '/api/web_search")', '/api/cdp/status")',
+        ]
+        for snippet in moved:
+            for verb in ("@app.get(", "@app.post(", "@app.put(", "@app.delete("):
+                assert (verb + '"' + snippet) not in src, (
+                    f"codec_dashboard.py must not redefine {verb}\"{snippet}; "
+                    "it now lives in routes/*.py"
+                )
+
+
+def test_dashboard_loc_below_2300():
+    """After F-series, codec_dashboard.py should be under 2,300 lines.
+    Tighten when more endpoints move (e.g. chat_completion)."""
+    from pathlib import Path
+    lines = (Path(__file__).resolve().parent.parent / "codec_dashboard.py").read_text().count("\n")
+    assert lines < 2300, f"codec_dashboard.py still has {lines} lines"

--- a/tests/test_tempfile_leaks.py
+++ b/tests/test_tempfile_leaks.py
@@ -116,9 +116,9 @@ def test_speak_unlinks_mp3_after_playback(monkeypatch):
 
 
 def test_run_code_unlinks_rust_out():
-    src = (REPO / "codec_dashboard.py").read_text()
+    # F5 / SR-54: run_code moved from codec_dashboard.py to routes/vibe_exec.py.
+    src = (REPO / "routes" / "vibe_exec.py").read_text()
     body = src[src.index("async def run_code("):]
-    body = body[:body.index("\n@app.", 1)]
     # Slice the cleanup block specifically — `tmp.name + ".out"` also appears in
     # the rust cmd_map, so a whole-body check would false-pass.
     fin = body[body.rindex("finally:"):]


### PR DESCRIPTION
## Summary

6th architecture-refactor wave in the codec_dashboard route-extraction series.
Moves 12 endpoints out of `codec_dashboard.py` into 7 focused `routes/*.py` modules.

### LOC reduction (since main, cumulative)
| Wave | After | Net |
|------|------:|----:|
| Pre-B6 baseline | 3,912 | — |
| B6 (chat helpers + crew split) | 3,706 | -206 |
| C1..C5 (5 route groups + crews) | 3,618 | -88 |
| D1..D5 (qchat/vibe/schedules/prompts/media) | 3,000 | -618 |
| E1/E2/E4 (update/health/upload) | 2,530 | -470 |
| **F1..F7 (this PR)** | **2,187** | **-343** |

That's a 44.1% reduction in `codec_dashboard.py` since the refactor began.

### New modules
| Module | Endpoints | Notes |
|---|---|---|
| `routes/config.py` | `GET/PUT /api/config` | + masking, 22-rule validation matrix |
| `routes/history.py` | `/api/history`, `/api/conversations` | read-only browse |
| `routes/tts.py` | `/api/tts`, `/api/response` | + `_latest_response_for_session` helper (C-2 / PR-4B logic) |
| `routes/vision.py` | `POST /api/vision` | Qwen-VL; A-11/A-12 allowlisted alongside media/upload |
| `routes/vibe_exec.py` | `/api/preview`, `/preview_frame`, `/api/run_code` | H-8 Rust `.out` cleanup preserved |
| `routes/web_search.py` | `POST /api/web_search` | proxies `codec_search.search()` |
| `routes/cdp.py` | `GET /api/cdp/status` | Chrome DevTools probe |

### What's intentionally still in codec_dashboard.py
- `/api/command` (safety-critical: `is_dangerous`, skill-hijack chain, consent gate) → deferred
- `/api/chat` (`chat_completion`, 608 LOC streaming + post-LLM `[SKILL:...]` tag) → next deferred extraction
- Page renderers (`/`, `/chat`, `/vibe`, `/tasks`, `/cortex`, `/audit`) — they're not API endpoints
- `/api/services/status` — reads `_bg_status` / `_bg_tasks` globals owned by the dashboard's startup hook
- Background daemons (`_bg_scheduler`, `_bg_heartbeat`, `_bg_watcher`)

## Test plan
- [x] `python3.13 -m pytest --ignore=tests/test_skills.py -q` → **2,039 passed, 77 skipped** (was 2,025; +14 net new tests)
- [x] All 11 F-series endpoints reachable via `app.routes` (covered by new `TestFSeriesRouteExtractions`)
- [x] `codec_dashboard.py` no longer redefines any of the 11 moved decorators (regression pin)
- [x] LOC floor `< 2,300` tightened
- [x] `test_a12_invariant`: `routes/vision.py` added to the documented A-11-pending allowlist
- [x] `test_dashboard_llm`: count of `/chat/completions` strings in dashboard 3 → 2 (one vision string moved out)
- [x] `test_tempfile_leaks::test_run_code_unlinks_rust_out` now scans `routes/vibe_exec.py` (H-8 invariant preserved)
- [x] `ruff check` on all touched files: 0 issues
- [x] `python3 -c 'import codec_dashboard'`: clean (all 7 routers wired in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)