### PR TITLE
security(vibe): K1 — harden /api/run_code (resource limits + secret-stripped env)

### DIFF
--- a/routes/vibe_exec.py
+++ b/routes/vibe_exec.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import tempfile
 import time as _time
 
@@ -23,6 +24,66 @@ from fastapi.responses import HTMLResponse, JSONResponse
 
 router = APIRouter()
 log = logging.getLogger("codec_dashboard")
+
+
+# ── /api/run_code execution hardening (K1) ────────────────────────────────
+# Proportionate sandboxing for the Vibe IDE's "run my code" feature. Unlike
+# the python_exec skill (single-language, utility) this endpoint must run 8
+# languages incl. compilers (go/rust) and bash, so a full codec_sandbox
+# deny-default `sandbox-exec` profile is INTENTIONALLY NOT applied — its
+# no-process-spawn + no-network rules break compilation and the IDE's
+# legitimate use (a user testing an API call wants network). Instead we apply
+# the two hardenings that are safe across every language:
+#   1. resource limits (CPU / address space / FDs / output-file size) so a
+#      runaway loop, memory bomb, FD leak, or disk-filling write is bounded;
+#   2. a secret-stripped env so executed code can't read the operator's API
+#      keys / tokens out of the inherited environment (PATH/HOME/tool config
+#      are preserved so every interpreter + compiler still resolves).
+# The existing is_dangerous() gate, dashboard auth, and 30s wall timeout
+# remain the other layers.
+_RUNCODE_RLIMIT_CPU_SECONDS = 25            # CPU time (< 30s wall) — kills infinite loops
+_RUNCODE_RLIMIT_AS_BYTES = 2 * 1024 ** 3    # 2 GB address space — stops bombs, allows rustc/go
+_RUNCODE_RLIMIT_NOFILE = 256                # compilers open many files
+_RUNCODE_RLIMIT_FSIZE_BYTES = 64 * 1024 ** 2  # 64 MB max single output file — stops disk-fill
+
+# Env var NAMES that look secret-bearing get dropped before the child runs.
+_SENSITIVE_ENV_RE = re.compile(
+    r"(?i)(secret|password|passwd|token|credential|api[_-]?key|access[_-]?key|"
+    r"private[_-]?key|bearer|session[_-]?token|auth[_-]?token|_key$|^key$)"
+)
+# Matches the pattern but is functionally needed → keep.
+_ENV_KEEP = {"SSH_AUTH_SOCK"}
+
+
+def _preexec_set_rlimits():  # pragma: no cover - runs in forked child, before exec
+    """Cap CPU / memory / FDs / output-file size in the child after fork.
+
+    Each limit is best-effort (RLIMIT_AS is not enforced on all macOS
+    versions) — wrapped so a soft failure never blocks the run. Limits are
+    inherited across the bash→rustc→binary chain for the rust path, so the
+    whole process tree is bounded."""
+    import resource
+    for _res, _val in (
+        (resource.RLIMIT_CPU, _RUNCODE_RLIMIT_CPU_SECONDS),
+        (resource.RLIMIT_AS, _RUNCODE_RLIMIT_AS_BYTES),
+        (resource.RLIMIT_NOFILE, _RUNCODE_RLIMIT_NOFILE),
+        (resource.RLIMIT_FSIZE, _RUNCODE_RLIMIT_FSIZE_BYTES),
+    ):
+        try:
+            resource.setrlimit(_res, (_val, _val))
+        except (ValueError, OSError):
+            pass
+
+
+def _hardened_run_env() -> dict:
+    """Inherited environment minus secret-bearing vars. PATH / HOME / locale /
+    tool config (GOPATH, GOCACHE, npm_config_*, …) are preserved so every
+    interpreter + compiler still resolves — only API keys / tokens / secrets
+    are dropped so executed code can't exfiltrate them via os.environ."""
+    env = {k: v for k, v in os.environ.items()
+           if k in _ENV_KEEP or not _SENSITIVE_ENV_RE.search(k)}
+    env.setdefault("LC_ALL", "C.UTF-8")
+    return env
 
 
 @router.post("/api/preview")
@@ -82,7 +143,17 @@ async def run_code(request: Request):
         cmd = ["bash", "-c", f"rustc {tmp.name} -o {tmp.name}.out 2>&1 && {tmp.name}.out"]
     start = _time.time()
     try:
-        proc = await asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=os.path.expanduser("~"))
+        # K1: env-stripped + resource-limited child (see module header). The
+        # rlimits bound runaway compute / memory / FDs / output size; the env
+        # withholds operator secrets. cwd stays $HOME so tool config resolves.
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=os.path.expanduser("~"),
+            env=_hardened_run_env(),
+            preexec_fn=_preexec_set_rlimits,
+        )
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
         return {"stdout": stdout.decode(errors="replace")[:10000], "stderr": stderr.decode(errors="replace")[:5000], "exit_code": proc.returncode, "elapsed": round(_time.time() - start, 1)}
     except asyncio.TimeoutError:

--- a/tests/test_run_code_hardening.py
+++ b/tests/test_run_code_hardening.py
@@ -1,0 +1,108 @@
+"""K1 — regression tests for /api/run_code execution hardening.
+
+The Vibe IDE's run_code endpoint runs 8 languages incl. compilers + bash, so a
+full sandbox-exec deny-default profile can't be applied without breaking the
+feature. Instead it gets two language-agnostic hardenings, pinned here:
+
+  1. resource limits (CPU / address-space / FDs / output-file size) applied in
+     the child via preexec_fn — bounds runaway compute / memory / disk;
+  2. a secret-stripped-but-functional env — drops API keys / tokens / secrets
+     while preserving PATH / HOME / tool config so every interpreter still runs.
+
+The python path is exercised end-to-end (proving the child actually receives
+the limits + stripped env); the compiler/bash paths are validated structurally.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+class _FakeReq:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def _run(payload):
+    import routes.vibe_exec as ve
+    return asyncio.run(ve.run_code(_FakeReq(payload)))
+
+
+# ── env stripping ──────────────────────────────────────────────────────────
+class TestHardenedEnv:
+    def test_secrets_dropped(self, monkeypatch):
+        import routes.vibe_exec as ve
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-leak")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-leak")
+        monkeypatch.setenv("MY_SECRET", "s")
+        monkeypatch.setenv("SOME_TOKEN", "t")
+        monkeypatch.setenv("DB_PASSWORD", "p")
+        monkeypatch.setenv("AWS_ACCESS_KEY", "a")
+        env = ve._hardened_run_env()
+        for leaked in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "MY_SECRET",
+                       "SOME_TOKEN", "DB_PASSWORD", "AWS_ACCESS_KEY"):
+            assert leaked not in env, f"{leaked} leaked into run_code env"
+
+    def test_functional_vars_preserved(self):
+        import routes.vibe_exec as ve
+        env = ve._hardened_run_env()
+        assert env.get("PATH"), "PATH must be preserved so interpreters resolve"
+        assert "HOME" in env, "HOME must be preserved for tool config"
+
+    def test_ssh_auth_sock_kept(self, monkeypatch):
+        # matches the 'auth' pattern but is in the keep-list
+        import routes.vibe_exec as ve
+        monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/ssh.sock")
+        assert ve._hardened_run_env().get("SSH_AUTH_SOCK") == "/tmp/ssh.sock"
+
+    def test_secrets_not_in_child_environ(self, monkeypatch):
+        """End-to-end: code run via /api/run_code must NOT see a secret env var."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-MUSTNOTLEAK")
+        out = _run({"code": "import os; print(os.environ.get('ANTHROPIC_API_KEY','<absent>'))",
+                    "language": "python"})
+        assert out["stdout"].strip() == "<absent>", "secret leaked into child process"
+
+
+# ── resource limits ─────────────────────────────────────────────────────────
+class TestResourceLimits:
+    def test_cpu_and_fsize_enforced_in_child(self):
+        out = _run({
+            "code": "import resource as r; "
+                    "print(r.getrlimit(r.RLIMIT_CPU)[0], r.getrlimit(r.RLIMIT_FSIZE)[0])",
+            "language": "python",
+        })
+        cpu, fsize = out["stdout"].split()
+        assert int(cpu) == 25, f"RLIMIT_CPU not applied (got {cpu})"
+        assert int(fsize) == 64 * 1024 * 1024, f"RLIMIT_FSIZE not applied (got {fsize})"
+
+    def test_nofile_enforced_in_child(self):
+        out = _run({
+            "code": "import resource as r; print(r.getrlimit(r.RLIMIT_NOFILE)[0])",
+            "language": "python",
+        })
+        assert int(out["stdout"].strip()) == 256
+
+    def test_preexec_and_env_wired_into_subprocess(self):
+        src = (_REPO / "routes" / "vibe_exec.py").read_text()
+        assert "preexec_fn=_preexec_set_rlimits" in src
+        assert "env=_hardened_run_env()" in src
+
+
+# ── the feature still works ─────────────────────────────────────────────────
+def test_python_still_runs():
+    out = _run({"code": "print(6 * 7)", "language": "python"})
+    assert out["stdout"].strip() == "42"
+    assert out["exit_code"] == 0
+
+
+def test_bash_still_runs():
+    out = _run({"code": "echo hardened", "language": "bash"})
+    assert "hardened" in out["stdout"]


### PR DESCRIPTION
## Summary

Closes the `/api/run_code` sandbox gap the post-refactor review flagged. The Vibe IDE's code-execution endpoint ran arbitrary `bash`/`node`/`go`/`rustc`/`python`/`swift`/`ruby` with only the `is_dangerous()` heuristic + dashboard auth — **no resource caps, full inherited env** (so executed code could read the operator's `ANTHROPIC_API_KEY` etc. straight out of `os.environ`).

Two **language-agnostic** hardenings, applied to every run:

### 1. Resource limits (via `preexec_fn`, verified enforced in-child)
| Limit | Value | Stops |
|---|---|---|
| `RLIMIT_CPU` | 25s | infinite loops (< the 30s wall timeout) |
| `RLIMIT_AS` | 2 GB | memory bombs (still allows rustc/go compiles) |
| `RLIMIT_NOFILE` | 256 | FD leaks |
| `RLIMIT_FSIZE` | 64 MB | a single output file filling the disk |

Limits inherit across the `bash→rustc→binary` chain (rust path), so the whole process tree is bounded.

### 2. Secret-stripped env
The child gets the inherited environment **minus** any var whose name looks secret-bearing (`api_key` / `token` / `secret` / `password` / `credential` / `access_key` / `*_key` / …). `PATH` / `HOME` / locale / tool config (`GOPATH`, `npm_config_*`, …) are **preserved** so every interpreter + compiler still resolves. Verified end-to-end: code run through the endpoint sees `ANTHROPIC_API_KEY` as `<absent>`.

### Why not a full `sandbox-exec` profile?
`python_exec` uses `codec_sandbox`'s deny-default profile (no network, no process spawn). That **can't** be applied here without breaking the feature: `go`/`rust` compilation spawns processes, `bash` spawns processes, and the IDE legitimately needs network (a user testing an API call). So the proportionate hardening is rlimits + env-strip; the rationale is documented in the module header so nobody "fixes" it by breaking the feature. `is_dangerous()` + dashboard auth + the 30s wall timeout remain the other layers.

## Test plan
- [x] `tests/test_run_code_hardening.py` — 9 tests: env-strip drops 6 secret patterns + keeps `PATH`/`HOME`/`SSH_AUTH_SOCK`; **child can't read a secret** (end-to-end); `RLIMIT_CPU`/`FSIZE`/`NOFILE` enforced in-child; preexec/env wired into the spawn; python + bash still run
- [x] `python3.13 -m pytest --ignore=tests/test_skills.py -q` → **2,064 passed, 77 skipped**
- [x] `ruff check`: 0 issues
- [x] Confirmed in-child: `RLIMIT_CPU=25`, `RLIMIT_FSIZE=67108864`; `print(6*7)` → `42`

> Branches off `main`; touches only the subprocess-call region of `routes/vibe_exec.py` — no overlap with #168's validation-region edits to the same function, so merges cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)