### PR TITLE
refactor(dashboard): G-series — extract memory_search + pilot_proxy

### DIFF
--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -9,7 +9,7 @@ import secrets
 from datetime import datetime, timedelta
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse as StarletteJSONResponse
@@ -357,6 +357,9 @@ from routes.vision import router as vision_router
 from routes.vibe_exec import router as vibe_exec_router
 from routes.web_search import router as web_search_router
 from routes.cdp import router as cdp_router
+# G-series (SR-57..58): cross-source memory search + Pilot proxy.
+from routes.memory_search import router as memory_search_router
+from routes.pilot_proxy import router as pilot_proxy_router
 # Phase 2 Step 6 — Trigger System PWA endpoints (auth-gated by /api/* middleware).
 try:
     from routes.triggers import router as triggers_router
@@ -391,6 +394,8 @@ app.include_router(vision_router)
 app.include_router(vibe_exec_router)
 app.include_router(web_search_router)
 app.include_router(cdp_router)
+app.include_router(memory_search_router)
+app.include_router(pilot_proxy_router)
 if _has_triggers:
     app.include_router(triggers_router)
 
@@ -736,149 +741,7 @@ async def chat_page():
 
 # ── Cross-source memory search endpoint ──────────────────────────────────────
 
-@app.post("/api/memory/search")
-async def memory_search_endpoint(request: Request):
-    """Search ALL conversation history across voice, chat, vibe, and flash sources.
-
-    JSON body: {"query": "search term", "limit": 20, "sources": ["chat", "voice", "flash", "all"]}
-    Returns list of: {timestamp, source, role, content, session_id}
-    """
-    body = await request.json()
-    query = (body.get("query") or "").strip()
-    if not query or len(query) < 2:
-        return JSONResponse({"error": "query must be at least 2 characters"}, status_code=400)
-
-    limit = min(int(body.get("limit", 20)), 100)
-    sources = body.get("sources", ["all"])
-    if isinstance(sources, str):
-        sources = [sources]
-    search_all = "all" in sources
-    keyword = f"%{query}%"
-    results = []
-
-    # 1. Voice memory (FTS5 via CodecMemory + conversations table in memory.db)
-    if search_all or "voice" in sources:
-        # FTS5 search (ranked by relevance)
-        try:
-            from codec_memory import CodecMemory
-            mem = CodecMemory()
-            fts_results = mem.search(query, limit=limit)
-            for r in fts_results:
-                results.append({
-                    "timestamp": r.get("timestamp", ""),
-                    "source": "voice",
-                    "role": r.get("role", ""),
-                    "content": (r.get("content", "") or "")[:500],
-                    "session_id": r.get("session_id", ""),
-                })
-        except Exception as e:
-            log.warning(f"Memory search (voice FTS): {e}")
-
-        # Also search conversations table (LIKE fallback for non-FTS matches)
-        try:
-            c = get_db()
-            rows = c.execute(
-                "SELECT session_id, timestamp, role, content FROM conversations "
-                "WHERE content LIKE ? COLLATE NOCASE ORDER BY id DESC LIMIT ?",
-                (keyword, limit)
-            ).fetchall()
-            for r in rows:
-                results.append({
-                    "timestamp": r[1] or "",
-                    "source": "voice",
-                    "role": r[2] or "",
-                    "content": (r[3] or "")[:500],
-                    "session_id": r[0] or "",
-                })
-        except Exception as e:
-            log.warning(f"Memory search (conversations table): {e}")
-
-    # 2. Dashboard chat (qchat.db)
-    if search_all or "chat" in sources:
-        try:
-            from routes.qchat import qchat_db; conn = qchat_db()
-            rows = conn.execute(
-                """SELECT m.session_id, m.timestamp, m.role, m.content, s.title
-                   FROM qchat_messages m
-                   LEFT JOIN qchat_sessions s ON m.session_id = s.id
-                   WHERE m.content LIKE ? COLLATE NOCASE
-                   ORDER BY m.id DESC LIMIT ?""",
-                (keyword, limit)
-            ).fetchall()
-            for r in rows:
-                results.append({
-                    "timestamp": r[1] or "",
-                    "source": "chat",
-                    "role": r[2] or "",
-                    "content": (r[3] or "")[:500],
-                    "session_id": r[0] or "",
-                })
-        except Exception as e:
-            log.warning(f"Memory search (qchat): {e}")
-
-    # 3. Vibe IDE (vibe.db)
-    if search_all or "vibe" in sources:
-        try:
-            from routes.vibe import vibe_db; conn = vibe_db()
-            rows = conn.execute(
-                """SELECT m.session_id, m.timestamp, m.role, m.content
-                   FROM vibe_messages m
-                   WHERE m.content LIKE ? COLLATE NOCASE
-                   ORDER BY m.id DESC LIMIT ?""",
-                (keyword, limit)
-            ).fetchall()
-            for r in rows:
-                results.append({
-                    "timestamp": r[1] or "",
-                    "source": "vibe",
-                    "role": r[2] or "",
-                    "content": (r[3] or "")[:500],
-                    "session_id": r[0] or "",
-                })
-        except Exception as e:
-            log.warning(f"Memory search (vibe): {e}")
-
-    # 4. Flash / task sessions (sessions table in memory.db)
-    if search_all or "flash" in sources:
-        try:
-            c = get_db()
-            rows = c.execute(
-                "SELECT id, timestamp, task, app, response FROM sessions "
-                "WHERE task LIKE ? COLLATE NOCASE OR response LIKE ? COLLATE NOCASE "
-                "ORDER BY id DESC LIMIT ?",
-                (keyword, keyword, limit)
-            ).fetchall()
-            for r in rows:
-                # Combine task + response for content
-                task_text = r[2] or ""
-                resp_text = r[4] or ""
-                content = f"[TASK] {task_text}"
-                if resp_text:
-                    content += f"\n[RESPONSE] {resp_text[:300]}"
-                results.append({
-                    "timestamp": r[1] or "",
-                    "source": "flash",
-                    "role": "system",
-                    "content": content[:500],
-                    "session_id": str(r[0]) if r[0] else "",
-                })
-        except Exception as e:
-            log.warning(f"Memory search (sessions/flash): {e}")
-
-    # Deduplicate by content prefix and sort by timestamp descending
-    seen = set()
-    unique = []
-    for r in sorted(results, key=lambda x: x.get("timestamp", ""), reverse=True):
-        key = r["content"][:80]
-        if key not in seen:
-            seen.add(key)
-            unique.append(r)
-    unique = unique[:limit]
-
-    log.info(f"Memory search '{query}': {len(unique)} results from {len(results)} raw hits")
-    return {"query": query, "count": len(unique), "results": unique}
-
-
+# G1 memory_search → moved to routes/*.py
 # E4 upload_image → moved to routes/*.py
 # D2 / SR-43: vibe endpoints + db helper moved to routes/vibe.py.
 # (/vibe page route stays here — it serves the HTML template.)
@@ -1871,35 +1734,7 @@ async def tasks_page():
             return HTMLResponse(f.read(), headers=_NO_CACHE)
     return HTMLResponse("<h1>Tasks page not found</h1>", status_code=500)
 
-@app.api_route("/api/pilot/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
-async def pilot_proxy(path: str, request: Request):
-    """Proxy /api/pilot/* → localhost:8094/* so the HTTPS dashboard can reach the local runner."""
-    import httpx
-    target = f"http://localhost:8094/{path}"
-    params = dict(request.query_params)
-    body = await request.body()
-    headers = {}
-    if request.headers.get("content-type"):
-        headers["content-type"] = request.headers["content-type"]
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            r = await client.request(
-                method=request.method,
-                url=target,
-                params=params,
-                content=body,
-                headers=headers,
-            )
-        return Response(
-            content=r.content,
-            status_code=r.status_code,
-            media_type=r.headers.get("content-type", "application/json"),
-        )
-    except httpx.ConnectError:
-        return JSONResponse({"error": "Pilot Runner offline — pm2 restart pilot-runner"}, status_code=503)
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=502)
-
+# G2 pilot_proxy → moved to routes/*.py
 # C3 / SR-38: cortex endpoints moved to routes/cortex.py.
 
 

--- a/routes/memory_search.py
+++ b/routes/memory_search.py
@@ -1,0 +1,171 @@
+"""CODEC cross-source memory search API.
+
+G1 / SR-57: extracted from codec_dashboard.py.
+
+Searches ALL conversation history across four backends, dedupes by
+content prefix, and returns the most-recent unique hits:
+
+  1. Voice memory  — FTS5 via CodecMemory + LIKE fallback on
+                     `conversations` table in memory.db
+  2. Dashboard chat — qchat_messages (qchat.db, via routes.qchat.qchat_db)
+  3. Vibe IDE      — vibe_messages (vibe.db, via routes.vibe.vibe_db)
+  4. Flash sessions — sessions table (task+response combined)
+
+Body: {"query": "term", "limit": 20, "sources": ["chat", "voice", "flash", "vibe", "all"]}
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from routes._shared import get_db
+
+router = APIRouter()
+log = logging.getLogger("codec_dashboard")
+
+
+@router.post("/api/memory/search")
+async def memory_search_endpoint(request: Request):
+    """Search ALL conversation history across voice, chat, vibe, and flash sources.
+
+    JSON body: {"query": "search term", "limit": 20, "sources": ["chat", "voice", "flash", "all"]}
+    Returns list of: {timestamp, source, role, content, session_id}
+    """
+    body = await request.json()
+    query = (body.get("query") or "").strip()
+    if not query or len(query) < 2:
+        return JSONResponse({"error": "query must be at least 2 characters"}, status_code=400)
+
+    limit = min(int(body.get("limit", 20)), 100)
+    sources = body.get("sources", ["all"])
+    if isinstance(sources, str):
+        sources = [sources]
+    search_all = "all" in sources
+    keyword = f"%{query}%"
+    results = []
+
+    # 1. Voice memory (FTS5 via CodecMemory + conversations table in memory.db)
+    if search_all or "voice" in sources:
+        # FTS5 search (ranked by relevance)
+        try:
+            from codec_memory import CodecMemory
+            mem = CodecMemory()
+            fts_results = mem.search(query, limit=limit)
+            for r in fts_results:
+                results.append({
+                    "timestamp": r.get("timestamp", ""),
+                    "source": "voice",
+                    "role": r.get("role", ""),
+                    "content": (r.get("content", "") or "")[:500],
+                    "session_id": r.get("session_id", ""),
+                })
+        except Exception as e:
+            log.warning(f"Memory search (voice FTS): {e}")
+
+        # Also search conversations table (LIKE fallback for non-FTS matches)
+        try:
+            c = get_db()
+            rows = c.execute(
+                "SELECT session_id, timestamp, role, content FROM conversations "
+                "WHERE content LIKE ? COLLATE NOCASE ORDER BY id DESC LIMIT ?",
+                (keyword, limit)
+            ).fetchall()
+            for r in rows:
+                results.append({
+                    "timestamp": r[1] or "",
+                    "source": "voice",
+                    "role": r[2] or "",
+                    "content": (r[3] or "")[:500],
+                    "session_id": r[0] or "",
+                })
+        except Exception as e:
+            log.warning(f"Memory search (conversations table): {e}")
+
+    # 2. Dashboard chat (qchat.db)
+    if search_all or "chat" in sources:
+        try:
+            from routes.qchat import qchat_db
+            conn = qchat_db()
+            rows = conn.execute(
+                """SELECT m.session_id, m.timestamp, m.role, m.content, s.title
+                   FROM qchat_messages m
+                   LEFT JOIN qchat_sessions s ON m.session_id = s.id
+                   WHERE m.content LIKE ? COLLATE NOCASE
+                   ORDER BY m.id DESC LIMIT ?""",
+                (keyword, limit)
+            ).fetchall()
+            for r in rows:
+                results.append({
+                    "timestamp": r[1] or "",
+                    "source": "chat",
+                    "role": r[2] or "",
+                    "content": (r[3] or "")[:500],
+                    "session_id": r[0] or "",
+                })
+        except Exception as e:
+            log.warning(f"Memory search (qchat): {e}")
+
+    # 3. Vibe IDE (vibe.db)
+    if search_all or "vibe" in sources:
+        try:
+            from routes.vibe import vibe_db
+            conn = vibe_db()
+            rows = conn.execute(
+                """SELECT m.session_id, m.timestamp, m.role, m.content
+                   FROM vibe_messages m
+                   WHERE m.content LIKE ? COLLATE NOCASE
+                   ORDER BY m.id DESC LIMIT ?""",
+                (keyword, limit)
+            ).fetchall()
+            for r in rows:
+                results.append({
+                    "timestamp": r[1] or "",
+                    "source": "vibe",
+                    "role": r[2] or "",
+                    "content": (r[3] or "")[:500],
+                    "session_id": r[0] or "",
+                })
+        except Exception as e:
+            log.warning(f"Memory search (vibe): {e}")
+
+    # 4. Flash / task sessions (sessions table in memory.db)
+    if search_all or "flash" in sources:
+        try:
+            c = get_db()
+            rows = c.execute(
+                "SELECT id, timestamp, task, app, response FROM sessions "
+                "WHERE task LIKE ? COLLATE NOCASE OR response LIKE ? COLLATE NOCASE "
+                "ORDER BY id DESC LIMIT ?",
+                (keyword, keyword, limit)
+            ).fetchall()
+            for r in rows:
+                # Combine task + response for content
+                task_text = r[2] or ""
+                resp_text = r[4] or ""
+                content = f"[TASK] {task_text}"
+                if resp_text:
+                    content += f"\n[RESPONSE] {resp_text[:300]}"
+                results.append({
+                    "timestamp": r[1] or "",
+                    "source": "flash",
+                    "role": "system",
+                    "content": content[:500],
+                    "session_id": str(r[0]) if r[0] else "",
+                })
+        except Exception as e:
+            log.warning(f"Memory search (sessions/flash): {e}")
+
+    # Deduplicate by content prefix and sort by timestamp descending
+    seen = set()
+    unique = []
+    for r in sorted(results, key=lambda x: x.get("timestamp", ""), reverse=True):
+        key = r["content"][:80]
+        if key not in seen:
+            seen.add(key)
+            unique.append(r)
+    unique = unique[:limit]
+
+    log.info(f"Memory search '{query}': {len(unique)} results from {len(results)} raw hits")
+    return {"query": query, "count": len(unique), "results": unique}

--- a/routes/pilot_proxy.py
+++ b/routes/pilot_proxy.py
@@ -1,0 +1,46 @@
+"""CODEC Pilot HTTP proxy.
+
+G2 / SR-58: extracted from codec_dashboard.py.
+
+Forwards every `/api/pilot/<rest>` request (GET/POST/PUT/DELETE) to the
+local Pilot Runner on http://localhost:8094/<rest>. The dashboard runs
+over Cloudflare-tunneled HTTPS — Pilot Runner is HTTP-localhost — so
+the PWA needs this same-origin proxy to reach it without a CORS
+preflight or a mixed-content block.
+"""
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, Response
+
+router = APIRouter()
+
+
+@router.api_route("/api/pilot/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
+async def pilot_proxy(path: str, request: Request):
+    """Proxy /api/pilot/* → localhost:8094/* so the HTTPS dashboard can reach the local runner."""
+    target = f"http://localhost:8094/{path}"
+    params = dict(request.query_params)
+    body = await request.body()
+    headers = {}
+    if request.headers.get("content-type"):
+        headers["content-type"] = request.headers["content-type"]
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            r = await client.request(
+                method=request.method,
+                url=target,
+                params=params,
+                content=body,
+                headers=headers,
+            )
+        return Response(
+            content=r.content,
+            status_code=r.status_code,
+            media_type=r.headers.get("content-type", "application/json"),
+        )
+    except httpx.ConnectError:
+        return JSONResponse({"error": "Pilot Runner offline — pm2 restart pilot-runner"}, status_code=503)
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=502)

--- a/tests/test_route_extractions.py
+++ b/tests/test_route_extractions.py
@@ -158,8 +158,61 @@ class TestFSeriesRouteExtractions:
 
 
 def test_dashboard_loc_below_2300():
-    """After F-series, codec_dashboard.py should be under 2,300 lines.
-    Tighten when more endpoints move (e.g. chat_completion)."""
+    """After F-series, codec_dashboard.py should be under 2,300 lines."""
     from pathlib import Path
     lines = (Path(__file__).resolve().parent.parent / "codec_dashboard.py").read_text().count("\n")
     assert lines < 2300, f"codec_dashboard.py still has {lines} lines"
+
+
+# ── G-series (SR-57..58): memory_search + pilot_proxy ─────────────────────
+class TestGSeriesRouteExtractions:
+    @pytest.mark.parametrize("path", [
+        "/api/memory/search",
+        "/api/pilot/{path:path}",
+    ])
+    def test_endpoint_registered(self, path):
+        assert path in _registered_paths()
+
+    def test_modules_exist_and_export_router(self):
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent / "routes"
+        for name in ("memory_search", "pilot_proxy"):
+            text = (root / f"{name}.py").read_text()
+            assert "router = APIRouter()" in text, f"{name}.py must export router"
+
+    def test_memory_search_covers_all_four_sources(self):
+        """G1: the extracted endpoint must still query voice + chat + vibe + flash."""
+        from pathlib import Path
+        text = (Path(__file__).resolve().parent.parent / "routes" / "memory_search.py").read_text()
+        assert "from codec_memory import CodecMemory" in text          # voice FTS
+        assert "from routes.qchat import qchat_db" in text             # chat
+        assert "from routes.vibe import vibe_db" in text               # vibe
+        assert "FROM sessions" in text                                  # flash
+
+    def test_pilot_proxy_forwards_to_8094(self):
+        """G2: the proxy must still hit localhost:8094 — that's the runner port."""
+        from pathlib import Path
+        text = (Path(__file__).resolve().parent.parent / "routes" / "pilot_proxy.py").read_text()
+        assert "localhost:8094" in text
+        assert "@router.api_route(" in text
+        assert "GET" in text and "POST" in text and "PUT" in text and "DELETE" in text
+
+    def test_dashboard_does_not_redefine_endpoints(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "codec_dashboard.py").read_text()
+        assert '@app.post("/api/memory/search")' not in src
+        assert '@app.api_route("/api/pilot/' not in src
+
+
+def test_dashboard_loc_below_2100():
+    """After G-series, codec_dashboard.py should be under 2,100 lines.
+
+    The big remaining occupants are:
+      - `/api/chat` chat_completion (~608 LOC streaming + post-LLM tag)
+      - `/api/command` (~180 LOC safety-critical)
+      - page renderers + startup/shutdown hooks
+      - background daemons (_bg_scheduler / _bg_heartbeat / _bg_watcher)
+    """
+    from pathlib import Path
+    lines = (Path(__file__).resolve().parent.parent / "codec_dashboard.py").read_text().count("\n")
+    assert lines < 2100, f"codec_dashboard.py still has {lines} lines"


### PR DESCRIPTION
## Summary

7th wave of the codec_dashboard route-extraction series. Smaller surface than F (12 endpoints) — just the two remaining straightforward extractions before the safety-critical paths.

### LOC reduction (cumulative since pre-B6 baseline)
| Wave | After | Net |
|------|------:|----:|
| Pre-B6 baseline | 3,912 | — |
| B6 | 3,706 | -206 |
| C1..C5 + crews | 3,618 | -88 |
| D1..D5 | 3,000 | -618 |
| E1/E2/E4 | 2,530 | -470 |
| F1..F7 (#164) | 2,187 | -343 |
| **G1..G2 (this PR)** | **2,018** | **-169** |

That's 48.4% off the dashboard since the refactor began.

### New modules
| Module | Endpoint | Notes |
|---|---|---|
| `routes/memory_search.py` | `POST /api/memory/search` | 143 LOC, cross-source dedup over voice FTS + qchat + vibe + flash/sessions |
| `routes/pilot_proxy.py` | `GET/POST/PUT/DELETE /api/pilot/{path}` | HTTPS dashboard → localhost:8094 runner proxy |

### What's intentionally still in codec_dashboard.py
- **`/api/command`** (180 LOC, safety-critical: is_dangerous + skill-hijack chain + consent gate)
- **`/api/chat` chat_completion** (608 LOC streaming + post-LLM `[SKILL:...]` tag)
- `/api/services/status` (small, reads dashboard-owned `_bg_status` / `_bg_tasks` globals)
- Page renderers (`/`, `/chat`, `/vibe`, `/tasks`, `/cortex`, `/audit`)
- Background daemons (`_bg_scheduler` / `_bg_heartbeat` / `_bg_watcher`)
- Startup/shutdown hooks

## Test plan
- [x] `python3.13 -m pytest --ignore=tests/test_skills.py -q` → **2,046 passed, 77 skipped** (was 2,039 in F; +7 net new tests)
- [x] Both G-series endpoints reachable via `app.routes` (regression pins)
- [x] Memory-search pin guards against quiet source removal — must still query all 4 backends
- [x] Pilot proxy pin guards against runner port change (8094) + all 4 verbs
- [x] Dashboard MUST NOT redefine either decorator (regression pin)
- [x] LOC floor tightened to `< 2,100`
- [x] `ruff check` on all touched files: 0 issues (dropped unused `Response` import)
- [x] `python3 -c 'import codec_dashboard'`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)