### PR TITLE
fix(logs): keychain miss negative-cache + emit-once, log level split

### DIFF
--- a/codec_keychain.py
+++ b/codec_keychain.py
@@ -35,7 +35,8 @@ skips. CODEC's threat model assumes Keychain on the production Mac.
 ## Audit events
 
   keychain_set            on every set, ok/error
-  keychain_get_missing    on read-miss (info, no secret in extras)
+  keychain_get_missing    on FIRST read-miss per process per key (info);
+                          repeat misses are negative-cached + stdlib DEBUG
   keychain_locked         on exit 51 from /usr/bin/security (warning)
   keychain_migration      on first migration from plaintext
 """
@@ -66,6 +67,32 @@ _SECURITY_BIN = "/usr/bin/security"
 _FALLBACK_KEY_PATH = Path(os.path.expanduser("~/.codec/secret.key"))
 _FALLBACK_STORE_PATH = Path(os.path.expanduser("~/.codec/secrets.enc.json"))
 _SECURITY_TIMEOUT = 5  # seconds
+
+# Negative-result cache (2026-07 log review). Known-missing keys are cached
+# for _NEGATIVE_TTL so hot callers (codec_config's 30s getter cache × N
+# daemons) don't shell out to /usr/bin/security — and don't emit an audit
+# line — on every poll. `keychain_get_missing` was 68% of the audit log
+# (23k lines / 3 weeks) for the intentionally-absent `dashboard_token`.
+# keychain_set / keychain_delete invalidate, so a freshly-stored secret is
+# visible immediately within this process; a secret added by ANOTHER
+# process (e.g. the operator via `security add-generic-password`) is picked
+# up after at most _NEGATIVE_TTL seconds.
+_NEGATIVE_CACHE: dict = {}   # key -> time.monotonic() of last confirmed miss
+_NEGATIVE_TTL = 300.0        # seconds
+_MISS_AUDITED: set = set()   # keys whose miss was already audited this process
+
+_kc_std_log = logging.getLogger("codec.keychain")
+
+
+def _invalidate_negative_cache(key: Optional[str] = None) -> None:
+    """Drop negative-cache state (all keys, or one). set/delete call this;
+    tests use it for isolation."""
+    if key is None:
+        _NEGATIVE_CACHE.clear()
+        _MISS_AUDITED.clear()
+    else:
+        _NEGATIVE_CACHE.pop(key, None)
+        _MISS_AUDITED.discard(key)
 
 # Public key names (canonical). Keep this list in sync with documentation.
 KEY_DASHBOARD_TOKEN = "dashboard_token"
@@ -265,6 +292,8 @@ def keychain_set(key: str, value: str) -> bool:
     """Store a secret. Returns True on success. Uses real Keychain on
     macOS, envelope-encrypted fallback elsewhere."""
     ok = _keychain_set(key, value) if is_keychain_available() else _fallback_set(key, value)
+    if ok:
+        _invalidate_negative_cache(key)
     _kc_log_event(
         "keychain_set", source="codec-keychain",
         message=f"Stored secret {key!r}" if ok else f"Failed to store secret {key!r}",
@@ -279,21 +308,38 @@ def keychain_set(key: str, value: str) -> bool:
 
 
 def keychain_get(key: str) -> Optional[str]:
-    """Read a secret. None if missing, locked, or unavailable."""
+    """Read a secret. None if missing, locked, or unavailable.
+
+    Misses are negative-cached for _NEGATIVE_TTL seconds (no re-probe, no
+    re-emit) and audited as `keychain_get_missing` ONCE per process per
+    key; later misses log at stdlib DEBUG only. See the cache block near
+    the top of the module for the rationale + staleness bound."""
+    import time as _time
+    miss_ts = _NEGATIVE_CACHE.get(key)
+    if miss_ts is not None and (_time.monotonic() - miss_ts) < _NEGATIVE_TTL:
+        return None
     val = _keychain_get(key) if is_keychain_available() else _fallback_get(key)
     if val is None:
-        _kc_log_event(
-            "keychain_get_missing", source="codec-keychain",
-            message=f"Secret {key!r} not found",
-            level="info", outcome="ok",
-            extra={"key": key,
-                   "method": "keychain" if is_keychain_available() else "fallback"},
-        )
+        _NEGATIVE_CACHE[key] = _time.monotonic()
+        if key not in _MISS_AUDITED:
+            _MISS_AUDITED.add(key)
+            _kc_log_event(
+                "keychain_get_missing", source="codec-keychain",
+                message=f"Secret {key!r} not found",
+                level="info", outcome="ok",
+                extra={"key": key,
+                       "method": "keychain" if is_keychain_available() else "fallback"},
+            )
+        else:
+            _kc_std_log.debug("Secret %r still missing (already audited)", key)
+    else:
+        _NEGATIVE_CACHE.pop(key, None)
     return val
 
 
 def keychain_delete(key: str) -> bool:
     """Delete a secret. Idempotent (returns True if not present)."""
+    _invalidate_negative_cache(key)
     return _keychain_delete(key) if is_keychain_available() else _fallback_delete(key)
 
 

--- a/codec_logging.py
+++ b/codec_logging.py
@@ -1,6 +1,7 @@
 """CODEC structured logging — JSON format for log aggregation."""
 import logging
 import json
+import sys
 import time
 import os
 
@@ -23,18 +24,33 @@ def setup_logging(level=logging.INFO, json_output=True):
     """Configure root logger with JSON or plain formatting.
 
     Call once at process startup. Set CODEC_LOG_JSON=0 for plain format.
+
+    Level-split handlers (2026-07 log review): DEBUG/INFO → stdout,
+    WARNING+ → stderr. PM2 maps stderr to `<name>-error.log`, so with a
+    single stderr StreamHandler the error logs were ~95% INFO chatter —
+    real errors were invisible. After the split, `*-error.log` only
+    contains WARNING and above.
     """
     root = logging.getLogger()
     if root.handlers:
         return  # already configured
 
-    handler = logging.StreamHandler()
     if json_output and os.environ.get("CODEC_LOG_JSON", "1") != "0":
-        handler.setFormatter(JSONFormatter())
+        formatter = JSONFormatter()
     else:
-        handler.setFormatter(logging.Formatter(
+        formatter = logging.Formatter(
             "%(asctime)s [%(name)s] %(levelname)s: %(message)s",
             datefmt="%H:%M:%S"
-        ))
-    root.addHandler(handler)
+        )
+
+    out_handler = logging.StreamHandler(sys.stdout)
+    out_handler.setFormatter(formatter)
+    out_handler.addFilter(lambda record: record.levelno < logging.WARNING)
+
+    err_handler = logging.StreamHandler(sys.stderr)
+    err_handler.setFormatter(formatter)
+    err_handler.setLevel(logging.WARNING)
+
+    root.addHandler(out_handler)
+    root.addHandler(err_handler)
     root.setLevel(level)

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -41,6 +41,9 @@ def _isolate_keychain(tmp_path, monkeypatch):
     test_id = f"_test_{os.getpid()}_{tmp_path.name}"
     monkeypatch.setattr(kc, "_SERVICE_PREFIX",
                          f"ai.avadigital.codec.{test_id}")
+    # Negative-cache state is keyed by bare key name (not service prefix) —
+    # clear it so a miss cached in a previous test can't leak into this one.
+    kc._invalidate_negative_cache()
     yield kc
     # Teardown: clear any real-Keychain entries we created (best-effort).
     if kc.is_keychain_available():
@@ -366,3 +369,66 @@ def test_secret_cache_invalidate(force_fallback, monkeypatch):
     # After invalidate: fresh
     cc._invalidate_secret_cache("llm_api_key")
     assert cc.get_llm_api_key() == "v2"
+
+
+# ── Negative-result cache + emit-once (2026-07 log review) ───────────────────
+
+
+def test_negative_cache_skips_reprobe(force_fallback, monkeypatch):
+    """A confirmed miss must not re-probe the backend within the TTL."""
+    kc = force_fallback
+    kc._invalidate_negative_cache()
+    calls = {"n": 0}
+    original = kc._fallback_get
+
+    def counting_get(key):
+        calls["n"] += 1
+        return original(key)
+
+    monkeypatch.setattr(kc, "_fallback_get", counting_get)
+    assert kc.keychain_get("neg_cache_key") is None
+    assert kc.keychain_get("neg_cache_key") is None
+    assert kc.keychain_get("neg_cache_key") is None
+    assert calls["n"] == 1, f"Expected 1 backend probe, got {calls['n']}"
+
+
+def test_negative_cache_invalidated_by_set(force_fallback):
+    """keychain_set must make the value visible immediately, even after a
+    cached miss."""
+    kc = force_fallback
+    kc._invalidate_negative_cache()
+    assert kc.keychain_get("neg_set_key") is None       # miss → cached
+    assert kc.keychain_set("neg_set_key", "now_present")
+    assert kc.keychain_get("neg_set_key") == "now_present"
+
+
+def test_negative_cache_expires_by_ttl(force_fallback, monkeypatch):
+    """After the TTL the backend is re-probed (external writers get seen)."""
+    kc = force_fallback
+    kc._invalidate_negative_cache()
+    assert kc.keychain_get("neg_ttl_key") is None
+    # Backdate the cached miss beyond the TTL
+    import time as _t
+    kc._NEGATIVE_CACHE["neg_ttl_key"] = _t.monotonic() - kc._NEGATIVE_TTL - 1
+    # Write via the raw backend (simulating another process — no invalidate)
+    kc._fallback_set("neg_ttl_key", "external_write")
+    assert kc.keychain_get("neg_ttl_key") == "external_write"
+
+
+def test_keychain_get_missing_audited_once_per_process(force_fallback, monkeypatch):
+    """The keychain_get_missing audit event fires on the FIRST miss only;
+    later misses (even after the negative cache is cleared) stay silent."""
+    kc = force_fallback
+    kc._invalidate_negative_cache()
+    events = []
+
+    def capture_event(event, *a, **kw):
+        events.append(event)
+
+    monkeypatch.setattr(kc, "_kc_log_event", capture_event)
+    assert kc.keychain_get("audit_once_key") is None
+    # Expire the negative cache but keep the audited-set intact — the
+    # re-probe must NOT re-emit.
+    kc._NEGATIVE_CACHE.clear()
+    assert kc.keychain_get("audit_once_key") is None
+    assert events.count("keychain_get_missing") == 1, events

--- a/tests/test_logging_split.py
+++ b/tests/test_logging_split.py
@@ -1,0 +1,52 @@
+"""codec_logging level-split (2026-07 log review): DEBUG/INFO → stdout,
+WARNING+ → stderr, so PM2 `<name>-error.log` only carries real problems."""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import codec_logging
+
+
+def _fresh_root():
+    root = logging.getLogger()
+    saved = (root.handlers[:], root.level)
+    root.handlers = []
+    return root, saved
+
+
+def _restore_root(root, saved):
+    root.handlers, level = saved[0], saved[1]
+    root.setLevel(level)
+
+
+def test_setup_logging_splits_streams():
+    root, saved = _fresh_root()
+    try:
+        codec_logging.setup_logging()
+        assert len(root.handlers) == 2
+        out = [h for h in root.handlers if getattr(h, "stream", None) is sys.stdout]
+        err = [h for h in root.handlers if getattr(h, "stream", None) is sys.stderr]
+        assert len(out) == 1 and len(err) == 1
+        # stderr handler ignores INFO
+        assert err[0].level == logging.WARNING
+        # stdout handler filters out WARNING+ (no double emission)
+        info_rec = logging.LogRecord("t", logging.INFO, __file__, 1, "m", (), None)
+        warn_rec = logging.LogRecord("t", logging.WARNING, __file__, 1, "m", (), None)
+        assert out[0].filter(info_rec)
+        assert not out[0].filter(warn_rec)
+    finally:
+        _restore_root(root, saved)
+
+
+def test_setup_logging_idempotent():
+    root, saved = _fresh_root()
+    try:
+        codec_logging.setup_logging()
+        codec_logging.setup_logging()
+        assert len(root.handlers) == 2, "second call must not add handlers"
+    finally:
+        _restore_root(root, saved)


### PR DESCRIPTION
## What

Two fixes from the 2026-07-02 21-day log review:

**1. `keychain_get_missing` audit spam (68% of the audit log).**
`dashboard_token` legitimately lives nowhere (auth is Touch ID/PIN), but every daemon re-probed Keychain on each 30s cache expiry and emitted a fresh audit line — 23,457 lines in 21 days. `keychain_get` now:
- negative-caches confirmed misses for 300s (no `security` shellout, no emit)
- audits the miss **once per process per key**; repeat misses → stdlib DEBUG
- `keychain_set`/`keychain_delete` invalidate the cache, so same-process writes are immediately visible; secrets added by another process are seen within 300s

**2. PM2 error logs were 95% INFO noise.**
`setup_logging` used a single stderr handler, and PM2 maps stderr → `<name>-error.log`. Handlers are now level-split: DEBUG/INFO → stdout, WARNING+ → stderr. Error logs become a real alarm channel.

## Tests
- 4 new keychain tests (negative cache skip/invalidate/TTL-expiry, emit-once)
- new `tests/test_logging_split.py` (stream split + idempotency)
- full keychain + audit + config-wiring set: **117 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)