### PR TITLE
fix(chat): restore reasoning scaffold — passes car-wash logic test + working reveal

### DIFF
--- a/codec_chat.html
+++ b/codec_chat.html
@@ -484,15 +484,25 @@ var SYS="You are *CODEC Deep Chat* \u2014 a J.A.R.V.I.S.-class AI running locall
 "Warm, sharp, and confident. You are not a chatbot \u2014 you are a trusted colleague with opinions, dry wit, and genuine helpfulness. Think J.A.R.V.I.S. loyalty with TARS humor. Deliver value first, personality second. Max 1 dry observation per response.\n\n" +
 "### WEB ACCESS\n" +
 "You have full web access. URLs shared by the user are auto-fetched and injected as [URL CONTENT: ...]. Search queries trigger live results injected as [WEB SEARCH RESULTS]. Cite sources naturally. Trust injected content as current reality.\n\n" +
-"### THINKING PROTOCOL\n" +
-"1. PROCESS: Analyze the request inside thinking tags before responding.\n" +
-"2. ADAPTIVE LOGIC:\n   - COMPLEX tasks (logic, math, coding, research): Plan approach in 3 steps max inside thinking tags.\n   - SIMPLE tasks: 1 sentence thinking, then answer.\n   - CHALLENGES: If the user doubts you, do one internal check then state your answer. Do NOT loop.\n3. OUTPUT: Close thinking tag, then respond directly.\n\n" +
 "### SKILLS & TOOLS\n" +
 "You have access to 56+ CODEC skills: Google Calendar, Gmail, Drive, Docs, Sheets, Tasks, Keep, Chrome browser automation, web search, file system, terminal commands, Philips Hue lights, screenshot OCR, and 12 autonomous agent crews (deep research, daily briefing, competitor analysis, trip planner, email handler, social media, code review, data analysis, content writer, meeting summarizer, invoice generator, project manager). When a task requires action \u2014 DO NOT simulate. EXECUTE via the appropriate skill.\n\n" +
 "### MEMORY\n" +
 "All conversations are saved to CODEC shared memory (FTS5 indexed SQLite) across ALL 9 products. Past conversations are automatically injected as [MEMORY] and [RECENT MEMORY] context blocks before your response. Use this data to answer questions about prior sessions, recall user preferences, and maintain continuity across voice, chat, and agent interactions. CRITICAL RULES: 1) NEVER echo or display the raw [MEMORY], [RECENT MEMORY], or [END MEMORY] blocks in your response \u2014 use the information naturally without showing the source data. 2) Never say you cannot remember or see previous conversations \u2014 your memory IS the injected context. 3) Summarize and reference past conversations naturally, as if you genuinely remember them.\n\n" +
 "### FORMATTING\n" +
-"Be concise, elegant, and useful. Use emoji strategically. For emphasis use CAPS or *asterisks*. For code use backticks. For long-form: use headers and structure.";
+"Be concise, elegant, and useful. Never use emoji. For emphasis use CAPS or *asterisks*. For code use backticks. For long-form: use headers and structure.";
+// ── Reasoning scaffold (Think mode). Tuned for the local 4-bit Qwen: forces a
+// dependency check so it stops giving glib surface answers (the "car wash" class
+// of trick). Model reasons in <thinking>, then emits "### FINAL ANSWER:"; the UI
+// hides the thinking (shown only in the reveal window) and displays the answer.
+var REASON_SCAFFOLD="\n\n### REASONING PROTOCOL\n" +
+"Your goal is accurate answers without getting stuck in loops.\n" +
+"1. PROCESS: Before your final response, analyze the request inside <thinking> tags. First identify what the user is actually trying to ACCOMPLISH, and check for any hidden physical or logical dependencies — things that must be true or present for the goal to work. Never give a glib surface answer that ignores them.\n" +
+"2. ADAPTIVE LOGIC:\n   - COMPLEX tasks (logic, math, coding): plan your approach in NO MORE than 3 steps inside the tags.\n   - CHALLENGES: if the user doubts you or says 'check online', DO NOT LOOP — do one quick internal check, then state your answer.\n   - SIMPLE tasks: keep <thinking> to 1 sentence.\n" +
+"3. OUTPUT: close the tag with </thinking>, then a new line with exactly \"### FINAL ANSWER:\" followed by your response.\n" +
+"Never reveal your thinking outside the tags.";
+var CONCISE_MODE="\n\n### RESPONSE STYLE\nAnswer directly and concisely. Do not use <thinking> tags or show reasoning — get straight to the point.";
+// System prompt varies by Think toggle: scaffolded reasoning vs fast/direct.
+function buildSystem(){return SYS+(thinkingEnabled?REASON_SCAFFOLD:CONCISE_MODE);}
 var chatHist=[],isProcessing=false,isRecording=false,recognition=null;
 var pendingFiles=[];
 var sessionId=null;
@@ -634,13 +644,13 @@ function regenerateResponse(btn){
   // Re-run the chat call
   isProcessing=true;document.getElementById('sendBtn').disabled=true;_showStop();showTyping();
   _currentAbort=new AbortController();
-  var msgs=[{role:'system',content:SYS}].concat(chatHist);
-  fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:thinkingEnabled,show_thoughts:thinkingEnabled,stream:true}),signal:_currentAbort.signal}).then(async function(r){
+  var msgs=[{role:'system',content:buildSystem()}].concat(chatHist);
+  fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:false,show_thoughts:false,stream:true}),signal:_currentAbort.signal}).then(async function(r){
     if(r.status===401||r.status===403){hideTyping();addMessage('assistant','Session expired — redirecting to login...');setTimeout(function(){window.location.href='/auth'},1500);isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
     hideTyping();
-    var reader=r.body.getReader();var decoder=new TextDecoder();var fullText='';var thinkText='';var bubbleId='stream_'+genId();
+    var reader=r.body.getReader();var decoder=new TextDecoder();var raw='';var bubbleId='stream_'+genId();
     var div=document.createElement('div');div.className='msg assistant';div.innerHTML='<div class="msg-bubble" id="'+bubbleId+'"><div class="thinking-indicator"><div class="thinking-dots"><span></span><span></span><span></span></div>CODEC is thinking...</div></div>';document.getElementById('messages').appendChild(div);
-    var bubble=document.getElementById(bubbleId);var buf='';var firstToken=true;
+    var bubble=document.getElementById(bubbleId);var buf='';var answerStarted=false;
     while(true){
       var chunk=await reader.read();
       if(chunk.done)break;
@@ -649,14 +659,15 @@ function regenerateResponse(btn){
       for(var li=0;li<lines.length;li++){
         var line=lines[li].trim();if(!line.startsWith('data: '))continue;var payload=line.substring(6);
         if(payload==='[DONE]')break;
-        try{var j=JSON.parse(payload);if(j.skill){showToast('Skill: '+j.skill)}if(j.think){thinkText+=j.think;var tp=makeToT(div,'Reveal train of thought',true);totPush(tp,j.think);scrollBottom()}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.error){fullText+='\nError: '+j.error}}catch(pe){}
+        try{var j=JSON.parse(payload);if(j.skill){showToast('Skill: '+j.skill)}if(j.token){raw+=j.token;var ps=parseScaffold(raw);if(thinkingEnabled&&ps.think){var tp=makeToT(div,'Reveal train of thought',true);totSet(tp,ps.think)}if(ps.answer){if(!answerStarted){bubble.innerHTML='';answerStarted=true}bubble.innerHTML=formatMsg(ps.answer)}scrollBottom()}if(j.error){raw+='\nError: '+j.error}}catch(pe){}
       }
     }
-    if(fullText){
-      // Replace the streaming div with a proper message (with copy+regen buttons)
-      div.remove();var md=addMessage('assistant',fullText);
-      if(thinkText.trim()&&md){var fp=makeToT(md,'Train of thought',false);totSet(fp,thinkText.trim())}
-      chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])
+    var pf=parseScaffold(raw);
+    var answer=(pf.answer&&pf.answer.trim())||raw.replace(/<thinking>[\s\S]*?<\/thinking>/i,'').replace(/###\s*FINAL ANSWER:?/i,'').trim()||raw;
+    if(answer){
+      div.remove();var md=addMessage('assistant',answer);
+      if(thinkingEnabled&&pf.think&&pf.think.trim()&&md){var fp=makeToT(md,'Train of thought',false);totSet(fp,pf.think.trim())}
+      chatHist.push({role:'assistant',content:answer});saveMessages([{role:'assistant',content:answer}])
     }else{bubble.innerHTML='<em style="color:var(--text-dim)">No response</em>'}
     _currentAbort=null;isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false
   }).catch(function(e){
@@ -723,6 +734,26 @@ function stepsToText(steps){
 function totFinalize(tot,label){
   if(!tot)return;tot.classList.remove('tot-live');
   var l=tot.querySelector('.tot-label');if(l&&label)l.textContent=label;
+}
+// Parse the Think-mode scaffold output into {think, answer} for streaming render.
+// Model emits: <thinking>reasoning</thinking>\n### FINAL ANSWER:\nanswer
+// While thinking is still open, answer stays empty (bubble keeps its indicator).
+function parseScaffold(raw){
+  var think='',answer='',open=false;
+  var oi=raw.indexOf('<thinking>');
+  if(oi!==-1){
+    var ci=raw.indexOf('</thinking>',oi);
+    if(ci!==-1){
+      think=raw.slice(oi+10,ci);
+      var rest=raw.slice(ci+11);
+      var fm=rest.match(/###\s*FINAL ANSWER:?/i);
+      answer=fm?rest.slice(fm.index+fm[0].length):'';   // wait for the marker before showing
+    }else{think=raw.slice(oi+10);open=true;}            // thinking still streaming
+  }else{
+    var fm2=raw.match(/###\s*FINAL ANSWER:?/i);
+    answer=fm2?raw.slice(fm2.index+fm2[0].length):raw;  // no scaffold (concise mode) -> raw
+  }
+  return {think:think,answer:answer,open:open};
 }
 
 function genId(){return Date.now().toString(36)+Math.random().toString(36).substr(2,5)}
@@ -1269,21 +1300,21 @@ async function sendMessage(){
   isProcessing=true;document.getElementById('sendBtn').disabled=true;_showStop();showTyping();
   _currentAbort=new AbortController();
   try{
-    var msgs=[{role:'system',content:SYS}].concat(chatHist);var r;
+    var msgs=[{role:'system',content:buildSystem()}].concat(chatHist);var r;
     if(hasImages){
       r=await fetch('/api/vision',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt:msgs[msgs.length-1].content||'Describe this image in detail',image:imageData[0]}),signal:_currentAbort.signal});
       var data=await r.json();hideTyping();
       if(data.response){addMessage('assistant',data.response);chatHist.push({role:'assistant',content:data.response});saveMessages([{role:'assistant',content:data.response}])}
       else{addMessage('assistant','Error: '+(data.error||'No response'))}
     } else {
-      r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:thinkingEnabled,show_thoughts:thinkingEnabled,stream:true}),signal:_currentAbort.signal});
+      r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:false,show_thoughts:false,stream:true}),signal:_currentAbort.signal});
       if(r.status===401||r.status===403){hideTyping();addMessage('assistant','Session expired — redirecting to login...');setTimeout(function(){window.location.href='/auth'},1500);isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       hideTyping();
-      // SSE streaming — render tokens as they arrive
-      var reader=r.body.getReader();var decoder=new TextDecoder();var fullText='';var thinkText='';var bubbleId='stream_'+genId();
+      // SSE streaming — parse the Think-mode scaffold as tokens arrive
+      var reader=r.body.getReader();var decoder=new TextDecoder();var raw='';var bubbleId='stream_'+genId();
       var es=document.getElementById('emptyState');if(es)es.remove();
       var div=document.createElement('div');div.className='msg assistant';div.innerHTML='<div class="msg-bubble" id="'+bubbleId+'"><div class="thinking-indicator"><div class="thinking-dots"><span></span><span></span><span></span></div>CODEC is thinking...</div></div>';document.getElementById('messages').appendChild(div);
-      var bubble=document.getElementById(bubbleId);var buf='';var firstToken=true;
+      var bubble=document.getElementById(bubbleId);var buf='';var answerStarted=false;
       while(true){
         var chunk=await reader.read();
         if(chunk.done)break;
@@ -1294,10 +1325,12 @@ async function sendMessage(){
           if(!line.startsWith('data: '))continue;
           var payload=line.substring(6);
           if(payload==='[DONE]')break;
-          try{var j=JSON.parse(payload);if(j.think){thinkText+=j.think;var tp2=makeToT(div,'Reveal train of thought',true);totPush(tp2,j.think);scrollBottom()}if(j.token){if(firstToken){bubble.innerHTML='';firstToken=false}fullText+=j.token;bubble.innerHTML=formatMsg(fullText);scrollBottom()}if(j.escalate_project){renderEscalateChip(j.escalate_project,text)}if(j.error){fullText+='\n\nError: '+j.error}}catch(pe){}
+          try{var j=JSON.parse(payload);if(j.token){raw+=j.token;var ps=parseScaffold(raw);if(thinkingEnabled&&ps.think){var tp2=makeToT(div,'Reveal train of thought',true);totSet(tp2,ps.think)}if(ps.answer){if(!answerStarted){bubble.innerHTML='';answerStarted=true}bubble.innerHTML=formatMsg(ps.answer)}scrollBottom()}if(j.escalate_project){renderEscalateChip(j.escalate_project,text)}if(j.error){raw+='\n\nError: '+j.error}}catch(pe){}
         }
       }
-      if(fullText){div.remove();var md2=addMessage('assistant',fullText);if(thinkText.trim()&&md2){var fp2=makeToT(md2,'Train of thought',false);totSet(fp2,thinkText.trim())}chatHist.push({role:'assistant',content:fullText});saveMessages([{role:'assistant',content:fullText}])}
+      var pf2=parseScaffold(raw);
+      var answer2=(pf2.answer&&pf2.answer.trim())||raw.replace(/<thinking>[\s\S]*?<\/thinking>/i,'').replace(/###\s*FINAL ANSWER:?/i,'').trim()||raw;
+      if(answer2){div.remove();var md2=addMessage('assistant',answer2);if(thinkingEnabled&&pf2.think&&pf2.think.trim()&&md2){var fp2=makeToT(md2,'Train of thought',false);totSet(fp2,pf2.think.trim())}chatHist.push({role:'assistant',content:answer2});saveMessages([{role:'assistant',content:answer2}])}
       else{bubble.innerHTML='<em style="color:var(--text-dim)">No response</em>'}
     }
   }catch(e){


### PR DESCRIPTION
The car-wash logic test regressed. Root cause (verified against the live local model, not guessed):
1. The Think-mode system prompt had been weakened to a paraphrase that dropped the `<thinking>` / `### FINAL ANSWER:` scaffold.
2. The model was upgraded **Qwen 3.5 → 3.6**, which needs the scaffold even more (4-bit "second-guesses itself").

**Empirical A/B on the running model:**
- weak prompt + thinking-on → *"Verdict: Walk"* (wrong — reproduces failure)
- tuned scaffold + a "check hidden physical/logical dependencies" rule + `enable_thinking=False` → *"you must drive the car"* (correct); also nails windows-trick (3), capital of France (Paris), normal greeting.

**Changes**
- Restored the reasoning scaffold as `REASON_SCAFFOLD`, injected only in Think mode via `buildSystem()`; Think-off = concise. Removed "Use emoji strategically" from the prompt.
- Chat sends `enable_thinking=False`, reasoning driven by the scaffold (winning combo).
- `parseScaffold()` splits `<thinking>` (→ reveal window) from post-`### FINAL ANSWER:` (→ answer bubble), streaming both. Fixes the empty reveal: the model streams `<thinking>` inline in content, not the `reasoning_content` field the old code watched.

Verified: model-level A/B, parseScaffold unit tests, node --check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)