### PR TITLE
fix(philips_hue): stop wake word "codec" hijacking light commands

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -61,7 +61,7 @@
     "notes.py": "7d50d1544ea955f59917a1f0e7902d115e9dbccd3188b641057a55b6a5b2803a",
     "notification_reader.py": "681208ae4253dfe549512cce4c722c76ca85f2bbbdb8737e37c026ec9444c972",
     "password_generator.py": "f11a917299e14cbd2560111da0bb748cd08792cf715cc4098c64eb62da8c54e3",
-    "philips_hue.py": "bcc2ef1b7e6c0e5e5f0165aae397fd6a3fd27367a3f100b949cd0efddac43496",
+    "philips_hue.py": "82a890b2a63c7a7076132ec3bfe07213787f71a95b84c6ee67228e33c5bc45b0",
     "pilot.py": "ded952504f8d44c3c6ea5b1da1ef2f09f0bbf1b771e2ad9dd90db6cd1701c3fb",
     "plugin_approve.py": "c93861353be2a9ebe08df212ca167bea646962dbeafe704b1864cd78a8cf57cc",
     "pm2_control.py": "53d34a9ddb7689b86f192694d6ccc18b154538626cbc72992445d0b74f2e5662",

--- a/skills/philips_hue.py
+++ b/skills/philips_hue.py
@@ -210,7 +210,16 @@ def _parse_action(task_lower):
     """
     # --- Scenes ---
     for scene_name, scene_state in SCENE_PRESETS.items():
-        if scene_name in task_lower:
+        # The "codec" scene name collides with the assistant's own wake word,
+        # which leaks into commands on the F18 / text / chat paths (only the
+        # hands-free wake listener strips it — see codec.py:778). Require an
+        # explicit "codec mode" / "codec scene" qualifier so a bare "codec"
+        # can never hijack an on/off/brightness command.
+        if scene_name == "codec":
+            matched = "codec scene" in task_lower or "codec mode" in task_lower
+        else:
+            matched = scene_name in task_lower
+        if matched:
             # Regenerate random hue for party each time
             if scene_name == "party":
                 scene_state = dict(scene_state)

--- a/tests/test_philips_hue.py
+++ b/tests/test_philips_hue.py
@@ -1,0 +1,50 @@
+"""Tests for the philips_hue skill command parser.
+
+Regression (2026-06-08): the wake word "codec" leaks into commands on the
+F18 / text / chat paths (only the hands-free wake-word listener strips it,
+codec.py:778). The scene parser matched scene names by bare substring, and
+one scene is literally named "codec" — the assistant's own name. So
+"hey codec lights off" matched the codec scene and turned the lights ON
+(orange) instead of OFF.
+
+Fix: the `codec` scene must require an explicit "codec mode" / "codec scene"
+qualifier so the bare wake word can never hijack an on/off/brightness command.
+Other scenes are intentionally left untouched (surgical fix).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills"))
+
+import philips_hue  # noqa: E402
+
+
+def test_wake_word_codec_does_not_hijack_off():
+    # "hey codec lights off" must turn OFF, not fire the codec scene.
+    state, desc = philips_hue._parse_action("hey codec lights off")
+    assert state == {"on": False}, f"wake word leaked into scene match: {desc}"
+    assert desc == "off"
+
+
+def test_wake_word_codec_does_not_hijack_on():
+    state, desc = philips_hue._parse_action("codec lights on")
+    assert state == {"on": True}, f"got {desc}"
+    assert desc == "on"
+
+
+def test_codec_scene_still_reachable_with_qualifier():
+    # The intentional codec scene stays reachable via "codec mode"/"codec scene".
+    assert philips_hue._parse_action("set codec mode")[1] == "codec scene"
+    assert philips_hue._parse_action("codec scene please")[1] == "codec scene"
+
+
+def test_other_scenes_unchanged():
+    # Surgical fix: only the codec scene is special-cased.
+    assert philips_hue._parse_action("relax mode")[1] == "relax scene"
+    assert philips_hue._parse_action("movie")[1] == "movie scene"
+
+
+def test_plain_commands_unaffected():
+    assert philips_hue._parse_action("lights off")[0] == {"on": False}
+    assert philips_hue._parse_action("lights on")[0] == {"on": True}
+    assert philips_hue._parse_action("lights 50%")[0]["bri"] == 127


### PR DESCRIPTION
## Problem
`"hey codec lights off"` (any command carrying the wake word **codec** on the F18 / text / chat paths) matched the scene literally named `codec` in `skills/philips_hue.py` — so the lights turned **on (orange)** instead of **off**. Only the hands-free wake listener strips `codec` (`codec.py:778`); F18/text/chat don't, so the assistant's own name leaked into the skill and hijacked on/off/brightness.

## Fix
The `codec` scene now requires an explicit **`codec mode` / `codec scene`** qualifier (matching the existing `SKILL_TRIGGERS` vocabulary). All other scenes untouched — surgical.

## Tests
- `tests/test_philips_hue.py` — 5 cases incl. the regression (`"hey codec lights off" → off`), the qualifier still reaching the codec scene, and other scenes / plain commands unaffected. **5/5 pass.**
- `skills/.manifest.json` regenerated (philips_hue.py is hash-pinned; `--check` clean, 84 skills).
- Verified live on the bridge: `run("hey codec lights off")` → lights off; `run("codec mode")` → codec scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)