### PR TITLE
feat(mcp): CODEC as MCP client (bidirectional) + 25-beat demo script

### DIFF
--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -1,83 +1,89 @@
-# CODEC Live Demo — Full Flow
+# CODEC Live Demo — Full Flow (25 beats)
 
-> Recovered from the April 12–14, 2026 planning session and expanded with the
-> features validated since. This is the locked recording scenario. Steps are
-> tested one-by-one before recording. Can't show all ~400 features — this picks
-> the highest-impact, most-jaw-dropping beats.
+> The locked recording scenario. Originally 15 steps (April 2026), expanded to 22,
+> now 25. Each beat has an exact **TRY** line to run live and an **EXPECT** so you
+> can confirm or flag it. Status legend:
+> ✅ done/works · ⚠️ half-built (fix before filming) · 🟡 seen once, re-confirm ·
+> 🔴 never run · ❌ not real yet (build before filming) · 🆕 new beat.
 
 ## Act 1 — It hears you and keeps its word (trust loop)
 
-| # | Page | Feature | Key Moment |
-|---|------|---------|------------|
-| 1 | `opencodec.org` | Wake Word + Calendar + Google Tasks | "Add to my to-do list: edit and upload demo video by tomorrow." |
-| 2 | GitHub → Safari | Voice App Control | "Open Time Magazine in Safari" |
-| 3 | Safari — Time Magazine | Instant — Read Aloud (Kokoro TTS) | Select paragraph → voice reads it aloud |
-| 4 | Gmail — client email | Vision + Draft reply | "Look at my screen and reply" → polished draft |
-| 5 | Calendar + Tasks | Trust moment — receipts from Step 1 | Show the task added in Step 1 is real |
-| 6 | WhatsApp Web — Ukrainian msg | Instant — Translate (UA → EN) | Right-click → instant translation |
+| # | Feature | TRY (live) | EXPECT | Status |
+|---|---|---|---|---|
+| 1 | Wake word + Calendar + Tasks | "Hey CODEC — add 'edit and upload demo video' to my calendar tomorrow 3pm, and to my to-do list." | Event on Google Calendar tomorrow 15:00 + a Google Task, both created | 🟡 |
+| 2 | Voice app control | "Open Time Magazine in Safari." | Safari opens time.com | 🟡 |
+| 3 | Instant Read Aloud (Kokoro TTS) | Select a paragraph → trigger Read Aloud | CODEC reads the selection in a natural voice | 🟡 |
+| 4 | Vision + draft reply | Open a client email in Gmail → "Look at my screen and draft a reply." | A polished, context-aware draft appears | 🟡 |
+| 5 | Trust receipt | Open Calendar + Tasks | The event + task from beat 1 are really there | 🟡 |
+| 6 | Instant Translate (UA→EN) | Select a Ukrainian WhatsApp message → Translate | Instant English translation in place | 🟡 |
 
 ## Act 2 — It sees and controls the machine
 
-| # | Page | Feature | Key Moment |
-|---|------|---------|------------|
-| 7 | Cloudflare DNS | **Vision Mouse Control (showstopper)** | "Click the DNS button" → cursor moves + clicks |
-| 8 | Menu → Live Video (PIP) | **Live webcam access** | Show CODEC can see through the webcam live |
-| 9 | CODEC Chat — Think mode | Reasoning + reveal | Ask a logic prompt (rate trap / car wash) → click "Reveal train of thought" |
+| # | Feature | TRY (live) | EXPECT | Status |
+|---|---|---|---|---|
+| 7 | **Vision Mouse Control** (showstopper) | On Cloudflare DNS: "Click the DNS button." | Cursor moves to the button and clicks it | ✅ done, worked |
+| 8 | Live webcam access (PIP) | "CODEC, look through my webcam — what do you see?" | CODEC describes the live webcam view | 🔴 |
+| 9 | Think mode + reveal | Ask a logic prompt (rate-trap / car-wash) with Think on → click "Reveal train of thought" | Correct answer + a readable reasoning panel | ✅ |
 
-## Act 3 — Autonomous & agentic (the "it works while you watch" act)
+## Act 3 — Autonomous & agentic (works while you watch)
 
-| # | Page | Feature | Key Moment |
-|---|------|---------|------------|
-| 10 | CODEC Chat — Agent Mode | Deep Research crew launched | "Runs for a few minutes — I'll show the rest while it works" |
-| 11 | CODEC Chat — **Project mode** | Drop-a-project autonomous agent | "Research top 5 Notion competitors, build a table, save to Drive" → approve plan once → it runs autonomously, messages you progress. Grant a domain live. |
-| 12 | Chat (auto-escalation) | CODEC offers to promote | Type a complex ask in chat → "Promote to Project mode?" |
-| 13 | CODEC Vibe | AI coding IDE (Monaco + live preview) | "Build me a snake game" → watch code write itself live |
-| 14 | CODEC Pilot | Browser automation you can teach | Record a task once (e.g. check a flight price) → CODEC compiles it into a reusable skill → replay it |
+| # | Feature | TRY (live) | EXPECT | Status |
+|---|---|---|---|---|
+| 10 | Deep Research crew | Agent mode: "Research the top 5 Notion competitors and summarize." | "Runs a few minutes" — crew launches, streams progress | 🟡 |
+| 11 | **Project mode** | Project: "Research Notion, Figma and Linear; draft a personalized Head-of-Growth outreach email to each; save them as Gmail drafts." Approve the plan once. | Approve once → runs autonomously → 3 Gmail drafts appear | ✅ verified |
+| 12 | Chat auto-escalation | In chat, type a big multi-step ask (e.g. "plan and build me a 5-page competitor report with charts"). | CODEC offers "Promote to Project mode?" | 🔴 |
+| 13 | **Vibe** live coding | Vibe: "Build me a snake game." | Code writes itself live in Monaco; preview plays | ✅ |
+| 14 | **Pilot** — teach & replay | Pilot: record "check the price of a MacBook on Amazon" once → replay | Records the run, compiles a reusable skill, replays it | ⚠️ half-broken — FIX FIRST |
 
 ## Act 4 — The nerve center & the payoff
 
-| # | Page | Feature | Key Moment |
-|---|------|---------|------------|
-| 15 | CODEC Cortex | Neural map | Pulsing zones, explain each |
-| 16 | CODEC Audit | Event log (16 categories) | Filter → show everything was logged |
-| 17 | Deep Research report (Google Doc) | Agent payoff | Open the doc from Step 10 — full report, real citations, native tables, relevant images |
+| # | Feature | TRY (live) | EXPECT | Status |
+|---|---|---|---|---|
+| 15 | Cortex neural map | Open Cortex | Pulsing zones; narrate each subsystem | 🟡 |
+| 16 | Audit log (16 categories) | Open Audit → filter by category | Every action from the demo is logged | 🟡 |
+| 17 | Deep Research → **Google Doc** | Open the doc from beat 10 | A real Google Doc: report, citations, native tables | ❌ only writes local .md — BUILD FIRST |
 
-## Act 5 — Claude gets superpowers, and the memory reveal
+## Act 5 — Claude gets superpowers + bidirectional MCP
 
-| # | Page | Feature | Key Moment |
-|---|------|---------|------------|
-| 18 | Claude Desktop (CODEC MCP) | **CODEC as MCP server** | To Claude: "Research the 3 best noise-cancelling headphones, then use CODEC to save your summary to my Mac Desktop, add a calendar reminder, and dim my office lights." Claude's brain + CODEC's local hands. |
-| 19 | CODEC voice / terminal | **Observer recall** | "Hey CODEC, what was I doing 20 minutes ago?" → it recalls (Safari on Time Magazine, etc.) from its continuous observation buffer |
+| # | Feature | TRY (live) | EXPECT | Status |
+|---|---|---|---|---|
+| 18 | **CODEC as MCP server** (for Claude) | In Claude Desktop (CODEC connector on): "Research the 3 best noise-cancelling headphones, then use CODEC to save the summary to my Desktop, add a calendar reminder, and dim my office lights." | Claude thinks, CODEC acts locally: file saved, reminder set, lights dim | 🔴 |
+| 23 | **CODEC as MCP client** 🆕 (bidirectional punch — right after 18) | "CODEC, connect to my [Notion] MCP and create a page titled 'Demo notes'." | CODEC calls out to the external MCP server and does it | 🆕 BUILD |
+| 19 | Observer recall | "Hey CODEC, what was I doing 20 minutes ago?" | Recalls Safari/Time, the Gmail draft, etc. from its buffer | 🟡 |
 
-## Act 6 — Voice + the finale
+## Act 6 — Voice, self-improvement, and the finale
 
-| # | Page | Feature | Key Moment |
-|---|------|---------|------------|
-| 20 | CODEC Voice Call | Live voice + mid-call interrupt | Interrupt CODEC mid-sentence → cuts instantly (proves real-time control) |
-| 21 | Phone → `codec.avadigital.ai` (Touch ID) | Remote access | Touch ID on phone → Mac Studio at home executes the command |
-| 22 | **FINALE** | Hue + Spotify | "CODEC, turn off the lights." (Philips Hue) → "CODEC, play music on Spotify." Lights dim, music starts. Cut. |
+| # | Feature | TRY (live) | EXPECT | Status |
+|---|---|---|---|---|
+| 24 | **Self-improve live** 🆕 | "CODEC, create a new skill that tells me the current moon phase." | CODEC writes itself a new skill on camera, then uses it | 🆕 |
+| 25 | **Compare** 🆕 | "Compare across models: what's the best programming language for a beginner?" | Side-by-side answers from multiple models | 🆕 |
+| 20 | Voice call + interrupt | Start a voice call → interrupt CODEC mid-sentence | It cuts instantly (proves real-time control) | 🔴 |
+| 21 | Phone Touch ID remote | On phone at `codec.avadigital.ai` → Touch ID → issue a command | Mac Studio at home executes it | 🔴 |
+| 22 | **FINALE** — Hue + Spotify | "CODEC, turn off the lights." then "CODEC, play music on Spotify." | Lights dim, music starts. Cut. | 🔴 |
+
+## Build-before-filming (not test items — make them real)
+- **#14 Pilot** — half-broken; fix the teach/replay.
+- **#17 Google Doc** — currently writes a local `.md`; build the real Drive-doc deliverable + a completion verifier.
+- **#23 MCP client** — new capability (CODEC → other MCP servers).
+- **#24 / #25** — wire the demo phrasing (skills exist: `create_skill`, `self_improve`, `compare`).
+
+## Test order (resume here)
+Software beats I can help verify headlessly: **11 ✅, 13 ✅**, then **10, 12, 23, 24, 25, 17**.
+Hardware/voice beats only Mickael can run: **1–6, 7 ✅, 8, 9 ✅, 18, 19, 20, 21, 22.**
 
 ## Pre-Record Checklist
-
-- Chrome tabs left-to-right: `opencodec.org` → GitHub → Gmail → WhatsApp Web → Cloudflare → CODEC Chat
-- Safari (separate window): Time Magazine article open
-- Claude Desktop open with the CODEC MCP connector active (Act 5)
-- Phone on desk: `codec.avadigital.ai` loaded, Touch ID ready
-- Philips Hue reachable; Spotify open and authorized (finale)
-- Vision Mouse Control tested 10× on the Cloudflare DNS button (must work twice clean in a row)
-- Observer running with a buffer (test "what was I doing" beforehand)
-- Fresh Deep Research + Project chat windows open
+- Chrome tabs L→R: `opencodec.org` → GitHub → Gmail → WhatsApp Web → Cloudflare → CODEC Chat
+- Safari: Time Magazine article open
+- Claude Desktop: CODEC MCP connector active (Act 5)
+- Phone: `codec.avadigital.ai` loaded, Touch ID ready
+- Philips Hue reachable; Spotify authorized (finale)
+- Vision Mouse tested 10× on the Cloudflare DNS button
+- Observer running with a buffer
+- Fresh Deep-Research + Project chat windows open
 
 ## Director's Notes
-
-- **Trust loop:** Steps 1 → 5 are the emotional hook — promise, then deliver.
-- **Showstopper risk:** Step 7 (Vision Mouse) — if it fails live, skip to Step 9.
-- **The "works while you watch" trio** (11 Project, 13 Vibe, 14 Pilot) is the core wow.
-- **Act 5 is the differentiator:** no other assistant lets Claude reach into your actual Mac.
-- **Save Hue + Spotify for the very last frame** — clean, human, memorable close.
-
-## Separate: 10-point technical validation (QA, not the demo)
-
-Run before recording: 1 Voice pipeline · 2 Dictate · 3 Dashboard security ·
-4 Chat & Flash · 5 Agents · 6 Skills · 7 Memory/FTS5 · 8 MCP server ·
-9 Infra/resilience · 10 Cortex & Audit.
+- Trust loop (1→5) is the emotional hook — promise, then deliver.
+- Showstopper risk: 7 (Vision Mouse) — if it fails live, skip to 9.
+- Core wow: the "works while you watch" trio (11 Project, 13 Vibe, 14 Pilot).
+- Act 5 is the differentiator: 18 (server) + 23 (client) back-to-back = bidirectional MCP.
+- Save Hue + Spotify (22) for the very last frame.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Sovereign AI Workstation — Full Product Breakdown
 
-> Engine: **CODEC v3.2** — 400 features · 86 skills · 2000+ tests · 52K+ lines of production code · 9 products
+> Engine: **CODEC v3.2** — 400 features · 87 skills · 2000+ tests · 52K+ lines of production code · 9 products
 
 The product name is **Sovereign AI Workstation**. Throughout this document
 and the codebase, **CODEC** refers to the underlying open-source engine /
@@ -594,7 +594,7 @@ The 8th product — a complete browser-automation pillar with a dedicated headle
 | 14. CODEC Pilot — Browser Automation You Can Teach *(v2.3)* | 32 |
 | **TOTAL** | **400** |
 
-**400 features · 86 skills · 2000+ tests · 52K+ lines of production code · 9 products**
+**400 features · 87 skills · 2000+ tests · 52K+ lines of production code · 9 products**
 
 ### What's new in v3.2
 

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -52,6 +52,7 @@
     "health_check.py": "01ac95da13770e2419460b4aaf1bd79c6628b6bc5413a5608153b81feee81568",
     "imessage_send.py": "862f7031a525faed4cec7cb703ef32f5d8bdc1045326f880d50455baf4cfcf86",
     "json_formatter.py": "42a770a1455a574d33e2f96f34c63ae7a83845f70789862e5e5198d0b429fde2",
+    "mcp_connect.py": "ded20c46eede06f1d39c78c4f5eda45e1347f4529fc12c4c43d885f33c5c1735",
     "memory_entities.py": "252ad5861d614b916504b8af6300c4a8c62622c9f6c15238b11d6c6a052bada7",
     "memory_history.py": "a2762c03c325517d10907f8aa9511103a5716a29f9e956d48473b817105fb65c",
     "memory_save.py": "3d801338bfd0818aaf1e65e692e404af0a0fba6886d26150f0fb66e4b4fde424",

--- a/skills/mcp_connect.py
+++ b/skills/mcp_connect.py
@@ -1,0 +1,215 @@
+"""CODEC Skill: MCP Connect — make CODEC an MCP *client*.
+
+CODEC already exposes its own skills as an MCP *server* (codec_mcp.py). This
+skill is the other direction: it lets CODEC reach OUT to other MCP servers —
+the same public connectors Claude can use (Notion, GitHub, Linear, …) — and
+call their tools. That makes CODEC bidirectional: a server Claude plugs into,
+and a client that plugs into everything else.
+
+Uses `fastmcp.Client` (already a dependency — no new install). Servers are
+declared in ``~/.codec/mcp_servers.json`` (seeded on first use). Each entry:
+
+    {
+      "name": "notion",
+      "transport": "http",            # "http" | "sse" | "stdio"
+      "url": "https://mcp.notion.com/mcp",   # for http/sse
+      "command": "npx", "args": [...],       # for stdio
+      "headers": {"Authorization": "Bearer …"},  # optional, for API-key servers
+      "enabled": true
+    }
+
+Task grammar (robust, LLM- and human-friendly):
+    "list mcp"                         → list configured servers
+    "list tools on notion"            → list a server's tools
+    "call notion <tool> {json args}"  → call a tool explicitly
+    "<anything mentioning a server>"  → connect + list that server's tools so
+                                         the caller can pick the next step
+"""
+SKILL_NAME = "mcp_connect"
+SKILL_DESCRIPTION = (
+    "Connect CODEC to external MCP servers (Notion, GitHub, Linear, …) and call "
+    "their tools. 'list mcp' shows configured servers; 'list tools on <server>' "
+    "lists a server's tools; 'call <server> <tool> {json}' runs one."
+)
+SKILL_TRIGGERS = ["mcp", "connect to", "list tools", "mcp server", "external tool"]
+# Not exposed on CODEC's OWN outbound MCP server: we don't want a remote client
+# chaining CODEC -> arbitrary third-party MCP tools unattended. Local voice/chat
+# (the demo path) still routes here normally.
+SKILL_MCP_EXPOSE = False
+
+import concurrent.futures
+import json
+import os
+import re
+
+CONFIG_PATH = os.path.expanduser("~/.codec/mcp_servers.json")
+
+# A curated menu of popular public MCP servers, seeded on first run. Most need
+# OAuth or an API key, so they ship DISABLED with a note — the operator fills in
+# `url`/`headers` and flips `enabled`. This is the "add all main public MCP"
+# starter set; enabling one is a one-line edit.
+_SEED = {
+    "servers": [
+        {"name": "notion", "transport": "http", "url": "https://mcp.notion.com/mcp",
+         "enabled": False, "auth": "oauth", "note": "Notion — pages, databases"},
+        {"name": "github", "transport": "http", "url": "https://api.githubcopilot.com/mcp/",
+         "enabled": False, "auth": "oauth", "note": "GitHub — repos, issues, PRs"},
+        {"name": "linear", "transport": "sse", "url": "https://mcp.linear.app/sse",
+         "enabled": False, "auth": "oauth", "note": "Linear — issues, projects"},
+        {"name": "stripe", "transport": "http", "url": "https://mcp.stripe.com",
+         "enabled": False, "auth": "api_key",
+         "headers": {"Authorization": "Bearer <STRIPE_KEY>"}, "note": "Stripe — payments (read)"},
+        {"name": "hugging-face", "transport": "http", "url": "https://huggingface.co/mcp",
+         "enabled": False, "auth": "none", "note": "Hugging Face — models, datasets, papers"},
+    ]
+}
+
+
+def _load_config() -> dict:
+    if not os.path.exists(CONFIG_PATH):
+        os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+        with open(CONFIG_PATH, "w", encoding="utf-8") as fh:
+            json.dump(_SEED, fh, indent=2)
+        return dict(_SEED)
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return dict(_SEED)
+
+
+def _servers() -> list[dict]:
+    return _load_config().get("servers", [])
+
+
+def _find_server(name: str) -> dict | None:
+    name = (name or "").strip().lower()
+    for s in _servers():
+        if s.get("name", "").lower() == name:
+            return s
+    # loose contains-match so "notion workspace" finds "notion"
+    for s in _servers():
+        if s.get("name", "").lower() in name:
+            return s
+    return None
+
+
+def _client_for(server: dict):
+    """Build a fastmcp.Client for a server entry (no connection yet)."""
+    from fastmcp import Client  # local import: keeps skill scan cheap
+    transport = server.get("transport", "http")
+    headers = server.get("headers") or None
+    if transport in ("http", "sse"):
+        url = server.get("url")
+        if not url:
+            raise ValueError(f"server '{server.get('name')}' has no url")
+        # fastmcp infers HTTP vs SSE from the URL; headers carry API-key auth.
+        try:
+            return Client(url, headers=headers)
+        except TypeError:  # older fastmcp signature without headers kwarg
+            return Client(url)
+    if transport == "stdio":
+        cmd = server.get("command")
+        if not cmd:
+            raise ValueError(f"server '{server.get('name')}' has no command")
+        return Client({"command": cmd, "args": server.get("args", [])})
+    raise ValueError(f"unknown transport '{transport}'")
+
+
+def _run_async(coro):
+    """Run an async coroutine from CODEC's sync skill context. Always uses a
+    fresh event loop on a worker thread so it's safe whether or not the caller
+    already has a running loop (the dashboard does)."""
+    def _target():
+        import asyncio
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(_target).result(timeout=60)
+
+
+async def _alist_tools(server: dict) -> list:
+    async with _client_for(server) as client:
+        return await client.list_tools()
+
+
+async def _acall_tool(server: dict, tool: str, args: dict):
+    async with _client_for(server) as client:
+        return await client.call_tool(tool, args or {})
+
+
+def _fmt_tools(tools) -> str:
+    out = []
+    for t in tools:
+        name = getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else str(t))
+        desc = getattr(t, "description", None) or (t.get("description", "") if isinstance(t, dict) else "")
+        out.append(f"  • {name}" + (f" — {desc[:80]}" if desc else ""))
+    return "\n".join(out) if out else "  (no tools)"
+
+
+def _list_servers() -> str:
+    servers = _servers()
+    if not servers:
+        return "No MCP servers configured. Edit " + CONFIG_PATH
+    lines = ["Configured MCP servers:"]
+    for s in servers:
+        state = "on" if s.get("enabled") else f"off ({s.get('auth', '?')})"
+        lines.append(f"  • {s['name']} [{state}] — {s.get('note', s.get('url', ''))}")
+    lines.append(f"\nEnable one by setting \"enabled\": true in {CONFIG_PATH}")
+    return "\n".join(lines)
+
+
+def run(task: str, context: str = "") -> str:
+    t = (task or "").strip()
+    low = t.lower()
+
+    # 1. list configured servers
+    if re.search(r"\b(list|show|which|what)\b.*\bmcp\b", low) or low in ("mcp", "mcp servers"):
+        if "tools" not in low:
+            return _list_servers()
+
+    # 2. explicit call:  call <server> <tool> {json}
+    m = re.match(r"(?:call|use)\s+(\S+)\s+(\S+)\s*(\{.*\})?\s*$", t, re.IGNORECASE | re.DOTALL)
+    if m:
+        server = _find_server(m.group(1))
+        if not server:
+            return f"No MCP server named '{m.group(1)}'. Try 'list mcp'."
+        if not server.get("enabled"):
+            return (f"MCP server '{server['name']}' is disabled. Enable it in "
+                    f"{CONFIG_PATH} (auth: {server.get('auth', '?')}).")
+        tool = m.group(2)
+        try:
+            args = json.loads(m.group(3)) if m.group(3) else {}
+        except ValueError as e:
+            return f"Could not parse tool arguments as JSON: {e}"
+        try:
+            res = _run_async(_acall_tool(server, tool, args))
+        except Exception as e:  # noqa: BLE001 — surface any client/network error
+            return f"MCP call failed ({server['name']}.{tool}): {type(e).__name__}: {e}"
+        return f"[{server['name']}.{tool}] {getattr(res, 'data', res)}"
+
+    # 3. list a server's tools:  "list tools on <server>" / mentions a server
+    server = None
+    mt = re.search(r"tools?\s+(?:on|for|from)\s+(\S+)", low)
+    if mt:
+        server = _find_server(mt.group(1))
+    if server is None:
+        # any server name mentioned in the task
+        for s in _servers():
+            if s.get("name", "").lower() in low:
+                server = s
+                break
+    if server is None:
+        return _list_servers()
+
+    if not server.get("enabled"):
+        return (f"MCP server '{server['name']}' is configured but disabled "
+                f"(auth: {server.get('auth', '?')}). Enable it in {CONFIG_PATH}.")
+    try:
+        tools = _run_async(_alist_tools(server))
+    except Exception as e:  # noqa: BLE001
+        return f"Could not connect to MCP server '{server['name']}': {type(e).__name__}: {e}"
+    return f"MCP server '{server['name']}' exposes:\n{_fmt_tools(tools)}"

--- a/tests/test_ask_user.py
+++ b/tests/test_ask_user.py
@@ -97,7 +97,13 @@ def test_round_trip_pwa_answer_unblocks_caller(temp_audit_log, temp_askuser_path
         time.sleep(0.05)
     assert qid is not None, "ask() never wrote a pending record"
 
-    # Verify notifications.json has a type="question" entry.
+    # Verify notifications.json has a type="question" entry. ask() writes the
+    # pending record and the notification as two separate writes, so under load
+    # the notification can lag the record we polled for above — poll for it too
+    # rather than assume it landed simultaneously (CI flake, 2026-07).
+    _nd = time.monotonic() + 2.0
+    while time.monotonic() < _nd and not notif_path.exists():
+        time.sleep(0.05)
     assert notif_path.exists(), "notification not written"
     notifs = json.loads(notif_path.read_text())
     assert any(n.get("type") == "question" and n.get("pending_question_id") == qid
@@ -173,10 +179,18 @@ def test_deadline_timeout_returns_sentinel(temp_audit_log, temp_askuser_paths):
     # Should be roughly 2s (polling loop checks every 1s); allow up to 4s.
     assert 1.5 <= elapsed <= 4.5, f"deadline elapsed={elapsed:.2f}s"
 
-    # Audit: emit + timeout.
+    # Audit: emit + timeout. Scope to THIS question's id: a background-threaded
+    # ask() in a neighbouring test can finalize a late timeout into this test's
+    # audit log (the log path is read live at write-time), so a global count is
+    # flaky under CI load. Count only events for our own qid.
+    my_qid = json.loads(pq_path.read_text())["pending_questions"][0]["id"]
+
+    def _for_me(events):
+        return [e for e in events if e.get("extra", {}).get("pending_question_id") == my_qid]
+
     recs = _records(temp_audit_log)
-    emits = _events_of(recs, codec_ask_user.ASKUSER_EVENT_EMIT)
-    timeouts = _events_of(recs, codec_ask_user.ASKUSER_EVENT_TIMEOUT)
+    emits = _for_me(_events_of(recs, codec_ask_user.ASKUSER_EVENT_EMIT))
+    timeouts = _for_me(_events_of(recs, codec_ask_user.ASKUSER_EVENT_TIMEOUT))
     assert len(emits) == 1
     assert len(timeouts) == 1
     assert timeouts[0]["extra"]["reason"] == "deadline"

--- a/tests/test_mcp_connect.py
+++ b/tests/test_mcp_connect.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import sys
-import types
 from pathlib import Path
 
 import pytest
@@ -119,7 +118,6 @@ def test_call_with_bad_json_is_reported(cfg, fake_client):
 # ── guards ──────────────────────────────────────────────────────────────────
 
 def test_disabled_server_is_not_contacted(cfg, monkeypatch):
-    called = {"n": 0}
     monkeypatch.setattr(mcp_connect, "_client_for",
                         lambda s: (_ for _ in ()).throw(AssertionError("must not connect")))
     out = mcp_connect.run("list tools on notion")

--- a/tests/test_mcp_connect.py
+++ b/tests/test_mcp_connect.py
@@ -1,0 +1,139 @@
+"""mcp_connect — CODEC as an MCP *client* (bidirectional MCP).
+
+Verifies the bridge logic without touching the network: fastmcp.Client is
+replaced with a fake async context manager. Covers config seeding, listing
+servers, listing a server's tools, an explicit tool call, and the
+disabled-server guard.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "skills"))
+
+import mcp_connect  # noqa: E402
+
+
+@pytest.fixture
+def cfg(tmp_path, monkeypatch):
+    """Point the skill at a throwaway config with one ENABLED fake server."""
+    path = tmp_path / "mcp_servers.json"
+    path.write_text(json.dumps({"servers": [
+        {"name": "acme", "transport": "http", "url": "https://acme.test/mcp", "enabled": True},
+        {"name": "notion", "transport": "http", "url": "https://mcp.notion.com/mcp",
+         "enabled": False, "auth": "oauth", "note": "Notion"},
+    ]}))
+    monkeypatch.setattr(mcp_connect, "CONFIG_PATH", str(path))
+    return path
+
+
+class _FakeTool:
+    def __init__(self, name, description=""):
+        self.name = name
+        self.description = description
+
+
+class _FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeClient:
+    """Async-context-manager stand-in for fastmcp.Client."""
+    last_call = None
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def list_tools(self):
+        return [_FakeTool("create_page", "Create a page"), _FakeTool("search")]
+
+    async def call_tool(self, name, args):
+        _FakeClient.last_call = (name, args)
+        return _FakeResult({"ok": True, "tool": name, "args": args})
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    monkeypatch.setattr(mcp_connect, "_client_for", lambda server: _FakeClient())
+    _FakeClient.last_call = None
+
+
+# ── config seeding ──────────────────────────────────────────────────────────
+
+def test_seeds_config_on_first_use(tmp_path, monkeypatch):
+    path = tmp_path / "mcp_servers.json"
+    monkeypatch.setattr(mcp_connect, "CONFIG_PATH", str(path))
+    out = mcp_connect.run("list mcp")
+    assert path.exists(), "config must be seeded on first use"
+    seeded = json.loads(path.read_text())
+    names = {s["name"] for s in seeded["servers"]}
+    assert {"notion", "github", "linear"} <= names, "popular servers must be seeded"
+    assert "notion" in out
+
+
+# ── listing ─────────────────────────────────────────────────────────────────
+
+def test_list_servers_shows_state(cfg):
+    out = mcp_connect.run("list mcp")
+    assert "acme" in out and "on" in out
+    assert "notion" in out and "off" in out
+
+
+def test_list_tools_on_enabled_server(cfg, fake_client):
+    out = mcp_connect.run("list tools on acme")
+    assert "create_page" in out and "search" in out
+
+
+def test_bare_server_mention_lists_its_tools(cfg, fake_client):
+    out = mcp_connect.run("what can acme do")
+    assert "create_page" in out
+
+
+# ── calling ─────────────────────────────────────────────────────────────────
+
+def test_explicit_call_invokes_the_tool(cfg, fake_client):
+    out = mcp_connect.run('call acme create_page {"title": "Demo notes"}')
+    assert _FakeClient.last_call == ("create_page", {"title": "Demo notes"})
+    assert "create_page" in out and "ok" in out.lower()
+
+
+def test_call_with_bad_json_is_reported(cfg, fake_client):
+    out = mcp_connect.run("call acme create_page {not json}")
+    assert "json" in out.lower()
+
+
+# ── guards ──────────────────────────────────────────────────────────────────
+
+def test_disabled_server_is_not_contacted(cfg, monkeypatch):
+    called = {"n": 0}
+    monkeypatch.setattr(mcp_connect, "_client_for",
+                        lambda s: (_ for _ in ()).throw(AssertionError("must not connect")))
+    out = mcp_connect.run("list tools on notion")
+    assert "disabled" in out.lower()
+
+
+def test_unknown_server_call_is_friendly(cfg, fake_client):
+    out = mcp_connect.run("call doesnotexist sometool {}")
+    assert "no mcp server" in out.lower()
+
+
+def test_network_error_is_caught(cfg, monkeypatch):
+    def boom(server):
+        raise ConnectionError("refused")
+    monkeypatch.setattr(mcp_connect, "_client_for", boom)
+    out = mcp_connect.run("list tools on acme")
+    assert "could not connect" in out.lower() and "acme" in out


### PR DESCRIPTION
Two things:

**1. CODEC as an MCP client (demo beat #23).** CODEC already serves its skills to Claude over MCP; this adds the reverse — CODEC connects *out* to external MCP servers (Notion, GitHub, Linear, Stripe, Hugging Face…) and calls their tools. Bidirectional MCP. Built on `fastmcp.Client` (existing dep). Servers live in `~/.codec/mcp_servers.json` (seeded with a popular-server menu; enabling one is a one-line edit). **Verified against a real server** — connected to `huggingface.co/mcp` and listed its live tools. 9 network-free tests, manifest regenerated.

**2. Corrected 25-beat `DEMO_SCRIPT.md`** with an exact TRY/EXPECT per beat (fixes Vision Mouse=done, Pilot=half-broken; adds MCP-client/self-improve/Compare).

Also fixed the #237-blocking flake separately (PR #238, merged).
🤖 Generated with [Claude Code](https://claude.com/claude-code)