### PR TITLE
fix(pilot): health check must send the token (#14 half-broken)

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -65,7 +65,7 @@
     "observer_recall.py": "7812db351063c96c11ac22fed862d9d4b690ffd779d7179ae958d4ad76761b85",
     "password_generator.py": "f11a917299e14cbd2560111da0bb748cd08792cf715cc4098c64eb62da8c54e3",
     "philips_hue.py": "fa831712c39dc6327c84199d8f0aeb09a169a264ce3d936cc337a5c5d6632f7e",
-    "pilot.py": "ded952504f8d44c3c6ea5b1da1ef2f09f0bbf1b771e2ad9dd90db6cd1701c3fb",
+    "pilot.py": "f9967890f138bc7a48ae4abc8b4170dca13961b81659ef4e530dc619c1cf90d4",
     "plugin_approve.py": "c93861353be2a9ebe08df212ca167bea646962dbeafe704b1864cd78a8cf57cc",
     "pm2_control.py": "53d34a9ddb7689b86f192694d6ccc18b154538626cbc72992445d0b74f2e5662",
     "pomodoro.py": "462142327a8c1e61668275c444816a09868cac9d44db231ba37727eb609c46d6",

--- a/skills/pilot.py
+++ b/skills/pilot.py
@@ -81,8 +81,15 @@ def _post(path: str, body: dict | None = None) -> dict:
 
 
 def _pilot_up() -> bool:
+    # Must send the token: the pilot-runner requires x-pilot-token on EVERY
+    # endpoint, /health included. Without it /health 401s and this returned
+    # False even when the runner was online + healthy — so every teach/replay
+    # command hit the "Pilot Runner is not running" branch. That was the whole
+    # "Pilot is half-broken" symptom.
     try:
-        with urllib.request.urlopen(_BASE + "/health", timeout=3):
+        req = urllib.request.Request(
+            _BASE + "/health", headers={"x-pilot-token": _pilot_token()})
+        with urllib.request.urlopen(req, timeout=3):
             return True
     except Exception:
         return False
@@ -116,7 +123,7 @@ def _extract_run_id(text: str) -> str | None:
 def _fmt(d: dict) -> str:
     """Turn a result dict into a readable string."""
     if "error" in d:
-        return f"❌ Pilot error: {d['error']}"
+        return f"Pilot error: {d['error']}"
     return json.dumps(d, indent=2)
 
 
@@ -127,7 +134,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
 
     if not _pilot_up():
         return (
-            "❌ Pilot Runner is not running. Start it with:\n"
+            "Pilot Runner is not running. Start it with:\n"
             "  pm2 start ecosystem.config.js --only pilot-runner\n"
             "or check: pm2 status pilot-runner"
         )
@@ -141,8 +148,8 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
             return _fmt(d)
         snap = d.get("latest_snapshot", "")
         snap_preview = snap[:300] + "…" if len(snap) > 300 else snap
-        status_icon = {"done": "✅", "error": "❌", "running": "⏳",
-                       "budget_exhausted": "⚠️"}.get(d.get("status", ""), "📊")
+        status_icon = {"done": "", "error": "", "running": "",
+                       "budget_exhausted": ""}.get(d.get("status", ""), "")
         error_line = f"\n   Error : {d.get('error', '')}" if d.get("error") else ""
         result_line = f"\n   Result: {d.get('result', '')}" if d.get("result") else ""
         return (
@@ -160,7 +167,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
         if "error" in d:
             return _fmt(d)
         return (
-            f"✅ Pilot Runner online\n"
+            f"Pilot Runner online\n"
             f"   URL   : {d.get('url', 'n/a')}\n"
             f"   CDP   : :{d.get('cdp_port', 9223)}\n"
             f"   Tunnel: https://pilot.lucyvpa.com"
@@ -175,7 +182,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
         if "error" in d:
             return _fmt(d)
         return (
-            f"✅ Navigated to {url}\n"
+            f"Navigated to {url}\n"
             f"   Title   : {d.get('title', '')}\n"
             f"   Elements: {d.get('element_count', 0)} interactive"
         )
@@ -186,7 +193,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
         if "error" in d:
             return _fmt(d)
         header = (
-            f"📄 Snapshot ({d.get('element_count', 0)} elements, {d.get('took_ms', 0):.0f}ms)\n"
+            f"Snapshot ({d.get('element_count', 0)} elements, {d.get('took_ms', 0):.0f}ms)\n"
             f"URL: {d.get('url', '')}\n"
             f"Title: {d.get('title', '')}\n\n"
         )
@@ -204,7 +211,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
             if "error" in d:
                 return _fmt(d)
             b64 = d.get("image", "")
-            return f"📸 Screenshot (base64, {len(b64)} chars)\n{b64[:100]}…"
+            return f"Screenshot (base64, {len(b64)} chars)\n{b64[:100]}…"
         # Save to /tmp
         import urllib.request
         out = "/tmp/pilot_screenshot.jpg"
@@ -212,9 +219,9 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
             urllib.request.urlretrieve(_BASE + "/screenshot", out)
             import os
             size = os.path.getsize(out)
-            return f"📸 Screenshot saved to {out} ({size/1024:.1f} KB)"
+            return f"Screenshot saved to {out} ({size/1024:.1f} KB)"
         except Exception as e:
-            return f"❌ Screenshot failed: {e}"
+            return f"Screenshot failed: {e}"
 
     # ── click ─────────────────────────────────────────────────────────────────
     if "click" in t:
@@ -224,7 +231,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
         d = _post(f"/click/{idx}")
         if "error" in d:
             return _fmt(d)
-        return f"✅ Clicked [{idx}]: {d.get('clicked', '')}"
+        return f"Clicked [{idx}]: {d.get('clicked', '')}"
 
     # ── type ──────────────────────────────────────────────────────────────────
     if any(w in t for w in ["type ", "fill ", "enter ", "input "]):
@@ -241,7 +248,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
         d = _post(f"/type/{idx}", {"text": text})
         if "error" in d:
             return _fmt(d)
-        return f"✅ Typed into [{idx}]: \"{text}\""
+        return f"Typed into [{idx}]: \"{text}\""
 
     # ── scroll ────────────────────────────────────────────────────────────────
     if "scroll" in t:
@@ -268,7 +275,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
                 "action": "scroll", "direction": direction, "amount": amount
             })
             _post(f"/run/{run_id}/complete", {"status": "done"})
-        return f"✅ Scrolled {direction} {amount}px"
+        return f"Scrolled {direction} {amount}px"
 
     # ── run (autonomous task) ─────────────────────────────────────────────────
     if any(w in t for w in ["run ", "task ", "automate", "agent ", "do "]):
@@ -294,13 +301,13 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
         start = _post(f"/run/{run_id}/start", {"step_budget": 20, "use_stub": True})
         if "error" in start:
             return (
-                f"🤖 Run registered (run_id={run_id}) but agent start failed:\n"
+                f"Run registered (run_id={run_id}) but agent start failed:\n"
                 f"   {start['error']}\n"
                 f"Check: pm2 logs pilot-runner"
             )
 
         return (
-            f"🤖 Pilot agent started\n"
+            f"Pilot agent started\n"
             f"   Run ID  : {run_id}\n"
             f"   Task    : {task_desc}\n"
             f"   Budget  : 20 steps\n"
@@ -317,7 +324,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
         runs = d.get("runs", [])
         if not runs:
             return "No pilot runs recorded yet."
-        lines = [f"📋 Pilot Runs ({len(runs)}):"]
+        lines = [f"Pilot Runs ({len(runs)}):"]
         for r in runs[:15]:
             lines.append(
                 f"  {r['run_id']} │ {r['status']:16} │ {r['task'][:60]}"
@@ -358,7 +365,7 @@ def run(task: str, app: str = "", ctx: str = "") -> str:  # noqa: A001
 
     # ── fallback: show help ───────────────────────────────────────────────────
     return (
-        "🤖 CODEC Pilot — headless browser agent\n\n"
+        "CODEC Pilot — headless browser agent\n\n"
         "Commands:\n"
         "  pilot navigate https://example.com\n"
         "  pilot snapshot              — indexed DOM elements\n"

--- a/tests/test_pilot_health.py
+++ b/tests/test_pilot_health.py
@@ -1,0 +1,66 @@
+"""Pilot health check must be authenticated (the "half-broken" root cause).
+
+2026-07: Pilot appeared dead — every teach/replay command returned "Pilot
+Runner is not running" even though the pilot-runner was online and healthy. The
+runner requires x-pilot-token on EVERY endpoint including /health (401 without),
+but _pilot_up() sent no header, so it always saw 401 → False. These tests pin
+that _pilot_up sends the token, and that a genuine outage still reads as down.
+"""
+from __future__ import annotations
+
+import sys
+import urllib.error
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "skills"))
+
+import pilot  # noqa: E402
+
+
+def test_pilot_up_sends_the_token(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(req, timeout=0):
+        seen["header"] = req.headers.get("X-pilot-token")
+
+        class _R:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+        return _R()
+
+    monkeypatch.setattr(pilot, "_pilot_token", lambda: "SECRET123")
+    monkeypatch.setattr(pilot.urllib.request, "urlopen", fake_urlopen)
+    assert pilot._pilot_up() is True
+    assert seen["header"] == "SECRET123", "health check must send x-pilot-token"
+
+
+def test_pilot_up_false_on_401(monkeypatch):
+    """A real 401 (bad/absent token) still reads as down — fail-closed."""
+    def raise_401(req, timeout=0):
+        raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, None)
+    monkeypatch.setattr(pilot, "_pilot_token", lambda: "")
+    monkeypatch.setattr(pilot.urllib.request, "urlopen", raise_401)
+    assert pilot._pilot_up() is False
+
+
+def test_pilot_up_false_when_service_down(monkeypatch):
+    def refuse(req, timeout=0):
+        raise ConnectionError("connection refused")
+    monkeypatch.setattr(pilot, "_pilot_token", lambda: "x")
+    monkeypatch.setattr(pilot.urllib.request, "urlopen", refuse)
+    assert pilot._pilot_up() is False
+
+
+def test_run_reports_not_running_when_down(monkeypatch):
+    monkeypatch.setattr(pilot, "_pilot_up", lambda: False)
+    out = pilot.run("pilot status")
+    assert "not running" in out.lower()
+
+
+def test_no_emoji_in_pilot_output():
+    """No-emoji rule: pilot.py must not contain pictographic emoji."""
+    src = (REPO / "skills" / "pilot.py").read_text()
+    offenders = sorted({c for c in src if ord(c) > 0x2600})
+    assert not offenders, f"pictographic emoji in pilot.py: {offenders}"


### PR DESCRIPTION
Pilot appeared dead — every command returned 'Pilot Runner is not running' though the runner was online. Root cause: the runner requires x-pilot-token on /health (401 without, 200 with), but _pilot_up() sent no token → always False. Fixed (send the token), verified end-to-end against the live service (navigate works now). Also stripped pictographic emoji. 5 tests.