### PR TITLE
feat(project): single approval grants full web access (no per-domain blocking)

### DIFF
--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -1156,6 +1156,19 @@ def approve_plan(agent_id: str) -> Dict[str, Any]:
         "auto_approved": auto_approved,
         **asdict(plan.permission_manifest),
     }
+    # Single-approval web access: if the plan needs the open web (it declares any
+    # network domains, or uses a web/browse skill), grant "*" so the agent runs
+    # start-to-finish without blocking on every new domain it visits. One approval
+    # = full web for this run. Path grants stay scoped (least privilege) — only
+    # network breadth is widened, and only when the plan actually browses.
+    _pm = plan.permission_manifest
+    _WEB_SKILLS = {"web_search", "web_fetch", "chrome_search", "chrome_open",
+                   "chrome_read", "chrome_automate", "chrome_extract",
+                   "clipboard_url_fetch"}
+    _needs_web = bool(getattr(_pm, "network_domains", None)) or bool(
+        set(getattr(_pm, "skills", []) or []) & _WEB_SKILLS)
+    if _needs_web:
+        grants["network_domains"] = ["*"]
     save_grants(agent_id, grants)
 
     # B-9: stamp the hashes AND flip status to approved in ONE atomic, flock-

--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -1168,7 +1168,8 @@ def approve_plan(agent_id: str) -> Dict[str, Any]:
     _needs_web = bool(getattr(_pm, "network_domains", None)) or bool(
         set(getattr(_pm, "skills", []) or []) & _WEB_SKILLS)
     if _needs_web:
-        grants["network_domains"] = ["*"]
+        grants["network_domains"] = sorted(set(
+            (grants.get("network_domains") or []) + ["*"]))
     save_grants(agent_id, grants)
 
     # B-9: stamp the hashes AND flip status to approved in ONE atomic, flock-

--- a/codec_agent_runner.py
+++ b/codec_agent_runner.py
@@ -312,7 +312,9 @@ def permission_gate(action: Action, agent_grants: Dict[str, Any],
     if wants_net and action.network_domain:
         domains = (set(agent_grants.get("network_domains", [])) |
                    set(global_grants.get("network_domains", [])))
-        if action.network_domain not in domains:
+        # "*" is a broad-web grant (issued at approval for plans that browse), so
+        # the agent doesn't block on every new domain it visits. Explicit opt-in.
+        if "*" not in domains and action.network_domain not in domains:
             raise PermissionViolation("domain_not_authorized", action.network_domain)
 
 

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -893,7 +893,12 @@ def test_e2e_full_lifecycle(monkeypatch, temp_codec_dir):
     m = cap.load_manifest(agent_id)
     assert m["status"] == "approved"
     assert "plan_hash" in m
-    assert grants["network_domains"] == ["idealista.com", "fotocasa.es"]
+    # Single-approval web access: a plan that declares network domains is granted
+    # a broad-web "*" at approval (so it doesn't block on every new domain), while
+    # the declared domains remain listed too.
+    assert "*" in grants["network_domains"]
+    assert "idealista.com" in grants["network_domains"]
+    assert "fotocasa.es" in grants["network_domains"]
 
     # Verify both audit events were emitted (paired correlation_ids will differ — independent ops)
     events = [e for e, _ in audit_emits]


### PR DESCRIPTION
Research/browse projects blocked on every new domain. Now approve_plan grants network_domains=['*'] when the plan browses, and permission_gate honors '*'. One approval = full web for the run. Path grants stay scoped. Verified E2E: web project ran to completed with 0 domain blocks.