### PR TITLE
ci: pin fastapi/pydantic/starlette to production versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,14 @@ jobs:
           # routes/* / codec_voice without ModuleNotFoundError on the Ubuntu
           # runner. pynput stays in the list, but the conftest installs a
           # stub when its real import fails (headless Linux has no X11).
-          pip install pytest fastmcp httpx requests pynput pydantic ruff \
-                      fastapi numpy pyotp 'qrcode[pil]'
+          # fastapi/pydantic/starlette are PINNED to the versions running in
+          # production on the Mac (2026-07-02). Unpinned, the runner pulled
+          # fastapi 0.139 / pydantic 2.13 which broke route-registration
+          # tests on main-as-is (verified via a no-op canary PR) — CI was
+          # testing a dependency set production never runs. Bump these pins
+          # together with a production upgrade, not before.
+          pip install pytest fastmcp httpx requests pynput 'pydantic==2.11.10' ruff \
+                      'fastapi==0.129.0' 'starlette==0.52.1' numpy pyotp 'qrcode[pil]'
       - name: Lint (ruff) — F-4 gate, config in ruff.toml
         run: ruff check .
       - name: Skill import smoke (standalone script, not a pytest module)


### PR DESCRIPTION
## What

The smoke workflow installs **unpinned** deps. Since the last run (Jun 9, PR #193), the runner started pulling fastapi 0.139.0 / pydantic 2.13.4, which fail ~60 route-registration tests (`tests/test_b6_refactor.py`, `tests/test_route_extractions*.py`) **on main with zero code changes** — proven by no-op canary PR #205.

Pin `fastapi==0.129.0`, `pydantic==2.11.10`, `starlette==0.52.1` — the exact versions production runs on the Mac — so CI tests reality. Bump the pins together with a deliberate production dependency upgrade.

Unblocks #203 and #204 (both failed smoke only due to this drift; #204 additionally had a ruff nit, already fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)