### PR TITLE
feat(watchdog): restart-storm alerts, extra-service probes, probe dedupe, observer timings, wider backups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,12 +490,19 @@ Four new event names exported from `codec_audit.py` for the Continuous Observati
 
 | Event | Source | level | extra fields |
 |---|---|---|---|
-| `observation_tick` | `codec-observer` | info | METADATA-ONLY: `active_app`, `active_title_len`, `ocr_chars`, `ocr_skipped`, `clipboard_changed`, `clipboard_kind`, `recent_files_count`, `idle_seconds`, `cadence_used_s`, `buffer_depth`, `poll_duration_ms` |
+| `observation_tick` | `codec-observer` | info | METADATA-ONLY: `active_app`, `active_title_len`, `ocr_chars`, `ocr_skipped`, `clipboard_changed`, `clipboard_kind`, `recent_files_count`, `idle_seconds`, `cadence_used_s`, `buffer_depth`, `poll_duration_ms`, `collector_ms` (2026-07: per-collector durations `{idle, window, clipboard, ocr, files}` — attributes slow polls to a specific collector; durations only, still metadata) |
 | `observation_tick_slow` | `codec-observer` | warning | Same as `observation_tick` — emitted instead when `poll_duration_ms > poll_slow_threshold_ms` (default 150ms). Q5.5 flag for visibility, no behavior change. |
 | `observation_summary_injected` | `codec-observer` | info | `tokens_used`, `injection_reason` (`always_local`\|`possessive_match`\|`continuation_match`\|`skill_flag`), `buffer_entries_summarized`. `transport` is top-level (reserved). |
 | `observer_buffer_inspected` | `codec-dashboard` | info | `client_ip`, `buffer_entries_returned`. Q5.6 PWA `?debug=1` audit. |
 
 `PHASE2_STEP5_EVENTS` frozenset exposed for analyzer breakdown. `observation_tick` is METADATA-ONLY by design — no titles, no OCR text, no clipboard content, no file paths leak to `~/.codec/audit.log`.
+
+### Watchdog events (2026-07 log review)
+One event name, emitted by the heartbeat's PM2 restart-storm detector (`codec_heartbeat.check_pm2_restart_storms`). Fires when an `autorestart:true` PM2 process burned ≥5 restarts since the previous heartbeat (~20 min) — the signature of a crash loop hiding behind PM2 status "online" (incident: `ava-litellm` restarted 34,207× over 3 weeks unnoticed). Cron-style jobs (`autorestart:false`) are excluded; a persisting storm re-alerts at most every 6h. State: `~/.codec/pm2_restart_state.json`. Related (no new event): `codec_alerts` supports read-only `alerts.extra_services` probes in `~/.codec/config.json` (`http(s)://` or `tcp://host:port`) with the same consecutive-failure alerting as built-ins but NEVER auto-restart.
+
+| Event | Source | level | extra fields |
+|---|---|---|---|
+| `pm2_restart_storm` | `codec-heartbeat` | warning | `process`, `delta` (restarts since last heartbeat), `total_restarts` |
 
 ### Phase 2 Step 6 audit events (Trigger System)
 Four event names. `trigger_evaluated` fires only when a pattern matches (pre-cooldown, pre-consent — silent on no-match to avoid audit spam). `trigger_fired` is the actual dispatch. `trigger_blocked` fires for any non-firing reason except `killed` (silent). `trigger_muted` fires when an otherwise-eligible match is suppressed by the runtime mute config (`~/.codec/triggers.json` — see `docs/PHASE2-STEP6-TRIGGER-MUTE.md`). All inherit the wrapping observer poll's `correlation_id`.

--- a/codec_alerts.py
+++ b/codec_alerts.py
@@ -5,13 +5,25 @@ Configure in ~/.codec/config.json:
     "telegram": {"enabled": true, "bot_token": "...", "chat_id": "..."},
     "email": {"enabled": false, "smtp_host": "smtp.gmail.com", "smtp_port": 587,
               "from": "codec@you.com", "to": "you@you.com", "password": "app-password"},
-    "slack": {"enabled": false, "webhook_url": "https://hooks.slack.com/..."}
+    "slack": {"enabled": false, "webhook_url": "https://hooks.slack.com/..."},
+    "extra_services": {
+      "AVA Gateway": "http://127.0.0.1:4000/health/liveliness",
+      "Postgres": "tcp://127.0.0.1:5433"
+    }
   }
+
+`extra_services` (2026-07 log review) extends the built-in CODEC probe set
+with user infrastructure. Values are `http(s)://` URLs (any HTTP response
+counts as up) or `tcp://host:port` (a successful connect counts as up).
+Extra services get the same consecutive-failure alerting + recovery
+notifications as built-ins but are NEVER auto-restarted — monitoring is
+strictly read-only for them.
 """
 import json
 import logging
 import os
 import smtplib
+import socket
 import subprocess
 import time
 import urllib.error
@@ -144,6 +156,17 @@ _SERVICES = {
 
 
 def _check_service(url: str, timeout: int = 5) -> bool:
+    """Probe one service. `http(s)://` → GET (any HTTP response = up);
+    `tcp://host:port` → bare connect (for non-HTTP services like Postgres)."""
+    if url.startswith("tcp://"):
+        try:
+            hostport = url[len("tcp://"):].rstrip("/")
+            host, _, port = hostport.rpartition(":")
+            with socket.create_connection((host or "127.0.0.1", int(port)),
+                                          timeout=timeout):
+                return True
+        except Exception:
+            return False
     try:
         req = urllib.request.Request(url, method="GET")
         urllib.request.urlopen(req, timeout=timeout)
@@ -169,13 +192,17 @@ def _try_restart(service_pm2_name: str) -> bool:
         return False
 
 
-# PM2 name mapping for auto-restart
+# PM2 name mapping for auto-restart. Only built-in CODEC services appear
+# here — extra_services entries are intentionally absent (never restarted).
+# 2026-07 log review: the old names "qwen35b" / "qwen-vision" didn't match
+# any live PM2 process (the real one is "qwen3.6"), so LLM/Vision
+# auto-restart had been silently no-op'ing.
 _PM2_NAMES = {
-    "LLM (Qwen)": "qwen35b",
+    "LLM (Qwen)": "qwen3.6",
     "Whisper STT": "whisper-stt",
     "Kokoro TTS": "kokoro-82m",
     "Dashboard": "codec-dashboard",
-    "Vision": "qwen-vision",
+    "Vision": "qwen3.6",
 }
 
 
@@ -200,9 +227,21 @@ def check_services_and_alert():
     failures = state.get("consecutive_failures", {})
     state.get("last_alert", {})
 
-    for name, url_tpl in _SERVICES.items():
-        url = url_tpl.format(**ports)
-        up = _check_service(url)
+    # Built-ins (port-templated) + user extras (literal URLs, read-only).
+    all_services = {name: url_tpl.format(**ports)
+                    for name, url_tpl in _SERVICES.items()}
+    extras = cfg.get("alerts", {}).get("extra_services", {}) or {}
+    for name, url in extras.items():
+        all_services.setdefault(str(name), str(url))
+
+    # Dedupe probes by resolved URL — LLM and Vision usually share one
+    # qwen process on :8083; probing it twice double-counted every blip.
+    _probe_cache: dict = {}
+
+    for name, url in all_services.items():
+        if url not in _probe_cache:
+            _probe_cache[url] = _check_service(url)
+        up = _probe_cache[url]
 
         if up:
             prev_fails = failures.get(name, 0)
@@ -223,9 +262,14 @@ def check_services_and_alert():
                 state[f"down_since_{name}"] = now
 
             if failures[name] == 1:
-                # First failure — try auto-restart (with cooldown to prevent restart loops)
+                # First failure — try auto-restart (with cooldown to prevent
+                # restart loops). extra_services never appear in _PM2_NAMES,
+                # so they can never be restarted from here. Cooldown is keyed
+                # by PM2 process name (not display name) so two entries
+                # sharing one process (LLM + Vision → qwen3.6) can't
+                # double-restart it in a single pass.
                 pm2_name = _PM2_NAMES.get(name)
-                last_restart_key = f"last_restart_{name}"
+                last_restart_key = f"last_restart_{pm2_name}"
                 last_restart = state.get(last_restart_key, "")
                 cooldown_ok = True
                 if last_restart:
@@ -244,6 +288,7 @@ def check_services_and_alert():
                     # Re-check after restart
                     if _check_service(url):
                         failures[name] = 0
+                        _probe_cache[url] = True  # later names on this URL see the recovery
                         send_alert("recovery", f"CODEC RECOVERED: {name} auto-restarted successfully.")
                         continue
 

--- a/codec_heartbeat.py
+++ b/codec_heartbeat.py
@@ -71,12 +71,15 @@ def check_system_health():
     (codec-observer, codec-agent-runner) rely on PM2's autorestart for
     crash recovery — see AGENTS.md §3 "Background Execution".
     """
+    # NOTE: LLM and Vision are served by the same qwen process on :8083 —
+    # probe it ONCE. The former duplicate "Vision" entry double-counted
+    # every 8083 blip as two service_down audit events (2026-07 log
+    # review: 30 of 35 service_down events were LLM+Vision pairs).
     services = {
-        "LLM": "http://localhost:8083/v1/models",
+        "LLM/Vision": "http://localhost:8083/v1/models",
         "Whisper": "http://localhost:8084/health",
         "Kokoro": "http://localhost:8085/v1/models",
         "Dashboard": "http://localhost:8090/",
-        "Vision": "http://localhost:8083/v1/models",
     }
     with ThreadPoolExecutor(max_workers=len(services)) as pool:
         futures = {
@@ -115,24 +118,13 @@ def check_memory_stats():
         log.error(f"Memory stats failed: {e}")
 
 
-def backup_memory_db():
-    """Create daily backup of memory database to ~/.codec/backups/"""
-    backup_dir = os.path.expanduser("~/.codec/backups")
-    os.makedirs(backup_dir, exist_ok=True)
-
-    today = datetime.now().strftime("%Y-%m-%d")
-    backup_path = os.path.join(backup_dir, f"memory_{today}.db")
-
-    # Skip if today's backup already exists
-    if os.path.exists(backup_path):
+def _backup_one_db(prefix: str, db_path: str, backup_dir: str, today: str):
+    """Daily SQLite backup (safe under WAL via the backup API), keep last 7."""
+    backup_path = os.path.join(backup_dir, f"{prefix}_{today}.db")
+    if os.path.exists(backup_path) or not os.path.exists(db_path):
         return
-
-    if not os.path.exists(DB_PATH):
-        return
-
     try:
-        # Use SQLite backup API for safe copy (handles WAL mode)
-        src = sqlite3.connect(DB_PATH, timeout=5.0)
+        src = sqlite3.connect(db_path, timeout=5.0)
         src.execute("PRAGMA busy_timeout=5000")
         dst = sqlite3.connect(backup_path, timeout=5.0)
         dst.execute("PRAGMA busy_timeout=5000")
@@ -140,8 +132,9 @@ def backup_memory_db():
         dst.close()
         src.close()
 
-        # Keep only last 7 backups
-        backups = sorted([f for f in os.listdir(backup_dir) if f.startswith("memory_") and f.endswith(".db")])
+        # Keep only last 7 backups per prefix
+        backups = sorted([f for f in os.listdir(backup_dir)
+                          if f.startswith(f"{prefix}_") and f.endswith(".db")])
         for old in backups[:-7]:
             try:
                 os.unlink(os.path.join(backup_dir, old))
@@ -149,9 +142,135 @@ def backup_memory_db():
                 pass
 
         size_mb = os.path.getsize(backup_path) / (1024 * 1024)
-        log.info(f"Memory backup: {backup_path} ({size_mb:.1f} MB)")
+        log.info(f"{prefix} backup: {backup_path} ({size_mb:.1f} MB)")
     except Exception as e:
-        log.warning(f"Memory backup failed: {e}")
+        log.warning(f"{prefix} backup failed: {e}")
+
+
+def _backup_agents_state(backup_dir: str, today: str):
+    """Daily tar.gz of ~/.codec/agents/ (plans, grants, state, messages),
+    keep last 7. Small (KBs) but irreplaceable after an agent run."""
+    agents_dir = os.path.expanduser("~/.codec/agents")
+    tar_path = os.path.join(backup_dir, f"agents_{today}.tar.gz")
+    if os.path.exists(tar_path) or not os.path.isdir(agents_dir):
+        return
+    try:
+        import tarfile
+        with tarfile.open(tar_path, "w:gz") as tf:
+            tf.add(agents_dir, arcname="agents")
+        tars = sorted([f for f in os.listdir(backup_dir)
+                       if f.startswith("agents_") and f.endswith(".tar.gz")])
+        for old in tars[:-7]:
+            try:
+                os.unlink(os.path.join(backup_dir, old))
+            except Exception:
+                pass
+        log.info(f"agents backup: {tar_path}")
+    except Exception as e:
+        log.warning(f"agents backup failed: {e}")
+
+
+def backup_memory_db():
+    """Daily backups to ~/.codec/backups/.
+
+    2026-07 log review: only memory.db was covered, but day-to-day chat
+    history actually lives in qchat.db (and Vibe IDE history in vibe.db) —
+    neither was backed up. Now all three SQLite stores + the agents/
+    runtime state get a dated backup, 7-day retention each.
+    """
+    backup_dir = os.path.expanduser("~/.codec/backups")
+    os.makedirs(backup_dir, exist_ok=True)
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    _backup_one_db("memory", DB_PATH, backup_dir, today)
+    _backup_one_db("qchat", os.path.expanduser("~/.codec/qchat.db"), backup_dir, today)
+    _backup_one_db("vibe", os.path.expanduser("~/.codec/vibe.db"), backup_dir, today)
+    _backup_agents_state(backup_dir, today)
+
+# ── PM2 restart-storm detection (2026-07 log review) ─────────────────────────
+#
+# ava-litellm crash-looped 34,207 times over ~3 weeks with zero alerts —
+# PM2's autorestart hides a permanently-failing service behind status
+# "online". Every heartbeat we snapshot per-process restart counters and
+# alert when an autorestart-enabled process burned >= _RESTART_STORM_DELTA
+# restarts since the previous heartbeat (~20 min). Cron-style jobs
+# (autorestart=false, e.g. intake-*, sentora-backup) are excluded — their
+# counters increment by design on every scheduled run.
+
+_PM2_BIN = "/opt/homebrew/bin/pm2"
+_RESTART_STATE_PATH = os.path.expanduser("~/.codec/pm2_restart_state.json")
+_RESTART_STORM_DELTA = 5           # restarts per heartbeat interval
+_RESTART_STORM_REALERT_S = 6 * 3600  # re-alert a persisting storm every 6h
+
+
+def _pm2_jlist() -> list:
+    try:
+        env = os.environ.copy()
+        env["PATH"] = "/opt/homebrew/opt/node@22/bin:/opt/homebrew/bin:" + env.get("PATH", "")
+        out = subprocess.check_output([_PM2_BIN, "jlist"], timeout=15, env=env)
+        return json.loads(out)
+    except Exception as e:
+        log.warning(f"pm2 jlist failed: {e}")
+        return []
+
+
+def check_pm2_restart_storms(procs=None) -> list:
+    """Detect crash-looping PM2 processes. Returns [(name, delta), ...].
+    `procs` is injectable for tests (defaults to live `pm2 jlist`)."""
+    if procs is None:
+        procs = _pm2_jlist()
+    if not procs:
+        return []
+    try:
+        with open(_RESTART_STATE_PATH) as f:
+            state = json.load(f)
+    except Exception:
+        state = {}
+    counts = state.get("counts", {})
+    last_alert = state.get("last_alert", {})
+    now = datetime.now()
+    storms = []
+
+    for p in procs:
+        env = p.get("pm2_env", {}) or {}
+        if not env.get("autorestart"):
+            continue  # cron jobs restart by design
+        name = p.get("name", "")
+        n = int(env.get("restart_time", 0) or 0)
+        prev = counts.get(name)
+        if prev is not None and (n - prev) >= _RESTART_STORM_DELTA:
+            delta = n - prev
+            storms.append((name, delta))
+            realert_ok = True
+            if name in last_alert:
+                try:
+                    elapsed = (now - datetime.fromisoformat(last_alert[name])).total_seconds()
+                    realert_ok = elapsed >= _RESTART_STORM_REALERT_S
+                except Exception:
+                    pass
+            if realert_ok:
+                last_alert[name] = now.isoformat()
+                msg = (f"🔁 PM2 restart storm: '{name}' restarted {delta}× since "
+                       f"the last heartbeat ({n} total) — likely crash-looping.")
+                log.warning(f"  {msg}")
+                log_event("pm2_restart_storm", "codec-heartbeat", msg,
+                          outcome="warning", level="warning",
+                          extra={"process": name, "delta": delta, "total_restarts": n})
+                try:
+                    from codec_alerts import send_alert
+                    send_alert("warning", msg)
+                except Exception:
+                    pass
+        counts[name] = n
+
+    try:
+        os.makedirs(os.path.dirname(_RESTART_STATE_PATH), exist_ok=True)
+        with open(_RESTART_STATE_PATH, "w") as f:
+            json.dump({"counts": counts, "last_alert": last_alert}, f)
+    except Exception:
+        pass
+    return storms
+
 
 def extract_task_from_message(content: str) -> str:
     """Extract actionable task from assistant's confirmation message."""
@@ -426,6 +545,7 @@ def heartbeat():
     global _last_cleanup
     log.info("═══ CODEC Heartbeat ═══")
     check_system_health()
+    check_pm2_restart_storms()
     # Run alert-based service monitoring (Telegram/Email/Slack)
     try:
         from codec_alerts import check_services_and_alert

--- a/codec_observer.py
+++ b/codec_observer.py
@@ -377,6 +377,23 @@ def _get_recent_files(window_seconds: int = 300) -> List[Dict[str, Any]]:
     return out
 
 
+def _get_recent_files_bounded(window_seconds: int = 300,
+                              timeout_s: float = 2.0) -> List[Dict[str, Any]]:
+    """_get_recent_files under a hard wall-clock bound. os.listdir /
+    getmtime can block on slow or just-woken volumes — the 2026-07 log
+    review saw poll spikes up to 21s with OCR disabled. On timeout the
+    scan is skipped for this tick (empty list) and polling continues."""
+    try:
+        return run_with_timeout(_get_recent_files, timeout_s, window_seconds)
+    except TimeoutError:
+        log.debug("[observer] recent-files scan exceeded %.1fs — skipped this tick",
+                  timeout_s)
+        return []
+    except Exception as e:
+        log.debug("[observer] recent-files scan failed (non-fatal): %s", e)
+        return []
+
+
 # ── Ring buffer ───────────────────────────────────────────────────────────────
 class RingBuffer:
     """Bounded snapshot buffer. Threadsafe-friendly: appends and snapshots
@@ -515,16 +532,30 @@ def poll(buffer: Optional[RingBuffer] = None,
         buffer = _get_or_init_buffer(cfg)
 
     t0 = time.monotonic()
-    idle = _idle_seconds()
+
+    # Per-collector wall-clock timings (2026-07 log review): 759
+    # observation_tick_slow warnings (median 352ms, max 21s) with OCR
+    # already disabled — without per-collector attribution the offender
+    # is unidentifiable. Durations ride in the tick extra (metadata-only).
+    collector_ms: Dict[str, float] = {}
+
+    def _timed(label: str, fn):
+        t = time.monotonic()
+        try:
+            return fn()
+        finally:
+            collector_ms[label] = round((time.monotonic() - t) * 1000.0, 1)
+
+    idle = _timed("idle", _idle_seconds)
     cadence = (int(cfg["cadence_active_s"])
                if idle < float(cfg["idle_threshold_s"])
                else int(cfg["cadence_idle_s"]))
 
     # 1. Active window
-    active_window = _get_active_window()
+    active_window = _timed("window", _get_active_window)
 
     # 2. Clipboard delta
-    cb_now = _get_clipboard_now()
+    cb_now = _timed("clipboard", _get_clipboard_now)
     import hashlib
     cb_hash = hashlib.sha1(cb_now.encode("utf-8", errors="replace")).hexdigest()
     cb_changed = cb_hash != buffer._last_clipboard_hash
@@ -542,13 +573,15 @@ def poll(buffer: Optional[RingBuffer] = None,
     # permission granted to the PM2 child process. Buffer still gets
     # active_window + clipboard + recent_files signals.
     if cfg.get("ocr_enabled", True):
-        ocr_text, ocr_skipped = _get_screenshot_ocr(
-            int(cfg["ocr_timeout_ms"]), int(cfg["ocr_retry_timeout_ms"]))
+        ocr_text, ocr_skipped = _timed("ocr", lambda: _get_screenshot_ocr(
+            int(cfg["ocr_timeout_ms"]), int(cfg["ocr_retry_timeout_ms"])))
     else:
         ocr_text, ocr_skipped = ("", True)
+        collector_ms["ocr"] = 0.0
 
     # 4. Recent files
-    recent_files = _get_recent_files(window_seconds=300)
+    recent_files = _timed("files",
+                          lambda: _get_recent_files_bounded(window_seconds=300))
 
     snapshot = {
         "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
@@ -565,7 +598,8 @@ def poll(buffer: Optional[RingBuffer] = None,
 
     if emit_audit:
         _emit_observation_tick(snapshot, cadence, poll_duration_ms,
-                               len(buffer), float(cfg["poll_slow_threshold_ms"]))
+                               len(buffer), float(cfg["poll_slow_threshold_ms"]),
+                               collector_ms=collector_ms)
 
     # Phase 2 Step 6 — evaluate registered triggers against this snapshot.
     # Inline (not a separate PM2 service) — observer poll is the only event
@@ -612,12 +646,16 @@ def poll(buffer: Optional[RingBuffer] = None,
 
 def _emit_observation_tick(snapshot: Dict[str, Any], cadence_used_s: int,
                            poll_duration_ms: float, buffer_depth: int,
-                           slow_threshold_ms: float) -> None:
+                           slow_threshold_ms: float,
+                           collector_ms: Optional[Dict[str, float]] = None) -> None:
     """Emit observation_tick (or observation_tick_slow). METADATA-ONLY —
-    no titles, no OCR text, no clipboard content, no file paths."""
+    no titles, no OCR text, no clipboard content, no file paths.
+    `collector_ms` is per-collector wall-clock durations (idle / window /
+    clipboard / ocr / files) — durations only, still metadata."""
     win = snapshot.get("active_window") or {}
     cb = snapshot.get("clipboard") or {}
     extra = {
+        "collector_ms": collector_ms or {},
         "active_app": win.get("app", ""),
         "active_title_len": len(win.get("title", "")),
         "ocr_chars": len(snapshot.get("screenshot_ocr") or ""),

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -170,3 +170,12 @@ try/except AttributeError — but `CodecMemory` has no `store_fact` method (it l
 `codec_memory_upgrade`). Extracted facts are therefore never written to the facts table.
 Found during the Daybreak audit (2026-06-09); out of Daybreak scope. Fix: route to
 `codec_memory_upgrade.store_fact` and add a round-trip test.
+
+## Pilot e2e skill files fail skill-contract tests (2026-07-02)
+
+`skills/pilot_full_test_e2e.py` and `skills/pilot_e2e_test_fetch_example_title.py`
+lack the required `SKILL_NAME` / `SKILL_TRIGGERS` module attrs, so 4
+`tests/test_skills.py` contract tests fail on every run (pre-existing on main,
+confirmed 2026-07-02 during the log-review PRs). They look like leftover Pilot
+e2e scratch files, not real skills. Fix: either add the required metadata +
+regenerate `skills/.manifest.json`, or delete both files.

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -548,3 +548,45 @@ def test_ocr_enabled_true_calls_screenshot(fresh_buffer, temp_audit_log,
     monkeypatch.setattr(codec_observer, "_get_screenshot_ocr", _track_call)
     codec_observer.poll(buffer=fresh_buffer, cfg=cfg, emit_audit=False)
     assert call_count[0] == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2026-07 log review — per-collector timings + bounded recent-files scan
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_poll_tick_includes_collector_timings(fresh_buffer, cfg_default,
+                                              mocked_primitives, temp_audit_log):
+    """observation_tick extra carries collector_ms (durations only — still
+    metadata) so slow polls are attributable to a specific collector."""
+    codec_observer.poll(buffer=fresh_buffer, cfg=cfg_default, emit_audit=True)
+    recs = _records(temp_audit_log)
+    ticks = _events_of(recs, codec_audit.OBSERVATION_TICK)
+    assert len(ticks) == 1
+    cms = ticks[0]["extra"]["collector_ms"]
+    for key in ("idle", "window", "clipboard", "ocr", "files"):
+        assert key in cms, f"collector_ms missing {key!r}: {cms}"
+        assert isinstance(cms[key], (int, float))
+
+
+def test_recent_files_bounded_times_out(monkeypatch):
+    """A hung recent-files scan is dropped after the bound, not propagated."""
+    import time as _t
+
+    def hang(window_seconds=300):
+        _t.sleep(5)
+        return [{"path": "/never"}]
+
+    monkeypatch.setattr(codec_observer, "_get_recent_files", hang)
+    t0 = _t.monotonic()
+    out = codec_observer._get_recent_files_bounded(window_seconds=300,
+                                                   timeout_s=0.2)
+    assert out == []
+    assert _t.monotonic() - t0 < 2.0, "must return promptly on timeout"
+
+
+def test_recent_files_bounded_passthrough(monkeypatch):
+    """Fast scans pass through unchanged."""
+    monkeypatch.setattr(codec_observer, "_get_recent_files",
+                        lambda window_seconds=300: [{"path": "/x", "mtime": "t"}])
+    out = codec_observer._get_recent_files_bounded()
+    assert out == [{"path": "/x", "mtime": "t"}]

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import socket
 import sys
-import threading
 from pathlib import Path
 
 import pytest

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,184 @@
+"""2026-07 log review — watchdog additions.
+
+Covers:
+- codec_alerts._check_service tcp:// probes
+- codec_alerts.check_services_and_alert: URL dedupe + extra_services
+  (monitored but NEVER auto-restarted)
+- codec_heartbeat.check_pm2_restart_storms: crash-loop detection with
+  cron-job exclusion and first-run baseline
+"""
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+import codec_alerts
+import codec_heartbeat
+
+
+# ── _check_service tcp:// ─────────────────────────────────────────────────────
+
+
+def test_check_service_tcp_up():
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+    try:
+        assert codec_alerts._check_service(f"tcp://127.0.0.1:{port}") is True
+    finally:
+        srv.close()
+
+
+def test_check_service_tcp_down():
+    # Grab a free port, then close it so nothing listens there.
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    assert codec_alerts._check_service(f"tcp://127.0.0.1:{port}", timeout=1) is False
+
+
+# ── check_services_and_alert: dedupe + extras ────────────────────────────────
+
+
+@pytest.fixture
+def alert_harness(monkeypatch, tmp_path):
+    """Isolate check_services_and_alert: fake config/state, capture probes,
+    restarts, and alerts; neutralize sleeps and the pm2 cwd check."""
+    calls = {"probes": [], "restarts": [], "alerts": []}
+    cfg = {"alerts": {}}
+    state_holder = {"state": {}}
+
+    monkeypatch.setattr(codec_alerts, "_load_config", lambda: cfg)
+    monkeypatch.setattr(codec_alerts, "_load_state",
+                        lambda: dict(state_holder["state"]))
+    monkeypatch.setattr(codec_alerts, "_save_state",
+                        lambda s: state_holder.update(state=s))
+    monkeypatch.setattr(codec_alerts, "send_alert",
+                        lambda level, msg, subject=None: calls["alerts"].append((level, msg)))
+    monkeypatch.setattr(codec_alerts, "_try_restart",
+                        lambda pm2_name: calls["restarts"].append(pm2_name) or True)
+    monkeypatch.setattr(codec_alerts.time, "sleep", lambda s: None)
+    # Neutralize the disk + pm2-cwd tail checks (subprocess)
+    monkeypatch.setattr(codec_alerts.subprocess, "check_output",
+                        lambda *a, **kw: b"")
+    return cfg, state_holder, calls
+
+
+def test_shared_url_probed_once(alert_harness, monkeypatch):
+    """LLM and Vision resolve to the same URL — exactly one probe fires."""
+    cfg, state_holder, calls = alert_harness
+
+    def probe(url, timeout=5):
+        calls["probes"].append(url)
+        return True
+
+    monkeypatch.setattr(codec_alerts, "_check_service", probe)
+    codec_alerts.check_services_and_alert()
+    # default ports: llm and vision both 8083 → one probe for that URL
+    assert len(calls["probes"]) == len(set(calls["probes"])), calls["probes"]
+
+
+def test_extra_services_monitored_but_never_restarted(alert_harness, monkeypatch):
+    """A down extra service alerts after 2 consecutive failures and is
+    NEVER pm2-restarted."""
+    cfg, state_holder, calls = alert_harness
+    cfg["alerts"]["extra_services"] = {"AVA Gateway": "http://127.0.0.1:1/x"}
+
+    def probe(url, timeout=5):
+        return "127.0.0.1:1" not in url  # only the extra is down
+
+    monkeypatch.setattr(codec_alerts, "_check_service", probe)
+    codec_alerts.check_services_and_alert()  # failure #1
+    codec_alerts.check_services_and_alert()  # failure #2 → alert
+    assert calls["restarts"] == [], "extra services must never be auto-restarted"
+    assert any("AVA Gateway" in msg for _, msg in calls["alerts"]), calls["alerts"]
+
+
+def test_builtin_down_triggers_single_restart(alert_harness, monkeypatch):
+    """LLM+Vision share qwen3.6 — one down pass must restart it at most once."""
+    cfg, state_holder, calls = alert_harness
+
+    def probe(url, timeout=5):
+        return "8083" not in url  # qwen URL down, everything else up
+
+    monkeypatch.setattr(codec_alerts, "_check_service", probe)
+    codec_alerts.check_services_and_alert()
+    assert calls["restarts"].count("qwen3.6") <= 1, calls["restarts"]
+
+
+# ── check_pm2_restart_storms ─────────────────────────────────────────────────
+
+
+def _proc(name: str, restarts: int, autorestart: bool = True) -> dict:
+    return {"name": name,
+            "pm2_env": {"autorestart": autorestart, "restart_time": restarts}}
+
+
+@pytest.fixture
+def storm_state(monkeypatch, tmp_path):
+    state_path = tmp_path / "pm2_restart_state.json"
+    monkeypatch.setattr(codec_heartbeat, "_RESTART_STATE_PATH", str(state_path))
+    events = []
+    monkeypatch.setattr(codec_heartbeat, "log_event",
+                        lambda *a, **kw: events.append((a, kw)))
+    return state_path, events
+
+
+def test_storm_first_run_sets_baseline_no_alert(storm_state):
+    state_path, events = storm_state
+    storms = codec_heartbeat.check_pm2_restart_storms(
+        procs=[_proc("ava-litellm", 34000)])
+    assert storms == []
+    assert events == []
+    saved = json.loads(state_path.read_text())
+    assert saved["counts"]["ava-litellm"] == 34000
+
+
+def test_storm_detected_on_delta(storm_state):
+    state_path, events = storm_state
+    codec_heartbeat.check_pm2_restart_storms(procs=[_proc("ava-litellm", 100)])
+    storms = codec_heartbeat.check_pm2_restart_storms(
+        procs=[_proc("ava-litellm", 100 + codec_heartbeat._RESTART_STORM_DELTA)])
+    assert storms == [("ava-litellm", codec_heartbeat._RESTART_STORM_DELTA)]
+    assert any(a[0][0] == "pm2_restart_storm" for a in events)
+
+
+def test_storm_below_delta_silent(storm_state):
+    state_path, events = storm_state
+    codec_heartbeat.check_pm2_restart_storms(procs=[_proc("svc", 10)])
+    storms = codec_heartbeat.check_pm2_restart_storms(procs=[_proc("svc", 12)])
+    assert storms == []
+    assert events == []
+
+
+def test_storm_cron_jobs_excluded(storm_state):
+    """autorestart=false processes (cron jobs) restart by design — never
+    counted as storms no matter the delta."""
+    state_path, events = storm_state
+    codec_heartbeat.check_pm2_restart_storms(
+        procs=[_proc("intake-outbound-retry", 100, autorestart=False)])
+    storms = codec_heartbeat.check_pm2_restart_storms(
+        procs=[_proc("intake-outbound-retry", 700, autorestart=False)])
+    assert storms == []
+    assert events == []
+
+
+def test_storm_realert_cooldown(storm_state):
+    """A persisting storm re-alerts only after the 6h cooldown."""
+    state_path, events = storm_state
+    codec_heartbeat.check_pm2_restart_storms(procs=[_proc("svc", 0)])
+    codec_heartbeat.check_pm2_restart_storms(procs=[_proc("svc", 10)])   # alert 1
+    n_after_first = len(events)
+    codec_heartbeat.check_pm2_restart_storms(procs=[_proc("svc", 20)])   # within cooldown
+    assert len(events) == n_after_first, "second alert must be suppressed by cooldown"


### PR DESCRIPTION
## What

Watchdog + observability upgrades from the 2026-07-02 21-day log review (companion to #203).

**1. PM2 restart-storm detection** (`codec_heartbeat.check_pm2_restart_storms`)
`ava-litellm` crash-looped **34,207 times over 3 weeks** with zero alerts — PM2 shows a crash loop as "online". Every heartbeat now diffs per-process restart counters; an `autorestart:true` process burning ≥5 restarts per interval fires a warning alert + new `pm2_restart_storm` audit event (6h re-alert cooldown; cron-style jobs excluded). AGENTS.md §6 updated.

**2. Read-only extra-service probes** (`codec_alerts` → `alerts.extra_services` in config)
The AVA gateway (:4000) and Postgres (:5433) were down 23 days, unmonitored. Config now accepts `{"name": "http(s)://…"}` or `"tcp://host:port"` entries that get the same consecutive-failure + recovery alerting as built-ins but are **never auto-restarted** (guaranteed by test).

**3. Probe dedupe + stale PM2-name fix**
LLM and Vision both probe the one qwen process on :8083 — every blip double-fired `service_down` (30 of 35 events in the window were pairs). Probes are now deduped by resolved URL. Also: `_PM2_NAMES` still said `qwen35b`/`qwen-vision` (no such processes) — LLM/Vision auto-restart had been silently no-op'ing; fixed to `qwen3.6`, with the restart cooldown keyed by PM2 name so a shared process can't be double-restarted in one pass.

**4. Observer slow-poll attribution + bounded file scan**
759 `observation_tick_slow` warnings (median 352ms, max 21s) were unattributable. The tick extra now carries `collector_ms` per collector (durations only — still metadata-only), and the recent-files scan runs under a 2s hard bound via `run_with_timeout`.

**5. Backup coverage**
Nightly backups covered only `memory.db` — but day-to-day chat history lives in `qchat.db` (and Vibe history in `vibe.db`), neither backed up. Now: memory + qchat + vibe SQLite backups plus an `agents/` tar.gz, 7-day retention each.

## Tests
- New `tests/test_watchdog.py` (10 tests: tcp probe, URL dedupe, extras-never-restarted, storm baseline/threshold/cron-exclusion/cooldown)
- 3 new observer tests (collector_ms in tick, bounded-scan timeout + passthrough)
- Full suite: **2,426 passed**; 4 pre-existing failures (pilot e2e skill files, unrelated) documented in `docs/known-issues.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)