### PR TITLE
fix(health): kokoro TTS probe used stale port 8880

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -49,7 +49,7 @@
     "google_sheets.py": "d9b67b7e46ac835f4ef6d171d161b962c93c1916837f1b6aa5f4ec2804a36e69",
     "google_slides.py": "30193598c0214305c03412911781dd32794e6c9d6349ed6a242753c38eb49101",
     "google_tasks.py": "a609902fa2a12eddee70942f3786f146c7e413ad60e0bd7e394b0502b99dc1e7",
-    "health_check.py": "b9d9bb6e12e131a3a71f6490a4ffea32c519b89a52a3e5a458635d016b6ff8eb",
+    "health_check.py": "5a6e5c71f77bc2a2f856bd70c44dadebd1f67ae58d1fe65416fa40c19479744c",
     "imessage_send.py": "862f7031a525faed4cec7cb703ef32f5d8bdc1045326f880d50455baf4cfcf86",
     "json_formatter.py": "42a770a1455a574d33e2f96f34c63ae7a83845f70789862e5e5198d0b429fde2",
     "memory_entities.py": "252ad5861d614b916504b8af6300c4a8c62622c9f6c15238b11d6c6a052bada7",

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -49,7 +49,7 @@
     "google_sheets.py": "d9b67b7e46ac835f4ef6d171d161b962c93c1916837f1b6aa5f4ec2804a36e69",
     "google_slides.py": "30193598c0214305c03412911781dd32794e6c9d6349ed6a242753c38eb49101",
     "google_tasks.py": "a609902fa2a12eddee70942f3786f146c7e413ad60e0bd7e394b0502b99dc1e7",
-    "health_check.py": "5a6e5c71f77bc2a2f856bd70c44dadebd1f67ae58d1fe65416fa40c19479744c",
+    "health_check.py": "01ac95da13770e2419460b4aaf1bd79c6628b6bc5413a5608153b81feee81568",
     "imessage_send.py": "862f7031a525faed4cec7cb703ef32f5d8bdc1045326f880d50455baf4cfcf86",
     "json_formatter.py": "42a770a1455a574d33e2f96f34c63ae7a83845f70789862e5e5198d0b429fde2",
     "memory_entities.py": "252ad5861d614b916504b8af6300c4a8c62622c9f6c15238b11d6c6a052bada7",

--- a/skills/health_check.py
+++ b/skills/health_check.py
@@ -54,18 +54,23 @@ def run(task: str = "", context: str = "") -> str:
     except Exception as e:
         results["whisper_stt"] = f"DOWN ({type(e).__name__})"
 
-    # 5. Kokoro TTS
+    # 5. Kokoro TTS — port from config (tts_url), default :8085. The old
+    # hardcoded :8880 was stale (kokoro has served on 8085 for months), so
+    # health_check falsely reported TTS DOWN — caught 2026-07-02 when a
+    # Project-mode dry run wrote "kokoro_tts is DOWN" into its status brief
+    # while the service was healthy.
     try:
-        req = Request("http://localhost:8880/health")
+        tts_base = "http://localhost:8085"
+        try:
+            with open(os.path.expanduser("~/.codec/config.json")) as f:
+                tts_base = json.load(f).get("tts_url", tts_base).rstrip("/")
+        except Exception:
+            pass
+        req = Request(f"{tts_base}/v1/models")
         resp = urlopen(req, timeout=5)
         results["kokoro_tts"] = "OK"
-    except Exception:
-        try:
-            req = Request("http://localhost:8880/v1/models")
-            resp = urlopen(req, timeout=5)
-            results["kokoro_tts"] = "OK"
-        except Exception as e:
-            results["kokoro_tts"] = f"DOWN ({type(e).__name__})"
+    except Exception as e:
+        results["kokoro_tts"] = f"DOWN ({type(e).__name__})"
 
     # 6. Memory DB
     try:

--- a/skills/health_check.py
+++ b/skills/health_check.py
@@ -60,10 +60,16 @@ def run(task: str = "", context: str = "") -> str:
     # Project-mode dry run wrote "kokoro_tts is DOWN" into its status brief
     # while the service was healthy.
     try:
+        from urllib.parse import urlparse
         tts_base = "http://localhost:8085"
         try:
             with open(os.path.expanduser("~/.codec/config.json")) as f:
-                tts_base = json.load(f).get("tts_url", tts_base).rstrip("/")
+                # tts_url is the FULL speech endpoint
+                # (e.g. http://localhost:8085/v1/audio/speech) — keep only
+                # scheme://host:port for the models probe.
+                _u = urlparse(json.load(f).get("tts_url", ""))
+                if _u.scheme and _u.netloc:
+                    tts_base = f"{_u.scheme}://{_u.netloc}"
         except Exception:
             pass
         req = Request(f"{tts_base}/v1/models")


### PR DESCRIPTION
One-liner class fix: health_check probed :8880 for kokoro; it serves on :8085 (config `tts_url`). Every health check falsely reported TTS DOWN — surfaced by the Project-mode live e2e test writing it into a status brief. Port now config-driven with the correct default. Live-verified: skill now reports 6/6 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)