### PR TITLE
fix(app): the paid Mac app now actually starts the fleet (W5-2 × W5-3 wiring)

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,71 @@
+# HANDOVER — CODEC buyer journey
+
+**Last updated:** 2026-07-10 · session: buyer-journey audit + R1 "stop the lies"
+
+## State
+
+The audit is done and merged. **R1 is complete and verified.** Nothing further ships
+without a decision from Mickael (see BLOCKERS).
+
+- Audit report: [artifact](https://claude.ai/code/artifact/0736616b-12d5-4582-a96c-bc8b66e70779)
+  · findings in `docs/audits/2026-07-10-CODEC-BUYER-JOURNEY-AUDIT.md` (PR #233, merged)
+- 82 findings · 16 critical · 30/30 adversarially-verified confirmed, 0 refuted.
+
+## What R1 shipped (all verified, not claimed)
+
+| # | Fix | Where | Evidence |
+|---|-----|-------|----------|
+| 1 | License email's download button 404'd | `ava-stack` branch `fix/r1-license-email-dead-link` | now points at the real v3.2.0 DMG; live `ava-license` restarted, `/health` ok |
+| 2 | Emoji in the license email subject | same | `test_license_email.py` asserts it stays clean |
+| 3 | **Leak-guard test was dead** — `test_codec_purchase_guard.py` could not collect (no `stripe` in system py, no `pytest` in venv) | same | `.venv/bin/python -m pytest` → 11 passed |
+| 4 | **`pytest` in license-server fired a LIVE webhook** — `test_webhook_live.py` was a script that minted a real license on import | same | renamed `check_webhook_live.py`; `pytest.ini` pins `python_files=test_*.py` |
+| 5 | Client's email `dr@jansen.de` live in a code sample on avadigital.ai/codec | `AVA-site-v2` branch `fix/r1-remove-client-identity` | removed |
+| 6 | avadigital.ai/codec sold a fictional TypeScript SDK (`npx codec init`, "Codec 0.9.4", 368 features, 940 tests, telegram/voice-sip/slack, `codec run --agent lucy`) | same branch | rewritten from verified facts: Python, v3.2, 86 skills, 400 features, 2,000+ tests, real skill sample. €500 cart preserved |
+| 7 | README sold a `€10/month` plan that never existed; `Get it →` led to no purchase path | codec repo, PR #234 (merged) | now `$99/year`, `Details →` |
+| 8 | FEATURES.md claimed 76 skills; manifest has 86 | PR #234 | corrected + guarded |
+| 9 | Nothing checked the marketing numbers | PR #234 | `tests/test_public_claims_true.py` — skill count == manifest, version == VERSION, test-count claim backed by real tests, phantom €10/month can never return. Guard proven to bite. |
+
+**Two audit findings I checked and rejected:** the Cmd+R / F5 hotkey copy is accurate
+(`README.md:103`), and the install one-liner already contains `cd codec`. Both were
+unverified low findings. Don't "fix" them.
+
+## BLOCKERS (need Mickael)
+
+1. **The site changes are committed but NOT LIVE.** `AVA-site-v2` has no git remote and
+   deploys by hand (static upload). Until it is re-published, avadigital.ai/codec still
+   shows the fictional SDK **and the client's email address**. This is the single most
+   urgent open item.
+2. **R2 needs a money decision** — creating the Stripe Payment Link and putting a Buy
+   button live is outward-facing; not done autonomously.
+3. **Concurrent session warning:** another Claude session is committing in `AVA-site-v2`
+   (`fe39df2 "HANDOVER: final InTake SPA deployed"` landed between my two commits).
+   Coordinate before working there.
+
+## Next (R2 → R6, from the audit roadmap)
+
+- **R2 Open the store** (2–3d): one Buy button wired to a Stripe Payment Link matching the
+  price the license server filters on; state terms (1 Mac / 1 year / renews); check
+  `payment_status` before minting; revoke on refund; alert+retry on email failure; fix the
+  year-2 renewal lockout (subscription renews forever, JWT dies at 365 days). Then buy it
+  yourself end-to-end and refund it.
+- **R3 Deliver what's paid for** (3–5d): publish the installer where the email points; fix
+  the app build that logs "no services started" and exits; fix the installer's permission
+  target; unfreeze the update feed (frozen since May 25, 141 commits behind); self-serve
+  license rebind.
+- **R4 Make the license mean something** (2–4d): runtime revalidation (revocation is
+  DB-only — the leaked license works until 2027); real hardware binding at run time;
+  rate-limit validation; stop sending the JWT as a URL query param; admin mint/unbind.
+- **R5 Separate the brands** (1–2d): move license infra off `lucyvpa.com` (a client's
+  domain); make the sibling Stripe webhook fail closed; remove the legacy
+  `onlyfriend-ai` webhook; split Resend sender identities.
+- **R6 Measure the web** (1–2d): analytics (conversion is entirely unmeasured); 1MB
+  hotlinked imgur logo; `www` doesn't resolve; page has no `h1`; make the repo the deploy
+  source of truth (opencodec.org is hand-published from Replit, repo copy 3 months stale).
+
+## Open threads
+
+- opencodec.org's `<head>` still tells Google **v2.0 / 234 features / 60 skills / price $0**
+  while its body says v3.2. A plain `curl` sees only the stale numbers. Not fixed — that
+  site's source is stale relative to its Replit deploy (see R6).
+- Decision taken 2026-07-10: **keep the Dr. Jansen Trustpilot testimonial and "Trusted by"
+  card as-is**; only the code-sample email leak was removed.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,6 +1,6 @@
 # HANDOVER — CODEC buyer journey
 
-**Last updated:** 2026-07-10 · session: buyer-journey audit + R1 "stop the lies"
+**Last updated:** 2026-07-10 · session: buyer-journey audit + R1 "stop the lies" + R2 "open the store"
 
 ## State
 
@@ -29,25 +29,47 @@ without a decision from Mickael (see BLOCKERS).
 (`README.md:103`), and the install one-liner already contains `cd codec`. Both were
 unverified low findings. Don't "fix" them.
 
+## What R2 shipped (2026-07-10)
+
+The store has a door. **All four money defects were fixed BEFORE the button went in.**
+
+| Fix | Evidence |
+|-----|----------|
+| Unpaid checkouts minted licenses (`payment_status` never checked) | fails closed now; mutation-tested |
+| A failed delivery email was swallowed with a 200 — no retry, no alert, and any Stripe retry returned early **without re-sending** | retries 3x, logs `email_failed` + ALERT, raises so Stripe's 3-day backoff retries; the retry re-sends. Paid-but-undelivered self-heals |
+| Refunds never revoked — `refunded` was a status no code could set | `charge.refunded` handled; **the live endpoint wasn't even subscribed to it** — subscribed |
+| Year-2 renewal lockout: subscription bills forever, JWT died at 365 days | `invoice.payment_succeeded` + `billing_reason=subscription_cycle` re-mints, extends, emails new key. First invoice explicitly excluded |
+
+- 24 tests pass (13 new, in `test_money_paths.py`). Each guard mutation-tested.
+- Stripe Payment Link **`plink_1TrcDiAnpzAGXuyI2wymB1pR`** → https://buy.stripe.com/8x200i4M58xBfwrbMX6Vq0n
+  Verified: live mode, recurring yearly, $99 USD, and the price **exactly matches** the one
+  `_session_is_codec_purchase()` filters on. A purchase through it will mint.
+- Buy button + honest terms (one Mac / one year / renews / key emailed immediately) on
+  `site/codec.html`, replacing "Launching Q3 2026 · Notify me".
+- `ava-license` restarted; `/health` ok; all guards confirmed present in the running process.
+
+## THE ONE TEST STILL OWED
+
+Nobody has ever completed a real CODEC purchase. I cannot — it needs a card. **Buy it once
+with your own card** through the link above. Expected: key email arrives within a minute,
+download button works. Then say the word and I will refund it via Stripe and verify the
+licence flips to `refunded` — which also proves the refund-revocation path end to end.
+
 ## BLOCKERS (need Mickael)
 
 1. **The site changes are committed but NOT LIVE.** `AVA-site-v2` has no git remote and
    deploys by hand (static upload). Until it is re-published, avadigital.ai/codec still
    shows the fictional SDK **and the client's email address**. This is the single most
    urgent open item.
-2. **R2 needs a money decision** — creating the Stripe Payment Link and putting a Buy
-   button live is outward-facing; not done autonomously.
+2. ~~R2 needs a money decision~~ — **done** (approved 2026-07-10). Payment Link created and
+   wired. Still not visible to buyers until the site is republished (blocker 1).
 3. **Concurrent session warning:** another Claude session is committing in `AVA-site-v2`
    (`fe39df2 "HANDOVER: final InTake SPA deployed"` landed between my two commits).
    Coordinate before working there.
 
 ## Next (R2 → R6, from the audit roadmap)
 
-- **R2 Open the store** (2–3d): one Buy button wired to a Stripe Payment Link matching the
-  price the license server filters on; state terms (1 Mac / 1 year / renews); check
-  `payment_status` before minting; revoke on refund; alert+retry on email failure; fix the
-  year-2 renewal lockout (subscription renews forever, JWT dies at 365 days). Then buy it
-  yourself end-to-end and refund it.
+- ~~**R2 Open the store**~~ — SHIPPED, pending deploy + the one real test purchase.
 - **R3 Deliver what's paid for** (3–5d): publish the installer where the email points; fix
   the app build that logs "no services started" and exits; fix the installer's permission
   target; unfreeze the update feed (frozen since May 25, 141 commits behind); self-serve

--- a/packaging/macos/build_app.sh
+++ b/packaging/macos/build_app.sh
@@ -103,6 +103,52 @@ done
 # any other top-level dashboard/PWA html
 find "$REPO" -maxdepth 1 -name '*.html' -exec cp {} "$CONTENTS/Resources/app/" \; 2>/dev/null || true
 
+# --- first-run + launchd fleet (W5-3 / W5-6) --------------------------------
+# Without these the shipped app has nothing to start: codec_app_main.py calls
+# Resources/first_run.py, which calls Resources/launchd/install_launchagents.sh.
+# Both were designed, built and tested — and then never copied into the bundle,
+# which is why a buyer's app opened and immediately exited.
+echo "==> copying first-run + launchd fleet installer"
+cp "$PKG_DIR/first_run.py"    "$CONTENTS/Resources/first_run.py"
+cp "$PKG_DIR/fetch_models.py" "$CONTENTS/Resources/fetch_models.py"
+cp "$PKG_DIR/models.json"     "$CONTENTS/Resources/models.json"
+cp -R "$PKG_DIR/launchd"      "$CONTENTS/Resources/launchd"
+rm -rf "$CONTENTS/Resources/launchd/__pycache__"
+chmod +x "$CONTENTS/Resources/launchd/"*.sh
+
+# --- services.json: the fleet definition, resolved at BUILD time ------------
+# ecosystem.config.js is a JS module, so reading it requires node. The build
+# machine has node; a BUYER'S MAC DOES NOT (no node, no PM2). Dump the service
+# list to plain JSON now, so install_launchagents.sh can read it on the buyer's
+# machine with stdlib Python alone.
+if command -v node >/dev/null 2>&1; then
+    # Every service in ecosystem.config.js has cwd = the DEVELOPER'S repo path.
+    # Baking that into a buyer's LaunchAgents makes all 15 services fail to start
+    # (the directory doesn't exist on their Mac). Drop the repo-root cwd so the
+    # generator substitutes the bundle's own Resources/app via --workdir.
+    node -e '
+      const [eco, repo] = process.argv.slice(1);
+      const apps = require(eco).apps.map(a => {
+        if (a.cwd === repo) delete a.cwd;   // -> --workdir applies
+        return a;
+      });
+      console.log(JSON.stringify(apps, null, 2));
+    ' "$REPO/ecosystem.config.js" "$REPO" > "$CONTENTS/Resources/services.json"
+
+    # Guard: no developer path may ever reach a buyer.
+    if grep -q "$REPO" "$CONTENTS/Resources/services.json"; then
+        echo "FATAL: services.json still contains the build machine's path ($REPO)." >&2
+        echo "       Those services would not start on a buyer's Mac." >&2
+        exit 1
+    fi
+    SVC_COUNT="$(python3 -c 'import json,sys;print(len(json.load(open(sys.argv[1]))))' "$CONTENTS/Resources/services.json" 2>/dev/null || echo '?')"
+    echo "==> services.json written ($SVC_COUNT services, no build-machine paths)"
+else
+    echo "FATAL: node not found — cannot generate Resources/services.json." >&2
+    echo "       The shipped app would have no fleet to start on a buyer's Mac." >&2
+    exit 1
+fi
+
 # --- optional validation ---------------------------------------------------
 if [ "$VALIDATE" -eq 1 ]; then
     if command -v plutil >/dev/null 2>&1; then

--- a/packaging/macos/first_run.py
+++ b/packaging/macos/first_run.py
@@ -23,6 +23,44 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 SENTINEL = ".first_run_complete"
 
+
+def bundle_contents() -> str | None:
+    """The .app's Contents dir when running from inside the bundle, else None.
+
+    In the bundle build_app.sh copies this file to Contents/Resources/first_run.py,
+    so HERE == .../Contents/Resources and Contents is one parent up. In the repo
+    HERE == packaging/macos and this returns None.
+    """
+    contents = os.path.dirname(HERE)
+    if os.path.basename(contents) == "Contents" and os.path.exists(
+        os.path.join(contents, "Info.plist")
+    ):
+        return contents
+    return None
+
+
+def launchagent_args(contents: str | None) -> list[str]:
+    """Extra args for install_launchagents.sh when running inside the .app.
+
+    A buyer's Mac has no node and no PM2, and no `python3` on PATH that has our
+    dependencies — so point the installer at the bundled interpreter, the bundled
+    source tree, and the services.json that build_app.sh generated at build time.
+    """
+    if not contents:
+        return []
+    resources = os.path.join(contents, "Resources")
+    args: list[str] = []
+    interp = os.path.join(resources, "python", "bin", "python3")
+    if os.path.exists(interp):
+        args += ["--interpreter", interp]
+    workdir = os.path.join(resources, "app")
+    if os.path.isdir(workdir):
+        args += ["--workdir", workdir]
+    services = os.path.join(resources, "services.json")
+    if os.path.exists(services):
+        args += ["--services-json", services]
+    return args
+
 _BASE = "x-apple.systempreferences:com.apple.preference.security?Privacy_"
 PERMISSIONS = [
     {"key": "accessibility", "label": "Accessibility", "deep_link": _BASE + "Accessibility",
@@ -152,6 +190,7 @@ def run(home: str, *, dry_run: bool = False, yes: bool = False,
     os.makedirs(os.path.expanduser("~/Library/Logs/CODEC"), exist_ok=True)
 
     install = ["bash", os.path.join(HERE, "launchd", "install_launchagents.sh")]
+    install += launchagent_args(bundle_contents())
     _run(install + (["--dry-run"] if dry_run else []), dry_run)
 
     fetch = [sys.executable, os.path.join(HERE, "fetch_models.py"), "--tier", "bundled"]

--- a/packaging/macos/launchd/install_launchagents.sh
+++ b/packaging/macos/launchd/install_launchagents.sh
@@ -1,27 +1,36 @@
 #!/bin/bash
 # Install the CODEC fleet as launchd LaunchAgents (W5-3, E-7). OPT-IN.
 #
-# Generates ai.avadigital.codec.<svc>.plist from the PM2 ecosystem, drops them in
+# Generates ai.avadigital.codec.<svc>.plist from the service list, drops them in
 # ~/Library/LaunchAgents/, and bootstraps them into the user's GUI domain.
+#
+# Service list, in priority order:
+#   1. --services-json PATH        (explicit)
+#   2. <script dir>/../services.json  (shipped in the .app — see build_app.sh)
+#   3. <repo>/ecosystem.config.js  (dev machines; requires `node`)
+#
+# (2) exists because a BUYER'S Mac has no node and no PM2: reading the PM2
+# ecosystem there is impossible. build_app.sh dumps the ecosystem to services.json
+# at build time, when node IS present, and ships that.
 #
 # Safety:
 #   * --dry-run prints the plan and touches nothing.
 #   * REFUSES if the PM2 codec fleet is currently running (so it can't double-run
 #     the services on a dev machine) unless --force is given.
 #
-# Usage: install_launchagents.sh [--dry-run] [--force] [--interpreter PATH] [--workdir DIR]
+# Usage: install_launchagents.sh [--dry-run] [--force] [--interpreter PATH]
+#                                [--workdir DIR] [--services-json PATH]
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-REPO="$(cd "$HERE/../../.." && pwd)"
 GEN="$HERE/generate_launchagents.py"
-ECOSYSTEM="$REPO/ecosystem.config.js"
 AGENTS_DIR="$HOME/Library/LaunchAgents"
 
 DRY_RUN=0
 FORCE=0
 INTERP=""
 WORKDIR=""
+SERVICES_JSON=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -29,10 +38,16 @@ while [ $# -gt 0 ]; do
         --force) FORCE=1; shift ;;
         --interpreter) INTERP="$2"; shift 2 ;;
         --workdir) WORKDIR="$2"; shift 2 ;;
+        --services-json) SERVICES_JSON="$2"; shift 2 ;;
         -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) echo "install_launchagents.sh: unknown arg: $1" >&2; exit 2 ;;
     esac
 done
+
+# Resolve the service list without requiring node wherever possible.
+if [ -z "$SERVICES_JSON" ] && [ -f "$HERE/../services.json" ]; then
+    SERVICES_JSON="$HERE/../services.json"
+fi
 
 # --- guard: don't double-run on top of a live PM2 fleet --------------------
 if command -v pm2 >/dev/null 2>&1; then
@@ -48,11 +63,29 @@ if command -v pm2 >/dev/null 2>&1; then
     fi
 fi
 
-GEN_ARGS=(--from-ecosystem "$ECOSYSTEM" --out "$AGENTS_DIR")
+if [ -n "$SERVICES_JSON" ]; then
+    [ -f "$SERVICES_JSON" ] || { echo "services JSON not found: $SERVICES_JSON" >&2; exit 1; }
+    GEN_ARGS=(--from-json "$SERVICES_JSON" --out "$AGENTS_DIR")
+else
+    REPO="$(cd "$HERE/../../.." && pwd)"
+    ECOSYSTEM="$REPO/ecosystem.config.js"
+    [ -f "$ECOSYSTEM" ] || {
+        echo "no service list: pass --services-json, ship services.json, or run from the repo" >&2
+        exit 1
+    }
+    command -v node >/dev/null 2>&1 || {
+        echo "node is required to read $ECOSYSTEM. On a machine without node, use" >&2
+        echo "  --services-json PATH  (build_app.sh ships one inside the .app)" >&2
+        exit 1
+    }
+    GEN_ARGS=(--from-ecosystem "$ECOSYSTEM" --out "$AGENTS_DIR")
+fi
 [ -n "$INTERP" ] && GEN_ARGS+=(--interpreter "python3=$INTERP" --interpreter "/usr/local/bin/python3.13=$INTERP")
 [ -n "$WORKDIR" ] && GEN_ARGS+=(--workdir "$WORKDIR")
 
-PY="$(command -v python3)"
+# Inside the .app the only interpreter is the bundled one; python3 may not be on PATH.
+PY="${INTERP:-$(command -v python3 || true)}"
+[ -n "$PY" ] || { echo "no python3 found (pass --interpreter)" >&2; exit 1; }
 
 if [ "$DRY_RUN" -eq 1 ]; then
     echo "[dry-run] would generate LaunchAgents into $AGENTS_DIR:"

--- a/packaging/macos/launcher/codec_app_main.py
+++ b/packaging/macos/launcher/codec_app_main.py
@@ -5,22 +5,34 @@ Thin, **stdlib-only** bootstrap that the bundle launcher (``Contents/MacOS/codec
 execs. It must run before any virtualenv / dependency wiring, so it imports
 nothing from the CODEC engine and nothing third-party.
 
-W5-2 scope: establish the bundle's runtime identity, logging, and a SAFE
-``--selftest``. It deliberately does **not** start the 16-service fleet — under
-the current architecture those run via PM2, and the launchd migration is W5-3.
-Running this normally just records a launch line and exits 0; it never touches a
-running fleet.
+Establishes the bundle's runtime identity, logging, a SAFE ``--selftest``, and —
+when launched from inside the .app — starts the CODEC service fleet.
 
-See docs/W5-2-APP-BUNDLE-DESIGN.md.
+2026-07: W5-3 (the PM2 -> launchd migration) shipped `launchd/` and `first_run.py`
+and wired them to each other, but nothing ever called first_run, and build_app.sh
+never copied it into the bundle. So this entry point kept logging "fleet start
+deferred to W5-3; no services started" and exiting 0 — a buyer's app opened and
+immediately quit. main() now runs first-run (idempotent, sentinel-guarded) and
+thereafter re-bootstraps the fleet if launchd has dropped it.
+
+SOURCE-TREE SAFETY IS PRESERVED: outside an .app bundle this still starts nothing,
+because on a developer's machine the fleet runs under PM2 and double-running it
+would be destructive. That was the right instinct in W5-2; it just also needs to
+do something when it IS the shipped app.
+
+See docs/W5-2-APP-BUNDLE-DESIGN.md, docs/W5-3-LAUNCHD-DESIGN.md.
 """
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 MIN_PY = (3, 11)
+FLEET_LABEL_PREFIX = "ai.avadigital.codec"
+SENTINEL = ".first_run_complete"
 
 
 def _home() -> Path:
@@ -100,6 +112,77 @@ def selftest() -> int:
     return 0
 
 
+def _fleet_loaded() -> int:
+    """How many CODEC LaunchAgents launchd currently knows about."""
+    try:
+        out = subprocess.run(["launchctl", "list"], capture_output=True, text=True,
+                             timeout=15).stdout
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    return sum(1 for line in out.splitlines() if FLEET_LABEL_PREFIX in line)
+
+
+def _run_first_run(resources: Path) -> int:
+    """Install the launchd fleet, fetch models, report permissions. Idempotent:
+    first_run.py no-ops once ~/.codec/.first_run_complete exists."""
+    script = resources / "first_run.py"
+    if not script.exists():
+        _log(f"FLEET ERROR: first_run.py missing from bundle ({script})")
+        return 1
+    proc = subprocess.run([sys.executable, str(script), "--home", str(_codec_dir())],
+                          capture_output=True, text=True)
+    for line in (proc.stdout or "").splitlines():
+        _log(f"  first-run: {line}")
+    if proc.returncode != 0:
+        _log(f"FLEET ERROR: first-run exited {proc.returncode}: {(proc.stderr or '').strip()[:300]}")
+    return proc.returncode
+
+
+def _bootstrap_fleet(resources: Path) -> int:
+    """Re-install the LaunchAgents when launchd has forgotten them (e.g. the user
+    ran the uninstaller's launchctl bootout, or agents were pruned)."""
+    script = resources / "launchd" / "install_launchagents.sh"
+    if not script.exists():
+        _log(f"FLEET ERROR: install_launchagents.sh missing from bundle ({script})")
+        return 1
+    interp = resources / "python" / "bin" / "python3"
+    cmd = ["bash", str(script)]
+    if interp.exists():
+        cmd += ["--interpreter", str(interp)]
+    if (resources / "app").is_dir():
+        cmd += ["--workdir", str(resources / "app")]
+    if (resources / "services.json").exists():
+        cmd += ["--services-json", str(resources / "services.json")]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        _log(f"FLEET ERROR: bootstrap exited {proc.returncode}: {(proc.stderr or '').strip()[:300]}")
+    return proc.returncode
+
+
+def start_fleet(contents: Path) -> int:
+    """Ensure the CODEC fleet is installed and running under launchd."""
+    resources = contents / "Resources"
+    home = _codec_dir()
+
+    if not (home / SENTINEL).exists():
+        _log("first launch — installing the CODEC fleet")
+        rc = _run_first_run(resources)
+        if rc != 0:
+            return rc
+    elif _fleet_loaded() == 0:
+        _log("fleet not loaded in launchd — re-bootstrapping")
+        rc = _bootstrap_fleet(resources)
+        if rc != 0:
+            return rc
+
+    n = _fleet_loaded()
+    if n == 0:
+        _log("FLEET ERROR: no CODEC LaunchAgents are loaded after setup")
+        return 1
+    _log(f"fleet running: {n} launchd service(s)")
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if "--selftest" in argv:
         return selftest()
@@ -107,11 +190,14 @@ def main(argv: list[str]) -> int:
     contents = _bundle_contents()
     where = str(contents) if contents else "source tree"
     _log(f"CODEC launched from {where}")
-    # W5-2: fleet orchestration (the 16 PM2 services) is deferred to W5-3
-    # (launchd migration). We intentionally do NOT start or touch a running
-    # fleet here — that would interfere with a developer machine.
-    _log("fleet start deferred to W5-3 (launchd); no services started")
-    return 0
+
+    if contents is None:
+        # Developer machine: the fleet runs under PM2 (ecosystem.config.js).
+        # Starting launchd agents here would double-run every service.
+        _log("source tree — fleet is managed by PM2; not starting anything")
+        return 0
+
+    return start_fleet(contents)
 
 
 if __name__ == "__main__":

--- a/tests/test_fleet_start.py
+++ b/tests/test_fleet_start.py
@@ -1,0 +1,295 @@
+"""The shipped .app must actually start the CODEC fleet (W5-2 x W5-3 wiring).
+
+2026-07 buyer-journey audit, finding D2: a paying customer's app launched, logged
+"fleet start deferred to W5-3 (launchd); no services started", and exited 0.
+
+The cause was never missing engineering. `launchd/generate_launchagents.py`,
+`launchd/install_launchagents.sh` and `first_run.py` all existed and were tested,
+and first_run even invoked the installer. But:
+
+  1. `codec_app_main.py:main()` never called first_run — nothing did.
+  2. `build_app.sh` never copied first_run.py or launchd/ into the bundle, so the
+     files a buyer received did not contain them.
+  3. `install_launchagents.sh` read the service list from ecosystem.config.js via
+     `node`, which a buyer's Mac does not have.
+
+Each test below pins one of those three, plus the dev-machine safety property
+that made W5-2 defer in the first place: outside a bundle, start NOTHING (the
+fleet runs under PM2 there and double-running it is destructive).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+PKG = REPO / "packaging" / "macos"
+ENTRY = PKG / "launcher" / "codec_app_main.py"
+BUILD = PKG / "build_app.sh"
+INSTALL_SH = PKG / "launchd" / "install_launchagents.sh"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def entry():
+    return _load(ENTRY, "codec_app_main_under_test")
+
+
+@pytest.fixture
+def first_run():
+    return _load(PKG / "first_run.py", "first_run_under_test")
+
+
+def _fake_bundle(tmp_path: Path) -> Path:
+    """A minimal .app skeleton: Contents/{Info.plist,MacOS/codec,Resources/...}"""
+    contents = tmp_path / "Sovereign AI Workstation.app" / "Contents"
+    (contents / "MacOS").mkdir(parents=True)
+    (contents / "MacOS" / "codec").write_text("#!/bin/sh\n")
+    res = contents / "Resources"
+    (res / "launchd").mkdir(parents=True)
+    (res / "app").mkdir()
+    (res / "python" / "bin").mkdir(parents=True)
+    (res / "python" / "bin" / "python3").write_text("#!/bin/sh\n")
+    (res / "first_run.py").write_text("#\n")
+    (res / "launchd" / "install_launchagents.sh").write_text("#!/bin/bash\n")
+    (res / "services.json").write_text("[]")
+    with (contents / "Info.plist").open("wb") as fh:
+        plistlib.dump({"CFBundleName": "Sovereign AI Workstation"}, fh)
+    return contents
+
+
+# ── 1. main() must start the fleet inside a bundle ──────────────────────────
+
+def test_main_runs_first_run_on_first_launch(entry, tmp_path, monkeypatch):
+    contents = _fake_bundle(tmp_path)
+    home = tmp_path / "codec_home"
+    home.mkdir()
+    calls = []
+
+    monkeypatch.setattr(entry, "_bundle_contents", lambda: contents)
+    monkeypatch.setattr(entry, "_codec_dir", lambda: home)
+    monkeypatch.setattr(entry, "_log", lambda *_a: None)
+    monkeypatch.setattr(entry, "_fleet_loaded", lambda: 15)
+    monkeypatch.setattr(entry, "_run_first_run", lambda res: calls.append(res) or 0)
+
+    assert entry.main([]) == 0
+    assert calls, "first launch must run first_run.py — this is the bug that shipped"
+
+
+def test_main_does_not_rerun_first_run_once_complete(entry, tmp_path, monkeypatch):
+    contents = _fake_bundle(tmp_path)
+    home = tmp_path / "codec_home"
+    home.mkdir()
+    (home / entry.SENTINEL).write_text("ok\n")
+
+    monkeypatch.setattr(entry, "_bundle_contents", lambda: contents)
+    monkeypatch.setattr(entry, "_codec_dir", lambda: home)
+    monkeypatch.setattr(entry, "_log", lambda *_a: None)
+    monkeypatch.setattr(entry, "_fleet_loaded", lambda: 15)
+    monkeypatch.setattr(entry, "_run_first_run",
+                        lambda res: pytest.fail("must not re-run first_run"))
+
+    assert entry.main([]) == 0
+
+
+def test_main_rebootstraps_when_launchd_dropped_the_fleet(entry, tmp_path, monkeypatch):
+    contents = _fake_bundle(tmp_path)
+    home = tmp_path / "codec_home"
+    home.mkdir()
+    (home / entry.SENTINEL).write_text("ok\n")
+    loaded = {"n": 0}
+    boots = []
+
+    monkeypatch.setattr(entry, "_bundle_contents", lambda: contents)
+    monkeypatch.setattr(entry, "_codec_dir", lambda: home)
+    monkeypatch.setattr(entry, "_log", lambda *_a: None)
+    monkeypatch.setattr(entry, "_fleet_loaded", lambda: loaded["n"])
+
+    def boot(res):
+        boots.append(res)
+        loaded["n"] = 15
+        return 0
+
+    monkeypatch.setattr(entry, "_bootstrap_fleet", boot)
+    assert entry.main([]) == 0
+    assert boots, "an empty launchd fleet must be re-bootstrapped"
+
+
+def test_main_fails_when_no_services_come_up(entry, tmp_path, monkeypatch):
+    """Silence is not success: if nothing is loaded after setup, say so."""
+    contents = _fake_bundle(tmp_path)
+    home = tmp_path / "codec_home"
+    home.mkdir()
+
+    monkeypatch.setattr(entry, "_bundle_contents", lambda: contents)
+    monkeypatch.setattr(entry, "_codec_dir", lambda: home)
+    monkeypatch.setattr(entry, "_log", lambda *_a: None)
+    monkeypatch.setattr(entry, "_run_first_run", lambda res: 0)
+    monkeypatch.setattr(entry, "_fleet_loaded", lambda: 0)
+
+    assert entry.main([]) == 1
+
+
+# ── 2. dev-machine safety: outside a bundle, start nothing ──────────────────
+
+def test_source_tree_starts_nothing(entry, monkeypatch):
+    """PM2 owns the fleet on a developer's machine; launchd must not double-run it."""
+    monkeypatch.setattr(entry, "_bundle_contents", lambda: None)
+    monkeypatch.setattr(entry, "_log", lambda *_a: None)
+    monkeypatch.setattr(entry, "start_fleet",
+                        lambda c: pytest.fail("must never start the fleet from the source tree"))
+    assert entry.main([]) == 0
+
+
+def test_selftest_still_starts_nothing(entry, monkeypatch):
+    monkeypatch.setattr(entry, "start_fleet",
+                        lambda c: pytest.fail("--selftest must not start the fleet"))
+    assert entry.main(["--selftest"]) in (0, 1)
+
+
+# ── 3. the bundle must actually contain what main() calls ──────────────────
+
+@pytest.mark.parametrize("copy_cmd", [
+    'cp "$PKG_DIR/first_run.py"',
+    'cp "$PKG_DIR/fetch_models.py"',
+    'cp "$PKG_DIR/models.json"',
+    'cp -R "$PKG_DIR/launchd"',
+])
+def test_build_app_bundles_the_fleet_installer(copy_cmd):
+    """Assert the actual copy COMMAND, not just the filename appearing somewhere:
+    the filenames also occur in comments, so a substring check passes even after
+    the cp line is deleted (caught by mutation-testing this very test)."""
+    src = BUILD.read_text()
+    assert copy_cmd in src, (
+        f"build_app.sh must run `{copy_cmd}`; without it the shipped app has "
+        f"nothing to start"
+    )
+
+
+def test_build_app_generates_services_json_at_build_time():
+    src = BUILD.read_text()
+    assert "services.json" in src, "build must emit Resources/services.json"
+    assert "ecosystem.config.js" in src and "node -e" in src, \
+        "services.json must be dumped from the PM2 ecosystem while node is available"
+    assert "FATAL: node not found" in src, \
+        "a build without node must fail loudly, not ship an app with no fleet"
+
+
+def test_build_app_strips_the_developers_repo_path():
+    """Every service in ecosystem.config.js has cwd = the build machine's repo.
+    Shipping that verbatim makes all 15 services fail on a buyer's Mac, because
+    the directory does not exist there. Caught during the 2026-07 fleet wiring."""
+    src = BUILD.read_text()
+    assert "delete a.cwd" in src, "the repo-root cwd must be dropped so --workdir applies"
+    assert 'grep -q "$REPO"' in src and "FATAL: services.json still contains" in src, \
+        "the build must FAIL if a build-machine path survives into services.json"
+
+
+def test_generator_substitutes_workdir_when_cwd_is_the_repo_root():
+    sys.path.insert(0, str(PKG / "launchd"))
+    import generate_launchagents as gen
+
+    # cwd absent (build_app.sh deleted it) -> the bundle's workdir is used
+    _lbl, plist = gen.pm2_app_to_launchd(
+        {"name": "svc", "script": "x.py"}, default_workdir="/App/Resources/app")
+    assert plist["WorkingDirectory"] == "/App/Resources/app"
+
+    # cwd == repo root and repo_root known -> also substituted
+    _lbl, plist = gen.pm2_app_to_launchd(
+        {"name": "svc", "script": "x.py", "cwd": "/repo"},
+        default_workdir="/App/Resources/app", repo_root="/repo")
+    assert plist["WorkingDirectory"] == "/App/Resources/app"
+
+    # an unrelated absolute cwd is preserved
+    _lbl, plist = gen.pm2_app_to_launchd(
+        {"name": "svc", "script": "x.py", "cwd": "/opt/other"},
+        default_workdir="/App/Resources/app", repo_root="/repo")
+    assert plist["WorkingDirectory"] == "/opt/other"
+
+
+# ── 4. the buyer's Mac has no node ─────────────────────────────────────────
+
+def test_install_script_accepts_a_services_json():
+    src = INSTALL_SH.read_text()
+    assert "--services-json" in src and "--from-json" in src, \
+        "installer must read a prebuilt services.json (a buyer's Mac has no node)"
+
+
+def test_install_script_prefers_bundled_services_json_over_node():
+    src = INSTALL_SH.read_text()
+    i_json = src.index("--from-json")
+    i_eco = src.index("--from-ecosystem", src.index("GEN_ARGS"))
+    assert i_json < i_eco, "the node-free path must be tried before the node path"
+
+
+def test_install_script_errors_clearly_when_node_is_missing():
+    src = INSTALL_SH.read_text()
+    assert "node is required" in src and "--services-json" in src
+
+
+def test_install_script_is_valid_bash():
+    r = subprocess.run(["bash", "-n", str(INSTALL_SH)], capture_output=True, text=True)
+    assert r.returncode == 0, f"syntax error: {r.stderr}"
+
+
+def test_build_app_is_valid_bash():
+    r = subprocess.run(["bash", "-n", str(BUILD)], capture_output=True, text=True)
+    assert r.returncode == 0, f"syntax error: {r.stderr}"
+
+
+# ── 5. first_run passes the bundle's own interpreter / workdir / services ──
+
+def test_first_run_detects_a_bundle(first_run, tmp_path, monkeypatch):
+    contents = _fake_bundle(tmp_path)
+    monkeypatch.setattr(first_run, "HERE", str(contents / "Resources"))
+    assert first_run.bundle_contents() == str(contents)
+
+
+def test_first_run_in_source_tree_is_not_a_bundle(first_run):
+    assert first_run.bundle_contents() is None
+
+
+def test_first_run_passes_bundle_paths_to_the_installer(first_run, tmp_path):
+    contents = _fake_bundle(tmp_path)
+    args = first_run.launchagent_args(str(contents))
+    assert "--interpreter" in args, "must use the bundled python, not one on PATH"
+    assert "--workdir" in args, "services must run from Resources/app"
+    assert "--services-json" in args, "must use the prebuilt service list (no node)"
+    interp = args[args.index("--interpreter") + 1]
+    assert interp.endswith("Resources/python/bin/python3")
+
+
+def test_first_run_passes_nothing_extra_outside_a_bundle(first_run):
+    assert first_run.launchagent_args(None) == []
+
+
+# ── 6. the generator really can build plists from that JSON, no node ───────
+
+def test_generator_builds_plists_from_services_json(tmp_path):
+    sys.path.insert(0, str(PKG / "launchd"))
+    import generate_launchagents as gen
+
+    services = [{"name": "dashboard", "script": "codec_dashboard.py",
+                 "interpreter": "python3", "autorestart": True}]
+    p = tmp_path / "services.json"
+    p.write_text(json.dumps(services))
+
+    apps = gen.load_from_json(str(p))
+    out = gen.generate_all(apps, interpreter_map={}, default_workdir="/app",
+                           repo_root=None, log_dir=str(tmp_path))
+    assert "ai.avadigital.codec.dashboard" in out
+    plist = plistlib.loads(out["ai.avadigital.codec.dashboard"])
+    assert plist["RunAtLoad"] is True
+    assert plist["KeepAlive"] is True


### PR DESCRIPTION
Audit finding **D2**: a paying customer's app launched, logged `"fleet start deferred to W5-3 (launchd); no services started"`, and exited 0.

**The engineering was never missing.** `generate_launchagents.py`, `install_launchagents.sh` and `first_run.py` all existed and were tested — first_run even invoked the installer. Three wires were never connected:

1. **Nothing called `first_run`.** `main()` now runs it on first launch (sentinel-idempotent), re-bootstraps if launchd dropped the fleet, and **fails loudly** when no agents load. Source-tree safety preserved: outside a bundle it still starts nothing (PM2 owns the fleet on a dev machine).
2. **`build_app.sh` never copied `first_run.py` or `launchd/` into the bundle.** A buyer's `.app` contained only `{app, codec_app_main.py, python}`.
3. **A buyer's Mac has no `node`.** The installer read `ecosystem.config.js` via node. The build now dumps `Resources/services.json` at build time; the installer prefers it.

**Found while verifying, not by reading:** every service's `cwd` is the *build machine's* repo path. Shipped verbatim, all 15 services would fail on a buyer's Mac. The build now strips it and **fails if any build-machine path survives**.

**Verified end to end:** built a real bundle, then regenerated all 15 LaunchAgents with `node` removed from `PATH` → 15 valid plists (`plutil -lint` OK), each pointing at the bundled interpreter and `Resources/app`.

23 new tests, each **mutation-tested**. (The bundling test was rewritten after mutation testing showed the first version passed a deleted `cp` line.) Full suite: **2497 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)