### PR TITLE
CODEC chat: Agent→Chat handoff, Stop button, Train-of-thought, report polish + no-emoji cleanup

### DIFF
--- a/codec_chat.html
+++ b/codec_chat.html
@@ -1024,9 +1024,23 @@ function removeChip(id){pendingFiles=pendingFiles.filter(function(f){return f.id
 function clearChips(){pendingFiles=[];document.getElementById('fileChips').innerHTML=''}
 
 var _currentAbort=null;
+// Agent/crew run handles — set while a Deep Research/crew job is polling so the
+// Stop button can cancel it (crews can't be killed mid-run, so this stops the
+// UI waiting AND flags the job cancelled server-side to ignore a late result).
+var _agentJobId=null,_agentPoll=null,_agentTicker=null;
 function _showStop(){document.getElementById('sendBtn').style.display='none';document.getElementById('stopBtn').style.display='flex'}
 function _showSend(){document.getElementById('stopBtn').style.display='none';document.getElementById('sendBtn').style.display='flex'}
 function stopGeneration(){
+  // An agent/crew run in progress takes priority over chat streaming.
+  if(_agentJobId||_agentPoll||_agentTicker){
+    if(_agentPoll){clearInterval(_agentPoll);_agentPoll=null}
+    if(_agentTicker){clearInterval(_agentTicker);_agentTicker=null}
+    var jid=_agentJobId;_agentJobId=null;
+    if(jid){fetch('/api/agents/cancel/'+jid,{method:'POST'}).catch(function(){})}
+    var st=document.getElementById('agentStatus');if(st&&st.parentElement)st.parentElement.remove();
+    addMessage('assistant','⏹ **Task stopped.** The agent run was cancelled. Any work already finished on the server may still be saved.');
+    hideTyping();_showSend();isProcessing=false;document.getElementById('sendBtn').disabled=false;return
+  }
   if(_currentAbort){_currentAbort.abort();_currentAbort=null}
   hideTyping();_showSend();isProcessing=false;document.getElementById('sendBtn').disabled=false
 }
@@ -1156,20 +1170,22 @@ async function sendMessage(){
     if(crew==='custom'){payload.agent_name=document.getElementById('agentName').value||'Custom Agent';payload.role=document.getElementById('agentRole').value||'';payload.tools=getSelectedTools();payload.max_iterations=parseInt(document.getElementById('agentMaxIter').value||'8');payload.task=researchText}else{if(['deep_research','competitor_analysis'].includes(crew))payload.topic=researchText;if(crew==='trip_planner')payload.destination=researchText}
 
     var elapsed=0;
-    var ticker=setInterval(function(){elapsed+=5;updateStatus('\u23F3 '+crewLabels[crew]+' running&hellip; ('+elapsed+'s)\n\n'+(crewHints[crew]||''))},5000);
+    _agentTicker=setInterval(function(){elapsed+=5;updateStatus('\u23F3 '+crewLabels[crew]+' running&hellip; ('+elapsed+'s)  \u2014 tap \u23F9 to stop\n\n'+(crewHints[crew]||''))},5000);
 
     try{
       var r=await fetch('/api/agents/run',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
       var startData=await r.json();
-      if(!r.ok||!startData.job_id){clearInterval(ticker);updateStatus('\u274C Agent error: '+(startData.error||'Failed to start'));isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
-      var jobId=startData.job_id;
-      var data=await new Promise(function(resolve,reject){var poll=setInterval(async function(){try{var sr=await fetch('/api/agents/status/'+jobId);var sd=await sr.json();if(sd.status!=='running'){clearInterval(poll);resolve(sd)}}catch(pe){clearInterval(poll);reject(pe)}},4000)});
-      clearInterval(ticker);if(statusEl)statusEl.parentElement.remove();
+      if(!r.ok||!startData.job_id){clearInterval(_agentTicker);_agentTicker=null;updateStatus('\u274C Agent error: '+(startData.error||'Failed to start'));isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
+      var jobId=startData.job_id;_agentJobId=jobId;
+      var data=await new Promise(function(resolve,reject){_agentPoll=setInterval(async function(){try{var sr=await fetch('/api/agents/status/'+jobId);var sd=await sr.json();if(sd.status!=='running'){clearInterval(_agentPoll);_agentPoll=null;resolve(sd)}}catch(pe){clearInterval(_agentPoll);_agentPoll=null;reject(pe)}},4000)});
+      clearInterval(_agentTicker);_agentTicker=null;_agentJobId=null;if(statusEl)statusEl.parentElement.remove();
+      // User pressed Stop after the crew already reported terminal \u2014 honor it.
+      if(data.status==='cancelled'){isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       var resultMsg;var reportDocUrl=null;
       if(data.status==='complete'){var result=data.result||'';var docMatch=result.match(/https:\/\/docs\.google\.com\/\S+/);if(docMatch){reportDocUrl=docMatch[0].replace(/[)\].,]+$/,'');var summary=result.replace(docMatch[0],'').trim();if(!summary)summary='Your report has been generated and saved to Google Docs.';resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+summary+'\n\n[Open in Google Docs]('+reportDocUrl+')'}else{resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+result}}else{resultMsg='\u274C Agent error: '+(data.error||'Unknown error')}
       addMessage('assistant',resultMsg);chatHist.push({role:'assistant',content:resultMsg});saveMessages([{role:'assistant',content:resultMsg}]);
       if(reportDocUrl)appendDiscussButton(reportDocUrl)
-    }catch(e){clearInterval(ticker);updateStatus('Agent error: '+e.message)}
+    }catch(e){if(_agentTicker){clearInterval(_agentTicker);_agentTicker=null}_agentJobId=null;updateStatus('Agent error: '+e.message)}
     isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return
   }
 

--- a/codec_chat.html
+++ b/codec_chat.html
@@ -184,6 +184,15 @@ input[type=file]{display:none}
 .discuss-report-btn{margin-top:2px;padding:9px 16px;border:1px solid var(--accent);border-radius:8px;cursor:pointer;font-size:13px;font-family:var(--font);font-weight:600;background:var(--accent);color:#fff;transition:all .15s;display:inline-flex;align-items:center;gap:6px}
 .discuss-report-btn:hover:not(:disabled){background:var(--accent-hover);border-color:var(--accent-hover)}
 .discuss-report-btn:disabled{cursor:default;opacity:.7;background:transparent;color:var(--accent)}
+/* Train-of-thought panel — reveals reasoning (chat) / agent steps, collapsed by default */
+.think-panel{margin:0 0 8px;border:1px solid var(--border);border-radius:8px;background:var(--surface-2);overflow:hidden}
+.think-panel>summary{cursor:pointer;padding:7px 12px;font-size:12px;font-weight:600;color:var(--text-muted);list-style:none;display:flex;align-items:center;gap:6px;user-select:none}
+.think-panel>summary::-webkit-details-marker{display:none}
+.think-panel>summary::before{content:'\25B8';font-size:10px;transition:transform .15s;color:var(--accent)}
+.think-panel[open]>summary::before{transform:rotate(90deg)}
+.think-panel .think-body{padding:4px 14px 12px;font-size:12px;line-height:1.55;color:var(--text-dim);white-space:pre-wrap;word-break:break-word;font-family:var(--font);max-height:340px;overflow:auto}
+.think-panel .think-step{padding:3px 0;border-bottom:1px dashed var(--border)}
+.think-panel .think-step:last-child{border-bottom:none}
 
 /* ── Agent Builder ── */
 #agentBuilder{display:none;flex-shrink:0;background:var(--surface);border-bottom:1px solid var(--border);padding:12px 14px;gap:10px;flex-direction:column}
@@ -335,6 +344,9 @@ input[type=file]{display:none}
 <button class="mode-btn active" id="thinkToggle" onclick="toggleThinking()" title="Deep thinking ON — better answers, slower (~15s)">
   <svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>Think
 </button>
+<button class="mode-btn" id="thoughtsToggle" onclick="toggleThoughts()" title="Show CODEC's train of thought — live reasoning &amp; agent steps (off by default)">
+  <svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>Thoughts
+</button>
 <button class="mode-btn" onclick="setMode('research')" id="modeResearchBtn"><svg class="ico" viewBox="0 0 24 24" style="width:14px;height:14px"><rect x="4" y="4" width="16" height="16" rx="2"/><circle cx="9" cy="10" r="1.5" fill="currentColor" stroke="none"/><circle cx="15" cy="10" r="1.5" fill="currentColor" stroke="none"/><path d="M9 15h6"/></svg>Agents</button>
 <button class="mode-btn" onclick="setMode('project')" id="modeProjectBtn" title="Drop a project — autonomous plan-and-build mode"><svg class="ico" viewBox="0 0 24 24" style="width:14px;height:14px"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="5"/><line x1="12" y1="2" x2="12" y2="22"/><line x1="2" y1="12" x2="22" y2="12"/></svg>Project</button>
 <select id="crewSelect">
@@ -485,6 +497,7 @@ var sessionId=null;
 var chatMode='chat';
 var webSearchEnabled=false;
 var thinkingEnabled=true;
+var thoughtsEnabled=false; // Train-of-thought reveal (chat reasoning + agent steps), off by default
 
 function showToast(msg){var t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');setTimeout(function(){t.classList.remove('show')},1800)}
 function _copyFallback(text){
@@ -621,10 +634,10 @@ function regenerateResponse(btn){
   isProcessing=true;document.getElementById('sendBtn').disabled=true;_showStop();showTyping();
   _currentAbort=new AbortController();
   var msgs=[{role:'system',content:SYS}].concat(chatHist);
-  fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:thinkingEnabled,stream:true}),signal:_currentAbort.signal}).then(async function(r){
+  fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:thinkingEnabled,show_thoughts:thoughtsEnabled,stream:true}),signal:_currentAbort.signal}).then(async function(r){
     if(r.status===401||r.status===403){hideTyping();addMessage('assistant','Session expired — redirecting to login...');setTimeout(function(){window.location.href='/auth'},1500);isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
     hideTyping();
-    var reader=r.body.getReader();var decoder=new TextDecoder();var fullText='';var bubbleId='stream_'+genId();
+    var reader=r.body.getReader();var decoder=new TextDecoder();var fullText='';var thinkText='';var bubbleId='stream_'+genId();
     var div=document.createElement('div');div.className='msg assistant';div.innerHTML='<div class="msg-bubble" id="'+bubbleId+'"><div class="thinking-indicator"><div class="thinking-dots"><span></span><span></span><span></span></div>CODEC is thinking...</div></div>';document.getElementById('messages').appendChild(div);
     var bubble=document.getElementById(bubbleId);var buf='';var firstToken=true;
     while(true){
@@ -635,12 +648,13 @@ function regenerateResponse(btn){
       for(var li=0;li<lines.length;li++){
         var line=lines[li].trim();if(!line.startsWith('data: '))continue;var payload=line.substring(6);
         if(payload==='[DONE]')break;
-        try{var j=JSON.parse(payload);if(j.skill){showToast('⚡ Skill: '+j.skill)}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.error){fullText+='\nError: '+j.error}}catch(pe){}
+        try{var j=JSON.parse(payload);if(j.skill){showToast('⚡ Skill: '+j.skill)}if(j.think){thinkText+=j.think;if(thoughtsEnabled){var tp=ensureThinkPanel(div,'🧠 Thinking…',true);setThinkText(tp,thinkText);scrollBottom()}}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.error){fullText+='\nError: '+j.error}}catch(pe){}
       }
     }
     if(fullText){
       // Replace the streaming div with a proper message (with copy+regen buttons)
-      div.remove();addMessage('assistant',fullText);
+      div.remove();var md=addMessage('assistant',fullText);
+      if(thoughtsEnabled&&thinkText.trim()&&md){var fp=ensureThinkPanel(md,'🧠 Train of thought',false);setThinkText(fp,thinkText.trim())}
       chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])
     }else{bubble.innerHTML='<em style="color:var(--text-dim)">No response</em>'}
     _currentAbort=null;isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false
@@ -665,6 +679,46 @@ function toggleThinking(){
   btn.classList.toggle('active',thinkingEnabled);
   btn.title=thinkingEnabled?'Deep thinking ON — better answers, slower (~15s)':'Quick mode — fast answers';
   showToast(thinkingEnabled?'Thinking ON — deeper answers':'Thinking OFF — fast mode');
+}
+
+// ── Train-of-thought toggle ────────────────────────────────────────────────
+// Off by default. When ON, chat reveals the model's <think> reasoning and
+// Agent/Project runs reveal their live step log — each in a collapsible panel.
+function toggleThoughts(){
+  thoughtsEnabled=!thoughtsEnabled;
+  var btn=document.getElementById('thoughtsToggle');
+  btn.classList.toggle('active',thoughtsEnabled);
+  btn.title=thoughtsEnabled?'Train of thought ON — showing reasoning & steps':"Show CODEC's train of thought (off by default)";
+  showToast(thoughtsEnabled?'🧠 Train of thought ON':'Train of thought OFF');
+}
+
+// Build (once) and return a collapsible thoughts panel inside `container`,
+// inserted before the first .msg-bubble. `label` names it; `open` expands it.
+function ensureThinkPanel(container,label,open){
+  var p=container.querySelector('.think-panel');
+  if(p)return p;
+  p=document.createElement('details');p.className='think-panel';if(open)p.open=true;
+  var s=document.createElement('summary');s.textContent=label||'🧠 Train of thought';
+  var body=document.createElement('div');body.className='think-body';
+  p.appendChild(s);p.appendChild(body);
+  var bubble=container.querySelector('.msg-bubble');
+  if(bubble)container.insertBefore(p,bubble);else container.appendChild(p);
+  return p;
+}
+// Render an array of step strings/objects into a panel body as discrete rows.
+function renderThinkSteps(panel,steps){
+  var body=panel.querySelector('.think-body');if(!body)return;
+  body.innerHTML='';
+  for(var i=0;i<steps.length;i++){
+    var st=steps[i];var txt=(typeof st==='string')?st:(st&&(st.text||st.message||st.step))||JSON.stringify(st);
+    var row=document.createElement('div');row.className='think-step';row.textContent=txt;body.appendChild(row);
+  }
+  body.scrollTop=body.scrollHeight;
+}
+// Set raw reasoning text (chat <think>) into a panel body.
+function setThinkText(panel,text){
+  var body=panel.querySelector('.think-body');if(!body)return;
+  body.textContent=text;body.scrollTop=body.scrollHeight;
 }
 
 function genId(){return Date.now().toString(36)+Math.random().toString(36).substr(2,5)}
@@ -808,6 +862,7 @@ function addMessage(role,content,animate){
     var plain = String(content).replace(/[`*_#>\[\]()]/g,'').replace(/\s+/g,' ').trim();
     if (plain) speakMessage(plain);
   }
+  return div;
 }
 
 // ── Agent → Chat handoff ────────────────────────────────────────────────────
@@ -1177,13 +1232,18 @@ async function sendMessage(){
       var startData=await r.json();
       if(!r.ok||!startData.job_id){clearInterval(_agentTicker);_agentTicker=null;updateStatus('\u274C Agent error: '+(startData.error||'Failed to start'));isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       var jobId=startData.job_id;_agentJobId=jobId;
-      var data=await new Promise(function(resolve,reject){_agentPoll=setInterval(async function(){try{var sr=await fetch('/api/agents/status/'+jobId);var sd=await sr.json();if(sd.status!=='running'){clearInterval(_agentPoll);_agentPoll=null;resolve(sd)}}catch(pe){clearInterval(_agentPoll);_agentPoll=null;reject(pe)}},4000)});
+      var data=await new Promise(function(resolve,reject){_agentPoll=setInterval(async function(){try{var sr=await fetch('/api/agents/status/'+jobId);var sd=await sr.json();
+        // Train-of-thought: stream the crew's live step log into a panel above the status.
+        if(thoughtsEnabled&&sd.progress&&sd.progress.length&&statusEl){var lp=ensureThinkPanel(statusEl.parentElement,'\uD83E\uDDE0 Live steps ('+sd.progress.length+')',true);renderThinkSteps(lp,sd.progress)}
+        if(sd.status!=='running'){clearInterval(_agentPoll);_agentPoll=null;resolve(sd)}}catch(pe){clearInterval(_agentPoll);_agentPoll=null;reject(pe)}},4000)});
       clearInterval(_agentTicker);_agentTicker=null;_agentJobId=null;if(statusEl)statusEl.parentElement.remove();
       // User pressed Stop after the crew already reported terminal \u2014 honor it.
       if(data.status==='cancelled'){isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       var resultMsg;var reportDocUrl=null;
       if(data.status==='complete'){var result=data.result||'';var docMatch=result.match(/https:\/\/docs\.google\.com\/\S+/);if(docMatch){reportDocUrl=docMatch[0].replace(/[)\].,]+$/,'');var summary=result.replace(docMatch[0],'').trim();if(!summary)summary='Your report has been generated and saved to Google Docs.';resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+summary+'\n\n[Open in Google Docs]('+reportDocUrl+')'}else{resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+result}}else{resultMsg='\u274C Agent error: '+(data.error||'Unknown error')}
-      addMessage('assistant',resultMsg);chatHist.push({role:'assistant',content:resultMsg});saveMessages([{role:'assistant',content:resultMsg}]);
+      var amd=addMessage('assistant',resultMsg);chatHist.push({role:'assistant',content:resultMsg});saveMessages([{role:'assistant',content:resultMsg}]);
+      // Persist the crew's step log on the final message when Thoughts is on.
+      if(thoughtsEnabled&&data.progress&&data.progress.length&&amd){var pp=ensureThinkPanel(amd,'\uD83E\uDDE0 Train of thought ('+data.progress.length+' steps)',false);renderThinkSteps(pp,data.progress)}
       if(reportDocUrl)appendDiscussButton(reportDocUrl)
     }catch(e){if(_agentTicker){clearInterval(_agentTicker);_agentTicker=null}_agentJobId=null;updateStatus('Agent error: '+e.message)}
     isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return
@@ -1209,11 +1269,11 @@ async function sendMessage(){
       if(data.response){addMessage('assistant',data.response);chatHist.push({role:'assistant',content:data.response});saveMessages([{role:'assistant',content:data.response}])}
       else{addMessage('assistant','Error: '+(data.error||'No response'))}
     } else {
-      r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:thinkingEnabled,stream:true}),signal:_currentAbort.signal});
+      r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:thinkingEnabled,show_thoughts:thoughtsEnabled,stream:true}),signal:_currentAbort.signal});
       if(r.status===401||r.status===403){hideTyping();addMessage('assistant','Session expired — redirecting to login...');setTimeout(function(){window.location.href='/auth'},1500);isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       hideTyping();
       // SSE streaming — render tokens as they arrive
-      var reader=r.body.getReader();var decoder=new TextDecoder();var fullText='';var bubbleId='stream_'+genId();
+      var reader=r.body.getReader();var decoder=new TextDecoder();var fullText='';var thinkText='';var bubbleId='stream_'+genId();
       var es=document.getElementById('emptyState');if(es)es.remove();
       var div=document.createElement('div');div.className='msg assistant';div.innerHTML='<div class="msg-bubble" id="'+bubbleId+'"><div class="thinking-indicator"><div class="thinking-dots"><span></span><span></span><span></span></div>CODEC is thinking...</div></div>';document.getElementById('messages').appendChild(div);
       var bubble=document.getElementById(bubbleId);var buf='';var firstToken=true;
@@ -1227,10 +1287,10 @@ async function sendMessage(){
           if(!line.startsWith('data: '))continue;
           var payload=line.substring(6);
           if(payload==='[DONE]')break;
-          try{var j=JSON.parse(payload);if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.escalate_project){renderEscalateChip(j.escalate_project,text)}if(j.error){fullText+='\n\nError: '+j.error}}catch(pe){}
+          try{var j=JSON.parse(payload);if(j.think){thinkText+=j.think;if(thoughtsEnabled){var tp2=ensureThinkPanel(div,'🧠 Thinking…',true);setThinkText(tp2,thinkText);scrollBottom()}}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.escalate_project){renderEscalateChip(j.escalate_project,text)}if(j.error){fullText+='\n\nError: '+j.error}}catch(pe){}
         }
       }
-      if(fullText){div.remove();addMessage('assistant',fullText);chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])}
+      if(fullText){div.remove();var md2=addMessage('assistant',fullText);if(thoughtsEnabled&&thinkText.trim()&&md2){var fp2=ensureThinkPanel(md2,'🧠 Train of thought',false);setThinkText(fp2,thinkText.trim())}chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])}
       else{bubble.innerHTML='<em style="color:var(--text-dim)">No response</em>'}
     }
   }catch(e){

--- a/codec_chat.html
+++ b/codec_chat.html
@@ -181,6 +181,9 @@ input[type=file]{display:none}
 .mode-btn{padding:4px 8px;border:none;border-radius:4px;cursor:pointer;font-size:11px;background:transparent;color:var(--text-dim);font-family:var(--font);font-weight:500;transition:all .15s;display:flex;align-items:center;gap:4px;white-space:nowrap}
 .mode-btn:hover{color:var(--text-muted)}
 .mode-btn.active{background:var(--surface);color:var(--text);box-shadow:0 1px 3px rgba(0,0,0,.2)}
+.discuss-report-btn{margin-top:2px;padding:9px 16px;border:1px solid var(--accent);border-radius:8px;cursor:pointer;font-size:13px;font-family:var(--font);font-weight:600;background:var(--accent);color:#fff;transition:all .15s;display:inline-flex;align-items:center;gap:6px}
+.discuss-report-btn:hover:not(:disabled){background:var(--accent-hover);border-color:var(--accent-hover)}
+.discuss-report-btn:disabled{cursor:default;opacity:.7;background:transparent;color:var(--accent)}
 
 /* ── Agent Builder ── */
 #agentBuilder{display:none;flex-shrink:0;background:var(--surface);border-bottom:1px solid var(--border);padding:12px 14px;gap:10px;flex-direction:column}
@@ -807,6 +810,47 @@ function addMessage(role,content,animate){
   }
 }
 
+// ── Agent → Chat handoff ────────────────────────────────────────────────────
+// After a Deep Research report completes with a Google Doc, offer a button to
+// switch to chat mode AND load the FULL report so chat-mode CODEC can discuss
+// it. (Without this, only the short summary is in chatHist and asking
+// "read the report you just made" while still in Agents mode re-ran the crew.)
+function appendDiscussButton(docUrl){
+  var wrap=document.createElement('div');
+  wrap.className='msg assistant';wrap.style.animation='none';
+  var b=document.createElement('button');
+  b.className='discuss-report-btn';
+  b.innerHTML='💬 Discuss this report in Chat';
+  b.onclick=function(){discussReportInChat(docUrl,b)};
+  var bubble=document.createElement('div');bubble.className='msg-bubble';
+  bubble.style.background='transparent';bubble.style.padding='0';bubble.style.boxShadow='none';
+  bubble.appendChild(b);
+  wrap.appendChild(bubble);
+  document.getElementById('messages').appendChild(wrap);
+  scrollBottom();
+}
+
+async function discussReportInChat(docUrl, btn){
+  if(btn){btn.disabled=true;btn.innerHTML='⏳ Loading report&hellip;';}
+  setMode('chat');
+  try{
+    var r=await fetch('/api/gdoc/read?url='+encodeURIComponent(docUrl));
+    var d=await r.json();
+    if(!r.ok||!d.text){throw new Error(d.error||'Could not read the report');}
+    // Inject the full report as hidden context so every follow-up /api/chat
+    // call carries it. Not rendered as a bubble — only the confirmation below.
+    var ctx='Here is the full text of the report we just generated'+(d.title?(' ("'+d.title+'")'):'')+'. Use it to answer my follow-up questions about it:\n\n'+d.text+(d.truncated?'\n\n[report truncated for length]':'');
+    chatHist.push({role:'user',content:ctx});
+    chatHist.push({role:'assistant',content:'I\'ve loaded the full report and I\'m ready to discuss it.'});
+    addMessage('assistant','📄 **Loaded the full report** — ask me anything about it (key findings, a specific section, or say "summarize the main risks").');
+    if(btn){btn.innerHTML='✓ Report loaded into chat';}
+  }catch(e){
+    addMessage('assistant','⚠️ I couldn\'t load the full report ('+e.message+'). You can still ask about the summary above, or open it in Google Docs.');
+    if(btn){btn.disabled=false;btn.innerHTML='💬 Discuss this report in Chat';}
+  }
+  var ci=document.getElementById('chatInput');if(ci)ci.focus();
+}
+
 // Play Kokoro TTS for any text — used by per-message Speak button + voice-reply autoplay
 var _ttsAudio = null;
 function speakMessage(text, btn){
@@ -1121,9 +1165,10 @@ async function sendMessage(){
       var jobId=startData.job_id;
       var data=await new Promise(function(resolve,reject){var poll=setInterval(async function(){try{var sr=await fetch('/api/agents/status/'+jobId);var sd=await sr.json();if(sd.status!=='running'){clearInterval(poll);resolve(sd)}}catch(pe){clearInterval(poll);reject(pe)}},4000)});
       clearInterval(ticker);if(statusEl)statusEl.parentElement.remove();
-      var resultMsg;
-      if(data.status==='complete'){var result=data.result||'';var docMatch=result.match(/https:\/\/docs\.google\.com\/\S+/);if(docMatch){var summary=result.replace(docMatch[0],'').trim();if(!summary)summary='Your report has been generated and saved to Google Docs.';resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+summary+'\n\n[Open in Google Docs]('+docMatch[0]+')'}else{resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+result}}else{resultMsg='\u274C Agent error: '+(data.error||'Unknown error')}
-      addMessage('assistant',resultMsg);chatHist.push({role:'assistant',content:resultMsg});saveMessages([{role:'assistant',content:resultMsg}])
+      var resultMsg;var reportDocUrl=null;
+      if(data.status==='complete'){var result=data.result||'';var docMatch=result.match(/https:\/\/docs\.google\.com\/\S+/);if(docMatch){reportDocUrl=docMatch[0].replace(/[)\].,]+$/,'');var summary=result.replace(docMatch[0],'').trim();if(!summary)summary='Your report has been generated and saved to Google Docs.';resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+summary+'\n\n[Open in Google Docs]('+reportDocUrl+')'}else{resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+result}}else{resultMsg='\u274C Agent error: '+(data.error||'Unknown error')}
+      addMessage('assistant',resultMsg);chatHist.push({role:'assistant',content:resultMsg});saveMessages([{role:'assistant',content:resultMsg}]);
+      if(reportDocUrl)appendDiscussButton(reportDocUrl)
     }catch(e){clearInterval(ticker);updateStatus('Agent error: '+e.message)}
     isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return
   }

--- a/codec_chat.html
+++ b/codec_chat.html
@@ -648,13 +648,13 @@ function regenerateResponse(btn){
       for(var li=0;li<lines.length;li++){
         var line=lines[li].trim();if(!line.startsWith('data: '))continue;var payload=line.substring(6);
         if(payload==='[DONE]')break;
-        try{var j=JSON.parse(payload);if(j.skill){showToast('⚡ Skill: '+j.skill)}if(j.think){thinkText+=j.think;if(thoughtsEnabled){var tp=ensureThinkPanel(div,'🧠 Thinking…',true);setThinkText(tp,thinkText);scrollBottom()}}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.error){fullText+='\nError: '+j.error}}catch(pe){}
+        try{var j=JSON.parse(payload);if(j.skill){showToast('⚡ Skill: '+j.skill)}if(j.think){thinkText+=j.think;if(thoughtsEnabled){var tp=ensureThinkPanel(div,'Thinking…',true);setThinkText(tp,thinkText);scrollBottom()}}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.error){fullText+='\nError: '+j.error}}catch(pe){}
       }
     }
     if(fullText){
       // Replace the streaming div with a proper message (with copy+regen buttons)
       div.remove();var md=addMessage('assistant',fullText);
-      if(thoughtsEnabled&&thinkText.trim()&&md){var fp=ensureThinkPanel(md,'🧠 Train of thought',false);setThinkText(fp,thinkText.trim())}
+      if(thoughtsEnabled&&thinkText.trim()&&md){var fp=ensureThinkPanel(md,'Train of thought',false);setThinkText(fp,thinkText.trim())}
       chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])
     }else{bubble.innerHTML='<em style="color:var(--text-dim)">No response</em>'}
     _currentAbort=null;isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false
@@ -689,7 +689,7 @@ function toggleThoughts(){
   var btn=document.getElementById('thoughtsToggle');
   btn.classList.toggle('active',thoughtsEnabled);
   btn.title=thoughtsEnabled?'Train of thought ON — showing reasoning & steps':"Show CODEC's train of thought (off by default)";
-  showToast(thoughtsEnabled?'🧠 Train of thought ON':'Train of thought OFF');
+  showToast(thoughtsEnabled?'Train of thought ON':'Train of thought OFF');
 }
 
 // Build (once) and return a collapsible thoughts panel inside `container`,
@@ -698,7 +698,7 @@ function ensureThinkPanel(container,label,open){
   var p=container.querySelector('.think-panel');
   if(p)return p;
   p=document.createElement('details');p.className='think-panel';if(open)p.open=true;
-  var s=document.createElement('summary');s.textContent=label||'🧠 Train of thought';
+  var s=document.createElement('summary');s.textContent=label||'Train of thought';
   var body=document.createElement('div');body.className='think-body';
   p.appendChild(s);p.appendChild(body);
   var bubble=container.querySelector('.msg-bubble');
@@ -797,7 +797,7 @@ async function loadSidebarHistory(){
     el.innerHTML=data.map(function(s){
       var ts=s.updated_at?new Date(s.updated_at).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}):'';
       var active=s.id===sessionId?' style="background:var(--surface-2)"':'';
-      return'<div class="sidebar-item"'+active+'><div class="si-main" onclick="loadSession(\''+s.id+'\')"><div class="si-title">'+escHtml(s.title)+'</div><div class="si-time">'+ts+'</div></div><button class="si-del" onclick="deleteSession(event,\''+s.id+'\')" title="Delete">🗑</button></div>'
+      return'<div class="sidebar-item"'+active+'><div class="si-main" onclick="loadSession(\''+s.id+'\')"><div class="si-title">'+escHtml(s.title)+'</div><div class="si-time">'+ts+'</div></div><button class="si-del" onclick="deleteSession(event,\''+s.id+'\')" title="Delete"><svg class="ico ico-sm" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg></button></div>'
     }).join('')
   }catch(e){el.innerHTML='<div style="padding:16px;color:var(--text-dim);font-size:12px">Error loading.</div>'}
 }
@@ -875,7 +875,7 @@ function appendDiscussButton(docUrl){
   wrap.className='msg assistant';wrap.style.animation='none';
   var b=document.createElement('button');
   b.className='discuss-report-btn';
-  b.innerHTML='💬 Discuss this report in Chat';
+  b.innerHTML='<svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Discuss this report in Chat';
   b.onclick=function(){discussReportInChat(docUrl,b)};
   var bubble=document.createElement('div');bubble.className='msg-bubble';
   bubble.style.background='transparent';bubble.style.padding='0';bubble.style.boxShadow='none';
@@ -886,7 +886,7 @@ function appendDiscussButton(docUrl){
 }
 
 async function discussReportInChat(docUrl, btn){
-  if(btn){btn.disabled=true;btn.innerHTML='⏳ Loading report&hellip;';}
+  if(btn){btn.disabled=true;btn.innerHTML='Loading report&hellip;';}
   setMode('chat');
   try{
     var r=await fetch('/api/gdoc/read?url='+encodeURIComponent(docUrl));
@@ -897,11 +897,11 @@ async function discussReportInChat(docUrl, btn){
     var ctx='Here is the full text of the report we just generated'+(d.title?(' ("'+d.title+'")'):'')+'. Use it to answer my follow-up questions about it:\n\n'+d.text+(d.truncated?'\n\n[report truncated for length]':'');
     chatHist.push({role:'user',content:ctx});
     chatHist.push({role:'assistant',content:'I\'ve loaded the full report and I\'m ready to discuss it.'});
-    addMessage('assistant','📄 **Loaded the full report** — ask me anything about it (key findings, a specific section, or say "summarize the main risks").');
-    if(btn){btn.innerHTML='✓ Report loaded into chat';}
+    addMessage('assistant','**Loaded the full report** — ask me anything about it (key findings, a specific section, or say "summarize the main risks").');
+    if(btn){btn.innerHTML='Report loaded into chat';}
   }catch(e){
-    addMessage('assistant','⚠️ I couldn\'t load the full report ('+e.message+'). You can still ask about the summary above, or open it in Google Docs.');
-    if(btn){btn.disabled=false;btn.innerHTML='💬 Discuss this report in Chat';}
+    addMessage('assistant','**Couldn\'t load the full report** ('+e.message+'). You can still ask about the summary above, or open it in Google Docs.');
+    if(btn){btn.disabled=false;btn.innerHTML='<svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Discuss this report in Chat';}
   }
   var ci=document.getElementById('chatInput');if(ci)ci.focus();
 }
@@ -1093,7 +1093,7 @@ function stopGeneration(){
     var jid=_agentJobId;_agentJobId=null;
     if(jid){fetch('/api/agents/cancel/'+jid,{method:'POST'}).catch(function(){})}
     var st=document.getElementById('agentStatus');if(st&&st.parentElement)st.parentElement.remove();
-    addMessage('assistant','⏹ **Task stopped.** The agent run was cancelled. Any work already finished on the server may still be saved.');
+    addMessage('assistant','**Task stopped.** The agent run was cancelled. Any work already finished on the server may still be saved.');
     hideTyping();_showSend();isProcessing=false;document.getElementById('sendBtn').disabled=false;return
   }
   if(_currentAbort){_currentAbort.abort();_currentAbort=null}
@@ -1219,18 +1219,18 @@ async function sendMessage(){
 
     isProcessing=true;document.getElementById('sendBtn').disabled=true;_showStop();
     var crewHints={'deep_research':'Searching the web \u2192 analyzing sources \u2192 writing report...','daily_briefing':'Checking calendar, weather, news...','trip_planner':'Researching destination \u2192 building itinerary...','competitor_analysis':'Scouting competitors \u2192 writing analysis...','email_handler':'Reading inbox \u2192 drafting replies...','custom':'Running custom agent...'};
-    updateStatus('\u23F3 Starting '+(crewLabels[crew]||crew)+'&hellip;\n\n'+(crewHints[crew]||'Running agent...'));
+    updateStatus('Starting '+(crewLabels[crew]||crew)+'&hellip;\n\n'+(crewHints[crew]||'Running agent...'));
 
     var payload={crew:crew};
     if(crew==='custom'){payload.agent_name=document.getElementById('agentName').value||'Custom Agent';payload.role=document.getElementById('agentRole').value||'';payload.tools=getSelectedTools();payload.max_iterations=parseInt(document.getElementById('agentMaxIter').value||'8');payload.task=researchText}else{if(['deep_research','competitor_analysis'].includes(crew))payload.topic=researchText;if(crew==='trip_planner')payload.destination=researchText}
 
     var elapsed=0;
-    _agentTicker=setInterval(function(){elapsed+=5;updateStatus('\u23F3 '+crewLabels[crew]+' running&hellip; ('+elapsed+'s)  \u2014 tap \u23F9 to stop\n\n'+(crewHints[crew]||''))},5000);
+    _agentTicker=setInterval(function(){elapsed+=5;updateStatus(crewLabels[crew]+' running&hellip; ('+elapsed+'s)  \u2014 press Stop to cancel\n\n'+(crewHints[crew]||''))},5000);
 
     try{
       var r=await fetch('/api/agents/run',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
       var startData=await r.json();
-      if(!r.ok||!startData.job_id){clearInterval(_agentTicker);_agentTicker=null;updateStatus('\u274C Agent error: '+(startData.error||'Failed to start'));isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
+      if(!r.ok||!startData.job_id){clearInterval(_agentTicker);_agentTicker=null;updateStatus('Agent error: '+(startData.error||'Failed to start'));isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       var jobId=startData.job_id;_agentJobId=jobId;
       var data=await new Promise(function(resolve,reject){_agentPoll=setInterval(async function(){try{var sr=await fetch('/api/agents/status/'+jobId);var sd=await sr.json();
         // Train-of-thought: stream the crew's live step log into a panel above the status.
@@ -1240,7 +1240,7 @@ async function sendMessage(){
       // User pressed Stop after the crew already reported terminal \u2014 honor it.
       if(data.status==='cancelled'){isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       var resultMsg;var reportDocUrl=null;
-      if(data.status==='complete'){var result=data.result||'';var docMatch=result.match(/https:\/\/docs\.google\.com\/\S+/);if(docMatch){reportDocUrl=docMatch[0].replace(/[)\].,]+$/,'');var summary=result.replace(docMatch[0],'').trim();if(!summary)summary='Your report has been generated and saved to Google Docs.';resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+summary+'\n\n[Open in Google Docs]('+reportDocUrl+')'}else{resultMsg='\u2705 **'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+result}}else{resultMsg='\u274C Agent error: '+(data.error||'Unknown error')}
+      if(data.status==='complete'){var result=data.result||'';var docMatch=result.match(/https:\/\/docs\.google\.com\/\S+/);if(docMatch){reportDocUrl=docMatch[0].replace(/[)\].,]+$/,'');var summary=result.replace(docMatch[0],'').trim();if(!summary)summary='Your report has been generated and saved to Google Docs.';resultMsg='**'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+summary+'\n\n[Open in Google Docs]('+reportDocUrl+')'}else{resultMsg='**'+crewLabels[crew]+' Complete!** ('+data.elapsed_seconds+'s)\n\n'+result}}else{resultMsg='Agent error: '+(data.error||'Unknown error')}
       var amd=addMessage('assistant',resultMsg);chatHist.push({role:'assistant',content:resultMsg});saveMessages([{role:'assistant',content:resultMsg}]);
       // Persist the crew's step log on the final message when Thoughts is on.
       if(thoughtsEnabled&&data.progress&&data.progress.length&&amd){var pp=ensureThinkPanel(amd,'\uD83E\uDDE0 Train of thought ('+data.progress.length+' steps)',false);renderThinkSteps(pp,data.progress)}
@@ -1287,10 +1287,10 @@ async function sendMessage(){
           if(!line.startsWith('data: '))continue;
           var payload=line.substring(6);
           if(payload==='[DONE]')break;
-          try{var j=JSON.parse(payload);if(j.think){thinkText+=j.think;if(thoughtsEnabled){var tp2=ensureThinkPanel(div,'🧠 Thinking…',true);setThinkText(tp2,thinkText);scrollBottom()}}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.escalate_project){renderEscalateChip(j.escalate_project,text)}if(j.error){fullText+='\n\nError: '+j.error}}catch(pe){}
+          try{var j=JSON.parse(payload);if(j.think){thinkText+=j.think;if(thoughtsEnabled){var tp2=ensureThinkPanel(div,'Thinking…',true);setThinkText(tp2,thinkText);scrollBottom()}}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.escalate_project){renderEscalateChip(j.escalate_project,text)}if(j.error){fullText+='\n\nError: '+j.error}}catch(pe){}
         }
       }
-      if(fullText){div.remove();var md2=addMessage('assistant',fullText);if(thoughtsEnabled&&thinkText.trim()&&md2){var fp2=ensureThinkPanel(md2,'🧠 Train of thought',false);setThinkText(fp2,thinkText.trim())}chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])}
+      if(fullText){div.remove();var md2=addMessage('assistant',fullText);if(thoughtsEnabled&&thinkText.trim()&&md2){var fp2=ensureThinkPanel(md2,'Train of thought',false);setThinkText(fp2,thinkText.trim())}chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])}
       else{bubble.innerHTML='<em style="color:var(--text-dim)">No response</em>'}
     }
   }catch(e){

--- a/codec_chat_stream.py
+++ b/codec_chat_stream.py
@@ -52,6 +52,16 @@ class SkillTagBuffer:
         # caller's blank-bubble fallback distinguish "all output was dropped
         # tool tags" from "the model produced nothing at all" (2026-07 fix).
         self.tags_resolved = 0
+        # Train-of-thought side channel: <think> fragments captured for the
+        # caller to (optionally) surface. Draining is opt-in — the clean-text
+        # yields from feed() are identical whether or not anyone reads this.
+        self._think_out: list = []
+
+    def drain_think(self) -> list:
+        """Return + clear <think> fragments captured since the last drain."""
+        out = self._think_out
+        self._think_out = []
+        return out
 
     def _count(self, text: str) -> str:
         """Account visible chars (only non-empty), return the text unchanged.
@@ -65,17 +75,25 @@ class SkillTagBuffer:
         # ── <think>…</think> handling (cross-chunk) ──
         if "<think>" in token:
             self.in_think = True
-            before = token.split("<think>")[0]
+            parts = token.split("<think>", 1)
+            before = parts[0]
             if before:
                 yield before          # emitted but NOT counted (faithful)
+            # Capture reasoning that shares this chunk (after the open tag).
+            if len(parts) > 1 and parts[1]:
+                self._think_out.append(parts[1])
             token = ""
         if self.in_think:
             if "</think>" in token:
                 self.in_think = False
-                after = token.split("</think>", 1)[-1]
+                head, after = token.split("</think>", 1)
+                if head:
+                    self._think_out.append(head)   # reasoning before the close
                 if after:
                     yield after       # emitted but NOT counted (faithful)
-            return                    # skip thinking content
+            elif token:
+                self._think_out.append(token)      # a pure reasoning chunk
+            return                    # skip thinking content from clean text
         if not token:
             return
 

--- a/codec_gdocs.py
+++ b/codec_gdocs.py
@@ -113,42 +113,50 @@ def _clean_topic_base(raw: str) -> str:
 
 
 def _smart_query(topic_base: str, positions: list, insert_idx: int) -> str:
+    """Build a Pexels query anchored to the REPORT topic and the SECTION heading.
+
+    Relevance fix (2026-07): the old version matched category buzzwords against
+    the section BODY text, which misfired constantly — a stray word like
+    "clinical" or "energy" in a sentence pulled a medical/energy stock photo into
+    an unrelated report. Now every query leads with the report topic, adds the
+    section's heading keywords, and only appends a category descriptor when the
+    signal is in the HEADING (a far more reliable cue)."""
     heading = ""
     for p in positions:
         if p["type"] in ("h2", "h3") and p["start"] <= insert_idx:
             heading = p["text"]
-    body = _section_body_text(positions, insert_idx)
-    ctx  = (heading + " " + body).lower()
-    kw   = _heading_keywords(heading)
+    tb = _clean_topic_base(topic_base)          # report topic (from title)
+    hk = _heading_keywords(heading)             # up to 2 salient heading words
+    hl = heading.lower()
 
-    # Clean noise from topic_base so queries don't contain dates/generic words
-    tb = _clean_topic_base(topic_base)
+    # Category descriptor keyed on the HEADING only (reliable), never replacing topic.
+    _CATS = [
+        (["privacy", "security", "encryption", "breach", "cyber"], "cybersecurity data protection"),
+        (["hardware", "chip", "processor", "npu", "gpu", "silicon", "semiconductor"], "computer hardware technology"),
+        (["market", "adoption", "growth", "forecast", "revenue", "statistic", "trend"], "business data analytics chart"),
+        (["energy", "power", "carbon", "sustainable", "climate", "green"], "sustainable energy"),
+        (["medical", "health", "clinical", "pharma", "drug"], "medical health technology"),
+        (["legal", "regulation", "regulatory", "compliance", "policy", "law"], "law regulation compliance"),
+        (["forex", "currency", "trading", "exchange"], "forex currency trading"),
+        (["ai", "artificial", "intelligence", "machine", "learning", "llm", "model", "neural"], "artificial intelligence technology"),
+    ]
+    descriptor = ""
+    for kws, desc in _CATS:
+        if any(k in hl for k in kws):
+            descriptor = desc
+            break
 
-    if any(w in ctx for w in ["statistic", "percent", "%", "billion", "million",
-                               "market", "adoption", "growth", "forecast"]):
-        return f"{tb} data analytics business" if tb else "financial data analytics business"
-    if any(w in ctx for w in ["hardware", "chip", "processor", "npu", "gpu", "silicon"]):
-        return f"{tb} computer hardware chip" if tb else "computer hardware technology chip"
-    if any(w in ctx for w in ["privacy", "security", "encryption", "gdpr", "breach"]):
-        return f"{tb} cybersecurity data protection" if tb else "cybersecurity data protection"
-    if any(w in ctx for w in ["global", "enterprise", "fortune", "deployment"]):
-        return f"{tb} global enterprise technology" if tb else "global enterprise technology"
-    if any(w in ctx for w in ["energy", "power", "carbon", "sustainable", "green"]):
-        return f"{tb} sustainable energy environment" if tb else "sustainable energy environment"
-    if any(w in ctx for w in ["medical", "health", "drug", "clinical", "pharma"]):
-        return f"{tb} medical health technology" if tb else "medical health technology"
-    if any(w in ctx for w in ["legal", "regulatory", "law", "regulation", "executive order"]):
-        return f"{tb} law regulation compliance" if tb else "law regulation compliance"
-    if any(w in ctx for w in ["future", "forecast", "trend", "next", "emerging"]):
-        return f"{tb} future innovation technology" if tb else "future innovation technology"
-    if any(w in ctx for w in ["forex", "currency", "trading", "exchange rate"]):
-        return f"{tb} forex currency trading" if tb else "forex currency trading markets"
-    if any(w in ctx for w in ["ai", "artificial intelligence", "machine learning", "llm", "gpt"]):
-        return f"{tb} artificial intelligence technology" if tb else "artificial intelligence technology"
-    if kw:
-        return f"{tb} {kw}" if tb else f"professional business {kw}"
-    # Fallback: use cleaned base or a professional default
-    return f"{tb} technology business" if tb else "global business technology professional"
+    parts = []
+    if tb:
+        parts.append(tb)
+    if hk and hk.lower() not in (tb or "").lower():
+        parts.append(hk)
+    if descriptor:
+        parts.append(descriptor)
+    q = " ".join(parts).strip()
+    if q:
+        return q
+    return f"{tb} professional business" if tb else "global business technology professional"
 
 
 def _find_image_positions(positions: list) -> tuple:
@@ -235,12 +243,8 @@ def _parse_markdown(content: str) -> list:
                 table_lines.append(cells)
                 i += 1
             if table_lines:
-                header = table_lines[0]
-                header_text = "   ".join(_strip_inline_md(c) for c in header)
-                blocks.append({"text": header_text, "type": "table_header"})
-                for row in table_lines[1:]:
-                    row_text = "   ".join(_strip_inline_md(c) for c in row)
-                    blocks.append({"text": row_text, "type": "table_row"})
+                rows = [[_strip_inline_md(c) for c in row] for row in table_lines]
+                blocks.append({"type": "table", "rows": rows, "text": ""})
             continue
 
         # ── Bullet points ──
@@ -264,6 +268,153 @@ def _parse_markdown(content: str) -> list:
         i += 1
 
     return blocks
+
+
+# ── Real Google Docs tables ─────────────────────────────────────────────────
+# Markdown tables are inserted into the text as a one-line sentinel paragraph
+# (⟦TABLE_n⟧). After the main text + images are laid down, we upgrade each
+# sentinel into a native Docs table. Sentinels are located by text search (so
+# they survive every prior index shift) and processed bottom-to-top. Each
+# upgrade is independently guarded: on any failure the sentinel is replaced with
+# readable flattened text, so a report never ships with a raw ⟦TABLE_n⟧ marker.
+def _table_marker(n: int) -> str:
+    return f"⟦TABLE_{n}⟧"
+
+
+def _find_marker(svc, doc_id: str, marker: str):
+    """Return (start, end) index range of `marker`'s text, or None."""
+    doc = svc.documents().get(documentId=doc_id).execute()
+    for el in doc.get("body", {}).get("content", []):
+        para = el.get("paragraph")
+        if not para:
+            continue
+        for pe in para.get("elements", []):
+            tr = pe.get("textRun")
+            if not tr:
+                continue
+            content = tr.get("content", "")
+            off = content.find(marker)
+            if off != -1:
+                s = pe["startIndex"] + off
+                return (s, s + len(marker))
+    return None
+
+
+def _replace_marker_with_text(svc, doc_id: str, marker: str, text: str):
+    """Fallback: swap the sentinel for plain text (never leave a raw marker)."""
+    loc = _find_marker(svc, doc_id, marker)
+    if not loc:
+        return
+    s, e = loc
+    reqs = [{"deleteContentRange": {"range": {"startIndex": s, "endIndex": e}}}]
+    if text:
+        reqs.append({"insertText": {"location": {"index": s}, "text": text}})
+    svc.documents().batchUpdate(documentId=doc_id, body={"requests": reqs}).execute()
+
+
+def _populate_table(svc, doc_id: str, near_idx: int, rows: list, orange, dark):
+    """Fill the freshly-inserted table's cells (bottom-to-top) + style header."""
+    doc = svc.documents().get(documentId=doc_id).execute()
+    table_el = None
+    for el in doc.get("body", {}).get("content", []):
+        if el.get("table") and el.get("startIndex", 0) >= near_idx - 1:
+            table_el = el
+            break
+    if not table_el:
+        return
+    trows = table_el["table"].get("tableRows", [])
+    inserts = []  # (cell_start_index, text)
+    for r, trow in enumerate(trows):
+        for c, cell in enumerate(trow.get("tableCells", [])):
+            cont = cell.get("content", [])
+            if not cont:
+                continue
+            cell_start = cont[0].get("startIndex")
+            if cell_start is None:
+                continue
+            text = rows[r][c] if (r < len(rows) and c < len(rows[r])) else ""
+            if text:
+                inserts.append((cell_start, text))
+    # Bottom-to-top so earlier inserts don't shift later cell indices.
+    inserts.sort(key=lambda x: x[0], reverse=True)
+    reqs = [{"insertText": {"location": {"index": idx}, "text": txt}}
+            for idx, txt in inserts]
+    if reqs:
+        svc.documents().batchUpdate(documentId=doc_id, body={"requests": reqs}).execute()
+
+    # Header styling pass (best-effort; re-fetch for post-insert indices).
+    try:
+        doc2 = svc.documents().get(documentId=doc_id).execute()
+        tbl2 = None
+        for el in doc2.get("body", {}).get("content", []):
+            if el.get("table") and el.get("startIndex", 0) >= near_idx - 1:
+                tbl2 = el
+                break
+        if not tbl2:
+            return
+        style_reqs = []
+        header_cells = tbl2["table"]["tableRows"][0].get("tableCells", [])
+        for cell in header_cells:
+            # Shade header cell background.
+            style_reqs.append({"updateTableCellStyle": {
+                "tableCellStyle": {"backgroundColor": {"color": {"rgbColor": orange}}},
+                "fields": "backgroundColor",
+                "tableCellLocation": {
+                    "tableStartLocation": {"index": tbl2["startIndex"]},
+                    "rowIndex": 0,
+                    "columnIndex": header_cells.index(cell),
+                },
+            }})
+            # Bold + white header text.
+            for ce in cell.get("content", []):
+                pel = ce.get("paragraph", {}).get("elements", [])
+                for x in pel:
+                    tr = x.get("textRun")
+                    if tr and tr.get("content", "").strip():
+                        style_reqs.append({"updateTextStyle": {
+                            "range": {"startIndex": x["startIndex"], "endIndex": x["endIndex"] - 1},
+                            "textStyle": {"bold": True,
+                                          "foregroundColor": {"color": {"rgbColor": {"red": 1, "green": 1, "blue": 1}}}},
+                            "fields": "bold,foregroundColor",
+                        }})
+        if style_reqs:
+            svc.documents().batchUpdate(documentId=doc_id, body={"requests": style_reqs}).execute()
+    except Exception as e:
+        print(f"[GDocs] table header styling skipped: {e}")
+
+
+def _insert_real_tables(svc, doc_id: str, tables: list, orange, dark):
+    """Upgrade every ⟦TABLE_n⟧ sentinel into a native Docs table."""
+    for t in range(len(tables) - 1, -1, -1):
+        rows = tables[t]
+        marker = _table_marker(t)
+        if not rows:
+            try:
+                _replace_marker_with_text(svc, doc_id, marker, "")
+            except Exception:
+                pass
+            continue
+        n_rows = len(rows)
+        n_cols = max(len(r) for r in rows)
+        try:
+            loc = _find_marker(svc, doc_id, marker)
+            if not loc:
+                continue
+            s, e = loc
+            # Delete the sentinel text, then insert an empty table in its place.
+            svc.documents().batchUpdate(documentId=doc_id, body={"requests": [
+                {"deleteContentRange": {"range": {"startIndex": s, "endIndex": e}}},
+                {"insertTable": {"location": {"index": s}, "rows": n_rows, "columns": n_cols}},
+            ]}).execute()
+            _populate_table(svc, doc_id, s, rows, orange, dark)
+            print(f"[GDocs] table {t}: rendered {n_rows}x{n_cols} native table")
+        except Exception as ex:
+            print(f"[GDocs] table {t} upgrade failed ({ex}); using text fallback")
+            try:
+                flat = "\n".join("   ".join(r) for r in rows)
+                _replace_marker_with_text(svc, doc_id, marker, flat)
+            except Exception:
+                pass
 
 
 def create_google_doc(title: str, content: str) -> str | None:
@@ -317,7 +468,12 @@ def create_google_doc(title: str, content: str) -> str | None:
         full_text = ""
         positions = []
         idx       = 1
+        tables    = []   # rows per markdown table, upgraded to native tables last
         for block in blocks:
+            if block.get("type") == "table":
+                # Reserve a one-line sentinel paragraph; real table swapped in later.
+                tables.append(block.get("rows") or [])
+                block = {"type": "body", "text": _table_marker(len(tables) - 1)}
             line = block["text"] + "\n"
             positions.append({
                 "start": idx, "end": idx + len(line),
@@ -539,8 +695,10 @@ def create_google_doc(title: str, content: str) -> str | None:
             "social media posts", "code review", "email",
         ])
         if _skip_images:
+            if tables:
+                _insert_real_tables(svc, doc_id, tables, ORANGE, DARK)
             print(f"[GDocs] Skipping images for: {title}")
-            print(f"[GDocs] Created: {doc_url} (0 images)")
+            print(f"[GDocs] Created: {doc_url} (0 images, {len(tables)} tables)")
             return doc_url
 
         hero_idx, additional_idxs = _find_image_positions(positions)
@@ -607,7 +765,11 @@ def create_google_doc(title: str, content: str) -> str | None:
         if img_reqs:
             svc.documents().batchUpdate(documentId=doc_id, body={"requests": img_reqs}).execute()
 
-        print(f"[GDocs] Created: {doc_url} ({len(insert_points)} images)")
+        # ── Batch 3: upgrade markdown-table sentinels into native tables ──
+        if tables:
+            _insert_real_tables(svc, doc_id, tables, ORANGE, DARK)
+
+        print(f"[GDocs] Created: {doc_url} ({len(insert_points)} images, {len(tables)} tables)")
         return doc_url
 
     except Exception as e:

--- a/codec_gdocs.py
+++ b/codec_gdocs.py
@@ -614,3 +614,61 @@ def create_google_doc(title: str, content: str) -> str | None:
         print(f"[GDocs] Error: {e}")
         import traceback; traceback.print_exc()
         return None
+
+
+def _doc_id_from(url_or_id: str) -> str | None:
+    """Extract a Google Doc ID from a full docs URL or accept a bare ID."""
+    if not url_or_id:
+        return None
+    s = url_or_id.strip()
+    m = re.search(r"/document/d/([a-zA-Z0-9_-]+)", s)
+    if m:
+        return m.group(1)
+    # Bare ID (Google Doc IDs are long alphanumeric strings with - and _)
+    if re.fullmatch(r"[a-zA-Z0-9_-]{20,}", s):
+        return s
+    return None
+
+
+def read_google_doc_text(url_or_id: str, max_chars: int = 60000) -> dict | None:
+    """
+    Read the plain-text body of a Google Doc the CODEC user owns/can access.
+    Accepts a full docs URL or a bare doc ID. Uses the same Google OAuth as
+    create_google_doc. Returns {"title", "text", "truncated"} or None on failure.
+    Used by the chat "Discuss this report" handoff so chat-mode CODEC can talk
+    about a report it generated in agent mode (the full report lives in the Doc,
+    not in the short chat summary).
+    """
+    from googleapiclient.discovery import build
+    from codec_google_auth import get_credentials
+
+    doc_id = _doc_id_from(url_or_id)
+    if not doc_id:
+        print(f"[GDocs] read: could not parse doc id from {url_or_id!r}")
+        return None
+    try:
+        creds = get_credentials()
+        svc = build("docs", "v1", credentials=creds)
+        doc = svc.documents().get(documentId=doc_id).execute()
+        title = doc.get("title", "Untitled")
+        text = ""
+        for element in doc.get("body", {}).get("content", []):
+            # Paragraph text
+            for para in element.get("paragraph", {}).get("elements", []):
+                text += para.get("textRun", {}).get("content", "")
+            # Table text (reports render comparison tables)
+            for row in element.get("table", {}).get("tableRows", []):
+                cells = []
+                for cell in row.get("tableCells", []):
+                    cell_txt = ""
+                    for ce in cell.get("content", []):
+                        for pe in ce.get("paragraph", {}).get("elements", []):
+                            cell_txt += pe.get("textRun", {}).get("content", "")
+                    cells.append(cell_txt.strip())
+                if any(cells):
+                    text += " | ".join(cells) + "\n"
+        truncated = len(text) > max_chars
+        return {"title": title, "text": text[:max_chars], "truncated": truncated}
+    except Exception as e:
+        print(f"[GDocs] read error: {e}")
+        return None

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -127,7 +127,12 @@ async def run_agent_crew(request: Request):
                 from codec_agents import run_crew
                 result = loop.run_until_complete(run_crew(crew_name, callback=on_progress, **body))
             _agent_jobs[job_id].update(result)
-            _agent_jobs[job_id]["status"] = result.get("status", "complete")
+            # If the user pressed Stop while the crew was still running, keep the
+            # cancelled status rather than overwriting it with a late result.
+            if _agent_jobs.get(job_id, {}).get("cancel_requested"):
+                _agent_jobs[job_id]["status"] = "cancelled"
+            else:
+                _agent_jobs[job_id]["status"] = result.get("status", "complete")
             _agent_jobs[job_id]["progress"] = progress_log
         except Exception as e:
             import traceback; traceback.print_exc()
@@ -147,6 +152,24 @@ async def agent_job_status(job_id: str):
     if not job:
         return JSONResponse({"error": "Job not found"}, status_code=404)
     return job
+
+
+@router.post("/api/agents/cancel/{job_id}")
+async def cancel_agent_job(job_id: str):
+    """Cooperatively cancel a running agent/crew job.
+
+    Crews run to completion in a daemon thread and can't be killed mid-run, so
+    this flags the job cancelled: the run thread checks the flag before writing
+    its final status, and status polls immediately see 'cancelled'. The chat UI
+    stops waiting as soon as this returns.
+    """
+    job = _agent_jobs.get(job_id)
+    if not job:
+        return JSONResponse({"error": "Job not found"}, status_code=404)
+    job["cancel_requested"] = True
+    if job.get("status") == "running":
+        job["status"] = "cancelled"
+    return {"job_id": job_id, "status": "cancelled"}
 
 
 @router.get("/api/agents/tools")

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -225,6 +225,30 @@ async def delete_custom_agent(request: Request):
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
+@router.get("/api/gdoc/read")
+async def read_gdoc(url: str = ""):
+    """Read the plain-text body of a Google Doc by URL or ID.
+
+    Powers the chat "Discuss this report" handoff: after Deep Research saves a
+    report to Google Docs, chat-mode CODEC fetches the full doc text here and
+    injects it as context so the user can talk about the report (the chat
+    summary alone omits the full body). Uses CODEC's existing Google OAuth.
+    """
+    if not url or not url.strip():
+        return JSONResponse({"error": "url required"}, status_code=400)
+    try:
+        from codec_gdocs import read_google_doc_text
+        doc = read_google_doc_text(url.strip())
+        if not doc:
+            return JSONResponse(
+                {"error": "Could not read that Google Doc (not found or no access)."},
+                status_code=404,
+            )
+        return doc
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
 # ── Phase 1 Step 3: AskUserQuestion reply path ──────────────────────────────
 # Per docs/PHASE1-STEP3-DESIGN.md §1.5. PWA + voice both POST here.
 # §1.7 strict-consent gate enforced inside codec_ask_user.submit_answer —

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -796,6 +796,10 @@ async def chat_completion(request: Request):
         # Dashboard chat & Vibe benefit from thinking mode (deeper answers).
         # Frontend can send thinking=false to override for speed.
         thinking = body.get("thinking", True)
+        # Train-of-thought reveal: when the frontend's Thoughts toggle is ON,
+        # also stream the model's <think> reasoning as separate SSE `think`
+        # events. Off by default → no think frames → identical to before.
+        show_thoughts = bool(body.get("show_thoughts", False))
 
         # A-12 (PR-3E-chat-stream): build the shared codec_llm args ONCE so the
         # stream + non-stream branches can't drift. top_p/frequency_penalty are
@@ -887,9 +891,15 @@ async def chat_completion(request: Request):
                             continue
                         for s in buf.feed(item):
                             yield _frame(s)
+                        if show_thoughts:
+                            for t in buf.drain_think():
+                                yield f"data: {json.dumps({'think': t})}\n\n"
                     # Stream ended ([DONE] or close): flush, then blank-bubble net.
                     for s in buf.finish():
                         yield _frame(s)
+                    if show_thoughts:
+                        for t in buf.drain_think():
+                            yield f"data: {json.dumps({'think': t})}\n\n"
                     if hit_token_cap:
                         yield _frame(
                             "\n\n⚠️ *Reply truncated — the model hit the "


### PR DESCRIPTION
Four demo-prep features + emoji cleanup.

## Features
1. **Agent → Chat handoff** — 'Discuss this report in Chat' button after Deep Research; switches to chat mode and loads the full Google Doc (new read_google_doc_text + GET /api/gdoc/read) so chat-CODEC can discuss it. Fixes the 'Job not found' from asking in Agents mode.
2. **Stop button** — cancels a running crew: stops the UI polling + POST /api/agents/cancel/{job_id}; run thread honors the flag so a late result can't override the stop.
3. **Train-of-thought toggle** — off by default; reveals model <think> reasoning (chat) and crew step log (Agent/Project) in a collapsible panel. Backend additive — clean-text stream byte-identical when off.
4. **Report polish (Option C)** — markdown tables render as native Google Docs tables (shaded header, guarded fallback); Pexels image queries anchored to report topic + heading (no more off-topic photos).

## Style
- Removed emoji from all new UI + the delete-chat trash-bin icon (line-SVG icons / plain text) per no-emoji product rule.

Verified: ruff clean, py_compile OK, node --check on inline JS, mock-tested the Docs table API sequence, SkillTagBuffer clean-text output byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)