### PR TITLE
fix(project): async drafting, working clarifying questions, path-glob bug, warmer UX

### DIFF
--- a/codec_agent_plan.py
+++ b/codec_agent_plan.py
@@ -616,14 +616,25 @@ class DescriptionTooVagueError(ValueError):
 def _ask_user(question: str, *, agent_id: str,
               deadline_seconds: int = 600) -> Tuple[str, Any]:
     """Lazy-loaded codec_ask_user.ask wrapper. Returns (status, answer).
-    status ∈ {"answered", "ambiguous_consent", "timeout"}."""
+    status ∈ {"answered", "timeout"}.
+
+    Bugfix: this previously called ask(question, source=..., deadline_seconds=...)
+    and expected a (status, answer) tuple back — but the real ask() signature has
+    no `source`/`deadline_seconds` kwargs (it's `timeout`/`asked_from`) and returns
+    a plain answer STRING (with TIMEOUT_SENTINEL/DISABLED_SENTINEL on failure), not
+    a tuple. The clarifying-question loop would TypeError the instant it fired —
+    this feature has never actually worked. Fixed to call the real API and map its
+    sentinel-string return back into the (status, answer) shape callers expect."""
     try:
-        from codec_ask_user import ask
+        from codec_ask_user import ask, TIMEOUT_SENTINEL, DISABLED_SENTINEL
     except Exception as e:
         log.warning("codec_ask_user unavailable: %s", e)
         return ("timeout", None)
-    return ask(question, source=f"agent_plan:{agent_id}",
-               deadline_seconds=deadline_seconds)
+    answer = ask(question, timeout=deadline_seconds,
+                 asked_from="agent_plan", agent=f"agent_plan:{agent_id}")
+    if answer in (TIMEOUT_SENTINEL, DISABLED_SENTINEL):
+        return ("timeout", None)
+    return ("answered", answer)
 
 
 def draft_plan_with_clarification(agent_id: str, description: str,
@@ -1039,30 +1050,25 @@ def merge_user_paths_into_manifest(plan, description: str) -> int:
     return added
 
 
-def create_agent(title: str, description: str,
-                 registry=None,
-                 notification_channels: Optional[List[str]] = None) -> str:
-    """Top-level entry point. Drafts a plan, persists to disk, emits audit.
-    Returns the new agent_id. Status after this call: awaiting_approval
-    (or plan_failed on validation error).
+def _reserve_agent(title: str,
+                   notification_channels: Optional[List[str]] = None) -> Tuple[str, Optional[Path]]:
+    """Fast synchronous half of agent creation: mint an agent_id, create the
+    human-browseable project folder, write the initial draft_pending manifest
+    + empty state. No LLM calls — safe to run inline in an HTTP handler.
 
-    Phase 3.5: ALSO creates a human-browseable project folder under
-    ~/codec-projects/<slug>/ (or the configured project_root_dir). The
-    plan's permission_manifest.write_paths defaults to this folder, so
-    files the agent creates land where the user can open them in an IDE.
-    """
+    Split out of create_agent() (2026-07) so a caller (the /api/agents route)
+    can return agent_id to the UI immediately and run the slow half
+    (_finish_draft — Qwen + possible clarifying-question wait) in a
+    background thread, instead of blocking the HTTP request. Previously the
+    whole thing ran inline: if Qwen ever asked a clarifying question the
+    request would hang for up to 10 minutes with the UI just spinning."""
     agent_id = _new_agent_id()
-    cid = secrets.token_hex(6)
-
-    # Phase 3.5: create the human-browseable project folder up-front so
-    # the plan-drafter can reference it as the default write_paths root.
     try:
         project_dir = create_project_folder(title, agent_id)
     except Exception as e:
         log.warning("[%s] project folder creation failed: %s", agent_id, e)
         project_dir = None
 
-    # Initial manifest
     manifest = {
         "agent_id": agent_id,
         "title": title[:120],
@@ -1074,8 +1080,19 @@ def create_agent(title: str, description: str,
     }
     save_manifest(agent_id, manifest)
     save_state(agent_id, {"current_checkpoint": 0})
+    return agent_id, project_dir
 
-    # Draft plan (with clarification loop)
+
+def _finish_draft(agent_id: str, description: str, project_dir: Optional[Path],
+                  registry=None, _reraise: bool = False) -> None:
+    """Slow half of agent creation: draft the plan (with the clarification
+    loop — may block on codec_ask_user for up to its deadline), persist on
+    success, or mark plan_failed on any failure. Never raises unless
+    `_reraise=True` (set by the synchronous create_agent() wrapper below, for
+    direct/script callers that want the old blocking + exception contract) —
+    the background-thread caller relies on this to leave the agent in a
+    terminal-for-drafting status instead of dying silently."""
+    cid = secrets.token_hex(6)
     try:
         plan = draft_plan_with_clarification(agent_id, description, registry=registry,
                                               project_dir=project_dir)
@@ -1085,14 +1102,31 @@ def create_agent(title: str, description: str,
                f"plan failed (vague): {e}", correlation_id=cid,
                outcome="warning", level="warning",
                extra={"agent_id": agent_id, "reason": "too_vague"})
-        raise
+        if _reraise:
+            raise
+        return
     except (PlanValidationError, QwenUnavailableError) as e:
         set_status(agent_id, "plan_failed", reason=str(e))
         _audit(AGENT_PLAN_REJECTED, "codec-agent-plan",
                f"plan failed: {e}", correlation_id=cid,
                outcome="error", level="error",
                extra={"agent_id": agent_id, "reason": str(e)[:200]})
-        raise
+        if _reraise:
+            raise
+        return
+    except Exception as e:
+        # Defense in depth: an unhandled exception in a background thread
+        # would otherwise die silently, leaving the agent stuck in
+        # draft_pending forever with no explanation.
+        log.exception("[%s] unhandled exception drafting plan", agent_id)
+        set_status(agent_id, "plan_failed", reason=f"unhandled:{type(e).__name__}:{str(e)[:150]}")
+        _audit(AGENT_PLAN_REJECTED, "codec-agent-plan",
+               f"plan failed (unhandled): {e}", correlation_id=cid,
+               outcome="error", level="error",
+               extra={"agent_id": agent_id, "reason": "unhandled_exception"})
+        if _reraise:
+            raise
+        return
 
     # Auto-grant: paths the user explicitly typed in their description go
     # into the manifest before approval. Reduces "blocked_on_permission"
@@ -1110,7 +1144,7 @@ def create_agent(title: str, description: str,
     set_status(agent_id, "awaiting_approval")
 
     _audit(AGENT_PLAN_DRAFTED, "codec-agent-plan",
-           f"plan drafted for {title[:60]}", correlation_id=cid,
+           f"plan drafted for {agent_id}", correlation_id=cid,
            extra={
                "agent_id": agent_id,
                "checkpoint_count": len(plan.checkpoints),
@@ -1119,6 +1153,27 @@ def create_agent(title: str, description: str,
                "domains_count": len(plan.permission_manifest.network_domains),
            })
 
+
+def create_agent(title: str, description: str,
+                 registry=None,
+                 notification_channels: Optional[List[str]] = None) -> str:
+    """Top-level SYNCHRONOUS entry point (direct/script callers — tests, the
+    REPL, etc.). Drafts a plan, persists to disk, emits audit. Returns the
+    new agent_id. Status after this call: awaiting_approval (or plan_failed
+    on validation error, which also re-raises).
+
+    HTTP callers should use _reserve_agent() + a background thread running
+    _finish_draft() instead (see routes/agents.py) — this blocking form is
+    NOT used by the /api/agents route because a clarifying-question round
+    can take up to 10 minutes and must not hang the HTTP request.
+
+    Phase 3.5: ALSO creates a human-browseable project folder under
+    ~/codec-projects/<slug>/ (or the configured project_root_dir). The
+    plan's permission_manifest.write_paths defaults to this folder, so
+    files the agent creates land where the user can open them in an IDE.
+    """
+    agent_id, project_dir = _reserve_agent(title, notification_channels)
+    _finish_draft(agent_id, description, project_dir, registry=registry, _reraise=True)
     return agent_id
 
 

--- a/codec_agent_runner.py
+++ b/codec_agent_runner.py
@@ -185,9 +185,20 @@ def _path_allowed(action_path: str, grants: Any) -> tuple[bool, str]:
         if glob_idx < 0:
             # Plain directory/file grant authorizes its subtree (unchanged).
             return True, ""
+        # A recursive grant (`root/**`) also authorizes the bare root directory
+        # itself — listing/reading `root` is a natural subset of "everything
+        # under root", but fnmatch(`root`, `root/**`) is False (no literal `/`
+        # after `root` to match the pattern's trailing separator). Without this,
+        # a plan that declares `X/**` still blocks the very first `list X`
+        # action and forces a redundant manual grant of the bare path. Narrower
+        # globs (`*.md`) intentionally do NOT get this — they authorize a file
+        # pattern, not "everything", so the bare directory stays ungranted.
+        glob_suffix = grant_expanded[glob_idx:]
+        if glob_suffix in ("**", "*/**") and action_real == grant_real:
+            return True, ""
         # B-18: the action must ALSO match the realpath-anchored glob pattern, so a
         # specific glob (`*.md`) is enforced rather than collapsed to its directory.
-        pattern = grant_real + os.sep + grant_expanded[glob_idx:]
+        pattern = grant_real + os.sep + glob_suffix
         if fnmatch.fnmatch(action_real, pattern):
             return True, ""
         # Under the root but doesn't match this glob — keep checking other grants.

--- a/codec_chat.html
+++ b/codec_chat.html
@@ -615,8 +615,8 @@ function setMode(mode){
       pPanel.style.cssText='margin:12px 16px 8px;padding:14px 16px;background:rgba(167,139,250,0.08);border:1px solid var(--accent,#a78bfa);border-radius:10px;font-size:13px;line-height:1.5';
       pPanel.innerHTML=
         '<div style="font-weight:600;color:var(--accent,#a78bfa);margin-bottom:6px">Project mode — autonomous plan-and-build</div>'+
-        '<div style="color:var(--text-dim);margin-bottom:8px">Drop a project below. CODEC drafts a plan + permission manifest, you approve once, then codec-agent-runner works through it autonomously (Qwen-3.6 + skills). Updates post back to this thread.</div>'+
-        '<div style="color:var(--text-dim);font-size:12px">Examples: <em>"Build a Telegram bot that monitors Marbella property listings under €500k"</em>  ·  <em>"Watch EUR/USD intraday vol and ping me when 30-min realized vol crosses 0.4%"</em>  ·  <em>"Plan the launch of [product] over 6 weeks with weekly milestones"</em></div>';
+        '<div style="color:var(--text-dim);margin-bottom:6px">Tell me what you want built or handled. I\'ll ask if anything\'s unclear, then show you the plan — one approval and I take it from there, updates posted right here.</div>'+
+        '<a href="https://github.com/AVADSA25/codec#readme" target="_blank" rel="noopener" style="color:var(--accent,#a78bfa);font-size:12px;text-decoration:none">Learn more &rarr;</a>';
     }
     var msgsEl=document.getElementById('messages');
     if(msgsEl&&!document.getElementById('projectModePanel')){
@@ -1056,14 +1056,113 @@ function renderAgentPlanCard(agentId,agentInfo){
     statusLine='<div style="margin-bottom:6px;font-size:11px;color:'+color+'">status: <strong>'+escHtml(label)+'</strong>'+(reason?' ('+escHtml(reason)+')':'')+'</div>';
   }
   var subline=isPendingApproval
-    ?'A plan with a permission manifest has been written. Review and approve to let the agent run autonomously.'
-    :(isTerminal?'Agent finished. View plan to see what ran.':'Agent state shown above; click View plan for live progress.');
-  return'<div style="font-weight:600;margin-bottom:6px">Project drafted</div>'+
-    '<div style="margin-bottom:6px">agent_id: <code>'+escHtml(agentId)+'</code></div>'+
+    ?'Take a look below — approve and I\'ll run with it end to end, or tell me what to change.'
+    :(isTerminal?'Done — click View plan to see what ran.':'Working on it — click View plan for live progress.');
+  // Surface the actual goals right in the card instead of hiding them behind
+  // "View plan" — approving a plan you can't see the substance of is what
+  // made this feel like a cold permission wall instead of a proposal.
+  var plan=agentInfo.plan||null;
+  var goalsHtml='';
+  if(plan&&plan.goals&&plan.goals.length){
+    goalsHtml='<div style="margin:2px 0 10px;font-size:12px;line-height:1.5">'+
+      plan.goals.slice(0,5).map(function(g){return'&bull; '+escHtml(g)}).join('<br>')+
+      (plan.checkpoints&&plan.checkpoints.length?'<div style="color:var(--text-dim);margin-top:4px">'+plan.checkpoints.length+' step'+(plan.checkpoints.length===1?'':'s')+(plan.estimated_duration_minutes?', ~'+plan.estimated_duration_minutes+' min':'')+'</div>':'')+
+      '</div>';
+  }
+  var header=isPendingApproval?'Here’s my plan':'Project';
+  return'<div style="font-weight:600;margin-bottom:6px">'+header+'</div>'+
+    goalsHtml+
     statusLine+
     folderHtml+
     '<div style="color:var(--text-dim);font-size:12px;margin-bottom:8px">'+subline+'</div>'+
     '<div style="display:flex;gap:8px;flex-wrap:wrap">'+buttonsHtml+'</div>';
+}
+
+// ── Clarifying questions (Project mode) ─────────────────────────────────────
+// When Qwen finds a project description too vague, it now asks 1-3 clarifying
+// questions THROUGH THIS CONVERSATION instead of drafting a bad plan — the
+// mechanism (codec_ask_user) existed but was wired with the wrong function
+// signature and would crash the instant it fired; fixed server-side. Rendered
+// as a normal warm assistant bubble with an inline reply, not a cold form.
+var _answeredQuestionIds={};
+function renderClarifyingQuestion(container,pendingQuestionId,questionText){
+  var div=document.createElement('div');div.className='msg assistant';
+  var fid='cq_'+pendingQuestionId;
+  div.innerHTML='<div class="msg-bubble">'+formatMsg(questionText)+
+    '<div style="margin-top:10px;display:flex;gap:6px">'+
+    '<input type="text" id="'+fid+'" placeholder="Your answer…" style="flex:1;padding:7px 10px;border-radius:8px;border:1px solid var(--border);background:var(--surface-2);color:var(--text);font-size:13px;font-family:var(--font)">'+
+    '<button onclick="answerClarifyingQuestion(\''+pendingQuestionId+'\',this)" style="padding:7px 14px;background:var(--accent);color:#fff;border:none;border-radius:8px;cursor:pointer;font-size:12px;font-weight:600">Answer</button>'+
+    '</div></div>';
+  container.appendChild(div);scrollBottom();
+  var inp=document.getElementById(fid);
+  if(inp)inp.addEventListener('keydown',function(e){if(e.key==='Enter'){e.preventDefault();answerClarifyingQuestion(pendingQuestionId,inp.nextElementSibling)}});
+  if(inp)setTimeout(function(){inp.focus()},50);
+}
+async function answerClarifyingQuestion(pendingQuestionId,btn){
+  var fid='cq_'+pendingQuestionId;var inp=document.getElementById(fid);
+  var val=inp?inp.value.trim():'';
+  if(!val){if(inp)inp.focus();return}
+  if(btn){btn.disabled=true;btn.textContent='…'}
+  if(inp)inp.disabled=true;
+  try{
+    var r=await fetch('/api/agents/answer/'+encodeURIComponent(pendingQuestionId),{
+      method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({answer:val,answered_via:'pwa'})
+    });
+    var d=await r.json();
+    _answeredQuestionIds[pendingQuestionId]=true;
+    if(inp){var wrap=inp.parentElement;wrap.innerHTML='<span style="color:var(--text-dim);font-size:12px">You answered: “'+escHtml(val)+'”</span>'}
+    if(!r.ok&&!d.ok){showToast('Answer failed: '+(d.error||r.status))}
+  }catch(e){showToast('Answer failed: '+e.message)}
+}
+
+// Poll a just-drafted (or clarifying) agent until it reaches awaiting_approval
+// or plan_failed. Renders clarifying questions conversationally as they show
+// up, then swaps the "drafting..." bubble for the real plan card.
+async function pollDraftingAgent(agentId,pendingDiv){
+  var messagesEl=document.getElementById('messages');
+  for(var i=0;i<150;i++){                          // ~150 * 2s = 5min safety cap
+    await new Promise(function(res){setTimeout(res,2000)});
+    var st='';
+    try{
+      var r=await fetch('/api/agents/'+encodeURIComponent(agentId));
+      if(!r.ok)continue;
+      var d=await r.json();
+      st=(d.manifest||{}).status||'';
+      if(st==='awaiting_approval'){
+        pendingDiv.querySelector('.msg-bubble').innerHTML=renderAgentPlanCard(agentId,d);
+        var planMarker='[CODEC_AGENT_PLAN:'+agentId+']';
+        var planText='Here’s my plan — agent_id '+agentId+'  '+planMarker;
+        chatHist.push({role:'assistant',content:planText});
+        saveMessages([{role:'assistant',content:planText}]);
+        setActiveAgent(agentId);
+        return;
+      }
+      if(st==='plan_failed'){
+        var reason=(d.manifest||{}).status_reason||'unknown reason';
+        pendingDiv.querySelector('.msg-bubble').innerHTML=
+          'I couldn’t turn that into a plan (<span style="color:var(--text-dim)">'+escHtml(reason)+'</span>). '+
+          'Want to describe it a bit differently, or give me more specifics?';
+        return;
+      }
+    }catch(e){continue}
+    // While drafting, check for a clarifying question aimed at this agent.
+    try{
+      var qr=await fetch('/api/agents/pending_questions');
+      if(qr.ok){
+        var qd=await qr.json();
+        var qs=(qd.pending_questions||qd.questions||[]);
+        for(var j=0;j<qs.length;j++){
+          var q=qs[j];
+          if(q.agent==='agent_plan:'+agentId&&!_answeredQuestionIds[q.id]){
+            _answeredQuestionIds[q.id]='pending';   // render-once guard
+            renderClarifyingQuestion(messagesEl,q.id,q.question);
+          }
+        }
+      }
+    }catch(e){}
+  }
+  pendingDiv.querySelector('.msg-bubble').innerHTML='Still working on this one — check back in a bit, or ask me for a status update.';
 }
 
 async function rehydrateAgentPlanCards(){
@@ -1199,10 +1298,14 @@ async function sendMessage(){
       return;
     }
 
-    // ── No active agent: draft a new project
+    // ── No active agent: draft a new project. Drafting now runs server-side
+    // in the background (see routes/agents.py) so a clarifying question never
+    // hangs this request — POST returns almost immediately with agent_id +
+    // status:draft_pending, and we poll from here, rendering any clarifying
+    // question conversationally as it comes up.
     var pendingDiv=document.createElement('div');
     pendingDiv.className='msg assistant';
-    pendingDiv.innerHTML='<div class="msg-bubble">Drafting plan via Qwen-3.6...</div>';
+    pendingDiv.innerHTML='<div class="msg-bubble">Let me think through a plan for that…</div>';
     document.getElementById('messages').appendChild(pendingDiv);
     scrollBottom();
     try{
@@ -1218,16 +1321,8 @@ async function sendMessage(){
         pendingDiv.querySelector('.msg-bubble').innerHTML='<span style="color:var(--danger,#f87171)">Plan failed:</span> '+escHtml(pd.detail);
         chatHist.push({role:'assistant',content:'Plan failed: '+pd.detail});
       }else if(pd.agent_id){
-        pendingDiv.querySelector('.msg-bubble').innerHTML=renderAgentPlanCard(pd.agent_id, pd);
-        // PR #39: persist a marker token so loadSession() can re-render the
-        // card on reload. Plain text content kept short and human-readable
-        // for users on screens that don't grok the marker (e.g. text export).
-        var planMarker='[CODEC_AGENT_PLAN:'+pd.agent_id+']';
-        var planText='Project drafted — agent_id '+pd.agent_id+'  '+planMarker;
-        chatHist.push({role:'assistant',content:planText});
-        saveMessages([{role:'assistant',content:planText}]);
-        // Bind this thread to the new agent — next messages route to it
-        setActiveAgent(pd.agent_id);
+        // Not resolved yet — poll (renders clarifying Qs, then the plan card).
+        pollDraftingAgent(pd.agent_id,pendingDiv);
         refreshAgentStatusPills();
       }else{
         pendingDiv.querySelector('.msg-bubble').innerHTML='<span style="color:var(--danger,#f87171)">Unknown response</span>';

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -371,23 +371,27 @@ def create_agent(body: CreateAgentBody):
     except Exception:
         pass
 
-    try:
-        agent_id = _cap.create_agent(
-            title=body.title,
-            description=body.description,
-            notification_channels=body.notification_channels,
-        )
-    except _cap.DescriptionTooVagueError as e:
-        raise HTTPException(status_code=400, detail=f"description too vague: {e}")
-    except _cap.PlanValidationError as e:
-        raise HTTPException(status_code=400, detail=f"plan invalid: {e}")
-    except _cap.QwenUnavailableError as e:
-        raise HTTPException(status_code=503, detail=f"Qwen-3.6 unavailable: {e}")
+    # Drafting runs in the background: the fast "reserve" half (mint agent_id
+    # + project folder + draft_pending manifest) happens inline so the caller
+    # gets an agent_id back immediately; the slow half (Qwen + a possible
+    # clarifying-question round, which can take up to its 10-minute deadline)
+    # runs in a thread. Previously the whole thing ran inline and a
+    # clarifying question would hang this HTTP request with the UI just
+    # spinning — the frontend now polls GET /api/agents/{id} for status
+    # (draft_pending -> awaiting_approval/plan_failed) and, while pending,
+    # GET /api/agents/pending_questions to render any question conversationally.
+    agent_id, project_dir = _cap._reserve_agent(body.title, body.notification_channels)
+    threading.Thread(
+        target=_cap._finish_draft,
+        args=(agent_id, body.description, project_dir),
+        kwargs={},
+        daemon=True, name=f"draft-{agent_id}",
+    ).start()
 
     manifest = _cap.load_manifest(agent_id)
     return {
         "agent_id": agent_id,
-        "status": manifest.get("status", "unknown"),
+        "status": manifest.get("status", "draft_pending"),
         "project_dir": manifest.get("project_dir"),  # Phase 3.5: human-browseable folder
     }
 

--- a/tests/test_agent_plan.py
+++ b/tests/test_agent_plan.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -649,7 +650,18 @@ def test_post_api_agents_creates_drafts(monkeypatch, temp_codec_dir, tmp_path):
     assert r.status_code == 200
     body = r.json()
     assert body["agent_id"].startswith("agent_")
-    assert body["status"] == "awaiting_approval"
+    # Drafting runs in a background thread (2026-07 fix — a clarifying-question
+    # round can take up to 10 minutes and must not hang this HTTP request), so
+    # the immediate response reflects the fast synchronous "reserve" half only.
+    assert body["status"] == "draft_pending"
+
+    # The slow half (draft_plan_with_clarification, monkeypatched above to be
+    # instant) finishes asynchronously — poll briefly for it to land.
+    for _ in range(50):
+        if cap.load_manifest(body["agent_id"]).get("status") == "awaiting_approval":
+            break
+        time.sleep(0.05)
+    assert cap.load_manifest(body["agent_id"])["status"] == "awaiting_approval"
 
 
 def test_get_api_agents_lists_all(temp_codec_dir):


### PR DESCRIPTION
Three real bugs found from the overnight stuck project + the "talking to a wall" feedback.

## 1. Crash bug (never actually worked)
`_ask_user` called `codec_ask_user.ask(question, source=..., deadline_seconds=...)` — neither kwarg exists on the real signature (`timeout=`/`asked_from=`), and `ask()` returns a plain string, not a `(status, answer)` tuple. The clarifying-question mechanism would `TypeError` the instant it fired. Fixed + verified with a real (non-mocked) ask/submit_answer round trip.

## 2. Architecture bug
Even fixed, `POST /api/agents` ran the entire draft — including up to a 10-minute clarifying-question wait — inline in the HTTP handler, hanging the browser's fetch with nothing visible. Split `create_agent()` into `_reserve_agent()` (fast/sync) + `_finish_draft()` (slow, backgrounded). POST now returns in ~2ms; frontend polls for status + pending questions and renders any question as a warm chat bubble with inline reply. Verified full chain end-to-end with a deterministic mock LLM.

## 3. Path-glob bug
`_path_allowed`'s recursive grant (`root/**`) didn't authorize the bare `root` directory itself (fnmatch needs a literal separator after `root` a bare-dir read lacks) — so a plan could declare `X/**` and still block the very first `list X` action. This is what made last night's project keep stopping for grants it should already have had. Fixed; narrower globs (`*.md`) unaffected.

## UX
Plan card now shows goals directly (not hidden behind "View plan"), warmer copy throughout, removed the odd inline examples for a short line + "Learn more → GitHub README" link.

Verified: 146 tests pass, ruff clean, node --check, plus two from-scratch end-to-end proofs (ask/answer round trip, full async draft flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)