### PR TITLE
docs: add DEMO_SCRIPT.md (recovered 15-step demo flow)

### DIFF
--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -1,0 +1,49 @@
+# CODEC Live Demo — 15-Step Flow
+
+> Recovered from the April 12–14, 2026 planning session and kept here so it is
+> never lost again. This is the locked recording scenario. Steps are tested
+> one-by-one before recording.
+
+| # | Tab / Page | Feature Shown | Key Moment |
+|---|------------|---------------|------------|
+| 1 | `opencodec.org` | Wake Word + Calendar + Google Tasks | "Add to my to-do list: edit and upload demo video by tomorrow." |
+| 2 | GitHub Repo → Safari | Voice App Control (Chrome → Safari launch) | "Open Time Magazine in Safari" |
+| 3 | Safari — Time Magazine | Instant — Read Aloud (Kokoro TTS) | Select paragraph → voice reads it aloud |
+| 4 | Gmail — Client Email | Vision + Draft Composition | "Look at my screen and reply" → polished text appears |
+| 5 | Calendar + Tasks (Gmail sidebar) | Trust Moment — receipts from Step 1 | Show the task added in Step 1 is real |
+| 6 | WhatsApp Web — Ukrainian message | Instant — Translate (UA → EN) | Right-click → translation appears instantly |
+| 7 | Cloudflare Dashboard — DNS page | **Vision Mouse Control (showstopper)** | "Click the DNS button" → cursor moves and clicks correctly |
+| 8 | CODEC Chat — Agent Mode | Deep Research crew launched | "This takes a few minutes, let me show you the rest while it works." |
+| 9 | CODEC Cortex — Neural Map | Nerve-center visualization | Pulsing zones, explain each |
+| 10 | CODEC Audit — Event Log | Full audit trail (16 categories) | Filter by category → show logged events |
+| 11 | Flash Chat / Think Mode | Quick command + reasoning reveal | Toggle Think → ask a logic question → "Reveal train of thought" |
+| 12 | CODEC Vibe | AI coding IDE (Monaco editor + live preview) | "Build me a snake game" → watch code write itself |
+| 13 | CODEC Voice Call | Live voice + mid-call interrupt | Interrupt TTS mid-response → cuts instantly |
+| 14 | Deep Research Report (Google Doc) | Agent crew payoff | Click link → full report, real citations, native tables |
+| 15 | Phone → `codec.avadigital.ai` (Touch ID) | Remote access from anywhere | Touch ID → Mac Studio responds to phone command |
+
+## Pre-Record Checklist
+
+- Chrome tabs left-to-right: `opencodec.org` → GitHub → Gmail → WhatsApp Web → Cloudflare → CODEC Chat
+- Safari (separate window): Time Magazine article open
+- Phone on desk: `codec.avadigital.ai` loaded, Touch ID ready
+- Vision Mouse Control tested 3× on the Cloudflare DNS button (must work cleanly twice in a row)
+- Kokoro TTS tested (Step 3 read-aloud)
+- Client email open with a real message (Step 4)
+- Ukrainian message ready on WhatsApp (Step 6)
+- Fresh Deep Research chat window open (Step 8)
+
+## Director's Notes
+
+- **Trust loop:** Steps 1 → 5 are the payoff — the viewer sees CODEC promise something, then deliver it.
+- **Showstopper risk:** Step 7 (Vision Mouse Control) — test 10× before recording; if it fails live, skip straight to Step 8.
+- **TTS interrupt:** Step 13 proves real-time control.
+- **Grand finale:** Save Step 14 (the full report) for last-but-one, Step 15 (phone) as the mic-drop.
+
+## Separate: 10-point technical validation checklist (QA, not the demo)
+
+Run before recording to confirm nothing is broken. Distinct from the demo flow above.
+
+1. Voice pipeline  2. Dictate  3. Dashboard security  4. Chat & Flash Chat
+5. Agents framework  6. Skills system  7. Memory & FTS5  8. MCP server
+9. Infrastructure & resilience  10. Cortex & Audit pages


### PR DESCRIPTION
Saves the CODEC live-demo recording script into the repo so it stops getting lost across sessions.