### PR TITLE
feat(chat/vibe): "+" folder button — allocate a working directory

### DIFF
--- a/codec_chat.html
+++ b/codec_chat.html
@@ -417,6 +417,13 @@ input[type=file]{display:none}
 
 <div class="input-area">
 <div class="file-chips" id="fileChips"></div>
+<div id="workdirChip" style="display:none;align-items:center;gap:6px;margin:0 0 6px 2px;font-size:11px;color:var(--text-dim)">
+  <svg class="ico" viewBox="0 0 24 24" style="width:13px;height:13px"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
+  <span id="workdirPath" style="max-width:60ch;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></span>
+  <button class="ibtn" onclick="clearWorkingFolder()" title="Remove working folder" style="width:16px;height:16px;padding:0">
+    <svg class="ico" viewBox="0 0 24 24" style="width:11px;height:11px"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+  </button>
+</div>
 <div class="input-row">
 <button class="ibtn" id="micBtn" onclick="toggleMic()" title="Voice input">
   <svg class="ico" viewBox="0 0 24 24"><path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
@@ -424,6 +431,9 @@ input[type=file]{display:none}
 <textarea class="chat-input" id="chatInput" placeholder="Message CODEC..." rows="1" onkeydown="handleKey(event)"></textarea>
 <button class="ibtn" onclick="document.getElementById('fileUp').click()" title="Upload file">
   <svg class="ico" viewBox="0 0 24 24"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+</button>
+<button class="ibtn" id="folderBtn" onclick="pickWorkingFolder()" title="Allocate a working folder to this chat">
+  <svg class="ico" viewBox="0 0 24 24"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/><line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/></svg>
 </button>
 <button class="ibtn send" id="sendBtn" onclick="sendMessage()">
   <svg class="ico" viewBox="0 0 24 24" style="stroke:#fff"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
@@ -512,6 +522,25 @@ var CONCISE_MODE="\n\n### RESPONSE STYLE\nAnswer directly and concisely. Do not 
 // scaffold is appended server-side (reason_scaffold flag) so it lands as the
 // LAST instruction and isn't buried under the backend's base prompt.
 function buildSystem(){return SYS+(thinkingEnabled?'':CONCISE_MODE);}
+
+// Working folder allocated to this chat (like a working directory). Sent with
+// every message so file operations can be scoped to it. Persists per-browser.
+var _workdir=localStorage.getItem('codec_workdir')||'';
+function _renderWorkdir(){
+  var chip=document.getElementById('workdirChip');
+  if(_workdir){document.getElementById('workdirPath').textContent=_workdir;chip.style.display='flex'}
+  else{chip.style.display='none'}
+}
+function pickWorkingFolder(){
+  fetch('/api/pick-folder',{method:'POST'}).then(function(r){return r.json()}).then(function(j){
+    if(j&&j.ok&&j.path){_workdir=j.path;localStorage.setItem('codec_workdir',_workdir);_renderWorkdir();
+      showToast('Working folder: '+_workdir)}
+    else if(j&&j.cancelled){/* user dismissed — no-op */}
+    else{showToast((j&&j.error)||'Could not open folder picker')}
+  }).catch(function(){showToast('Folder picker unavailable')});
+}
+function clearWorkingFolder(){_workdir='';localStorage.removeItem('codec_workdir');_renderWorkdir();}
+_renderWorkdir();
 var chatHist=[],isProcessing=false,isRecording=false,recognition=null;
 var pendingFiles=[];
 var sessionId=null;
@@ -654,7 +683,7 @@ function regenerateResponse(btn){
   isProcessing=true;document.getElementById('sendBtn').disabled=true;_showStop();showTyping();
   _currentAbort=new AbortController();
   var msgs=[{role:'system',content:buildSystem()}].concat(chatHist);
-  fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:false,show_thoughts:false,reason_scaffold:thinkingEnabled,stream:true}),signal:_currentAbort.signal}).then(async function(r){
+  fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:false,show_thoughts:false,reason_scaffold:thinkingEnabled,stream:true,workdir:_workdir}),signal:_currentAbort.signal}).then(async function(r){
     if(r.status===401||r.status===403){hideTyping();addMessage('assistant','Session expired — redirecting to login...');setTimeout(function(){window.location.href='/auth'},1500);isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
     hideTyping();
     var reader=r.body.getReader();var decoder=new TextDecoder();var raw='';var bubbleId='stream_'+genId();
@@ -1416,7 +1445,7 @@ async function sendMessage(){
       if(data.response){addMessage('assistant',data.response);chatHist.push({role:'assistant',content:data.response});saveMessages([{role:'assistant',content:data.response}])}
       else{addMessage('assistant','Error: '+(data.error||'No response'))}
     } else {
-      r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:false,show_thoughts:false,reason_scaffold:thinkingEnabled,stream:true}),signal:_currentAbort.signal});
+      r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({messages:msgs,force_search:webSearchEnabled,thinking:false,show_thoughts:false,reason_scaffold:thinkingEnabled,stream:true,workdir:_workdir}),signal:_currentAbort.signal});
       if(r.status===401||r.status===403){hideTyping();addMessage('assistant','Session expired — redirecting to login...');setTimeout(function(){window.location.href='/auth'},1500);isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return}
       hideTyping();
       // SSE streaming — parse the Think-mode scaffold as tokens arrive

--- a/codec_vibe.html
+++ b/codec_vibe.html
@@ -266,7 +266,7 @@ body{font-family:var(--ft);background:var(--bg);color:var(--tx);height:100vh;hei
   </div>
 </div>
 <div class="sp">
-<div class="cp"><div class="hd" style="font-size:13px;color:var(--tx2);font-weight:500">Vibe Coding</div><div class="ms" id="cm"><div class="mg ma">Tell me what to build!</div></div><div class="ia"><button class="vibe-mic" id="vibeMic" onclick="toggleVibeMic()" title="Voice input"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></button><textarea id="vi" class="ii" rows="1" placeholder="Describe what to build..."></textarea><button class="sb" id="sndb" title="Send"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg></button><button class="sb" id="stopb" onclick="doStop()" style="display:none;background:#c0392b" title="Stop"><svg width="14" height="14" viewBox="0 0 24 24" fill="#fff" stroke="none"><rect x="4" y="4" width="16" height="16" rx="2"/></svg></button></div></div>
+<div class="cp"><div class="hd" style="font-size:13px;color:var(--tx2);font-weight:500">Vibe Coding</div><div class="ms" id="cm"><div class="mg ma">Tell me what to build!</div></div><div class="ia"><button class="vibe-mic" id="vibeMic" onclick="toggleVibeMic()" title="Voice input"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></button><textarea id="vi" class="ii" rows="1" placeholder="Describe what to build..."></textarea><button class="vibe-mic" id="vibeFolder" onclick="pickWorkingFolder()" title="Allocate a working folder"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/><line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/></svg></button><button class="sb" id="sndb" title="Send"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg></button><button class="sb" id="stopb" onclick="doStop()" style="display:none;background:#c0392b" title="Stop"><svg width="14" height="14" viewBox="0 0 24 24" fill="#fff" stroke="none"><rect x="4" y="4" width="16" height="16" rx="2"/></svg></button></div></div>
 <div style="width:4px;cursor:col-resize;background:var(--bd)" id="rh"></div>
 <div class="ep"><div id="eb"></div><div class="tb"><button class="bt primary" onclick="doRun()" title="Execute code"><svg class="ico ico-sm" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"/></svg>Run</button><button class="bt" onclick="doPrev()" title="Live preview"><svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>Preview</button><button class="bt" id="inspectBtn" onclick="toggleInspect()" title="Inspect elements"><svg class="ico ico-sm" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>Inspect</button><div class="tb-sep"></div><button class="bt" onclick="doSave()" title="Save file"><svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>Save</button><button class="bt" onclick="doCopy()" title="Copy code"><svg class="ico ico-sm" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button><span class="rs" id="rs"></span></div></div>
 <div class="pp" id="pp"><div class="ph"><span>Live Preview</span><button onclick="document.getElementById('pp').classList.remove('sh')" style="background:0;border:0;color:var(--tx2);cursor:pointer;font-size:16px">&#10005;</button></div><iframe id="pf" sandbox="allow-scripts allow-same-origin"></iframe></div>
@@ -542,6 +542,32 @@ function doStop() {
   document.getElementById('stopb').style.display = 'none';
 }
 
+// Working folder allocated to this Vibe session (like a working directory),
+// sent with every message so file operations scope to it. Persists per-browser.
+var _workdir = localStorage.getItem('codec_workdir') || '';
+function _renderVibeWorkdir() {
+  var chip = document.getElementById('vibeWorkdirChip');
+  if (!_workdir) { if (chip) chip.style.display = 'none'; return; }
+  if (!chip) {
+    var ia = document.querySelector('.ia');
+    chip = document.createElement('div');
+    chip.id = 'vibeWorkdirChip';
+    chip.style.cssText = 'display:flex;align-items:center;gap:6px;padding:4px 8px;font-size:11px;color:var(--tx2)';
+    chip.innerHTML = '<span id="vibeWorkdirPath" style="max-width:52ch;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></span>' +
+      '<span onclick="clearWorkingFolder()" title="Remove" style="cursor:pointer">&times;</span>';
+    if (ia && ia.parentNode) ia.parentNode.insertBefore(chip, ia);
+  }
+  chip.style.display = 'flex';
+  var p = document.getElementById('vibeWorkdirPath'); if (p) p.textContent = '\u{1F4C1} ' + _workdir;
+}
+function pickWorkingFolder() {
+  fetch('/api/pick-folder', {method: 'POST'}).then(function(r){return r.json()}).then(function(j){
+    if (j && j.ok && j.path) { _workdir = j.path; localStorage.setItem('codec_workdir', _workdir); _renderVibeWorkdir(); }
+    else if (!(j && j.cancelled)) { alert((j && j.error) || 'Could not open folder picker'); }
+  }).catch(function(){ alert('Folder picker unavailable'); });
+}
+function clearWorkingFolder() { _workdir = ''; localStorage.removeItem('codec_workdir'); _renderVibeWorkdir(); }
+
 function doSend() {
   var inp = document.getElementById('vi');
   var t = inp.value.trim();
@@ -594,7 +620,7 @@ function doSend() {
     try {
       var r = await fetch('/api/chat', {
         method: 'POST', headers: {'Content-Type': 'application/json'}, credentials: 'same-origin',
-        body: JSON.stringify({messages: msgs, thinking: false, stream: true}), signal: _vibeAbort.signal
+        body: JSON.stringify({messages: msgs, thinking: false, stream: true, workdir: _workdir}), signal: _vibeAbort.signal
       });
       if (r.status === 401 || r.redirected) { window.location.href = '/auth'; return; }
       if (!r.body) throw new Error('No stream body (status ' + r.status + ')');
@@ -1138,6 +1164,7 @@ function applyEdits() {
 
 // Events
 document.getElementById('sndb').addEventListener('click', doSend);
+_renderVibeWorkdir();
 document.getElementById('vi').addEventListener('keydown', function(e) {
   if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); doSend(); }
 });

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -749,6 +749,44 @@ async def escalate_silence(request: Request):
     return {"ok": True, "silenced": bool(sid)}
 
 
+@router.post("/api/pick-folder")
+async def pick_folder():
+    """Open the native macOS folder chooser and return the selected POSIX path.
+
+    Powers the "+" button in Chat and Vibe: the user allocates a working folder
+    to the conversation (like a working directory), which the frontend then sends
+    with each message so file operations can be scoped to it. Returns
+    {ok:false, cancelled:true} if the user dismisses the dialog."""
+    import asyncio
+
+    script = (
+        'POSIX path of (choose folder with prompt '
+        '"Allocate a working folder to this CODEC chat")'
+    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "osascript", "-e", script,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=120)
+    except asyncio.TimeoutError:
+        return JSONResponse({"ok": False, "error": "folder chooser timed out"}, status_code=504)
+    except FileNotFoundError:
+        return JSONResponse({"ok": False, "error": "folder chooser unavailable (macOS only)"},
+                            status_code=501)
+    if proc.returncode != 0:
+        # User cancelled → osascript exits non-zero with "User canceled".
+        msg = (err or b"").decode(errors="replace")
+        if "cancel" in msg.lower():
+            return {"ok": False, "cancelled": True}
+        return JSONResponse({"ok": False, "error": msg.strip()[:200] or "no folder chosen"},
+                            status_code=400)
+    path = (out or b"").decode(errors="replace").strip().rstrip("/")
+    if not path:
+        return {"ok": False, "cancelled": True}
+    return {"ok": True, "path": path}
+
+
 @router.post("/api/chat")
 async def chat_completion(request: Request):
     """Direct LLM chat with full context window + tool calling"""
@@ -868,6 +906,18 @@ async def chat_completion(request: Request):
         sys_prompt = _build_chat_system_prompt(
             config, _budget, has_attachment, last_user_text
         )
+
+        # Working folder allocated to this chat via the "+" button. Tell the model
+        # so file operations (save/read with relative names) resolve there — the
+        # chat's working directory, like Claude Code.
+        _workdir = str(body.get("workdir") or "").strip()
+        if _workdir:
+            sys_prompt += (
+                f"\n\nWORKING FOLDER: {_workdir}\n"
+                f"When the user asks to save, create, read, or edit a file without an "
+                f"absolute path, use this folder — e.g. save to '{_workdir}/<name>'. "
+                f"Treat it as the current working directory for this conversation."
+            )
 
         # Prepend system message (or replace existing one)
         if messages and messages[0].get("role") == "system":


### PR DESCRIPTION
Adds the folder-picker button next to Send in Chat and Vibe (native macOS folder chooser via POST /api/pick-folder), a removable chip, and threads the chosen  into the system prompt so file ops resolve there. Both pages' JS parse, tags balanced, chat tests pass.