### PR TITLE
feat(agent): verify "saved to Drive" is real before completing (#17)

### DIFF
--- a/codec_agent_runner.py
+++ b/codec_agent_runner.py
@@ -952,9 +952,13 @@ def _execute_checkpoint(plan_dict: Dict[str, Any],
     _sig_counts: Dict[str, int] = {}
     _nudged_sigs: set = set()
     _nudges_given = 0
+    _gdoc_verify_nudged = False       # gdoc completion-verifier nudge fired?
     _executed_targets: set = set()   # dedup keys for fetch/search already run
     for h in history:
         if h.get("_skill_correction_nudge") or h.get("_resume_skipped"):
+            continue
+        if h.get("_gdoc_verify_nudge"):
+            _gdoc_verify_nudged = True
             continue
         if h.get("_loop_correction_nudge"):
             _nudges_given += 1
@@ -992,6 +996,28 @@ def _execute_checkpoint(plan_dict: Dict[str, Any],
         action = _next_action()
 
         if action.kind == "checkpoint_done":
+            # Completion verifier (#17): don't accept a "saved to Google Drive /
+            # Google Doc" claim unless a real doc was actually produced. A research
+            # Project once wrote a local .md and called it "saved to Drive" — a
+            # false completion. Nudge ONCE, then let it finish (so an unreachable
+            # Google OAuth can't wedge the checkpoint forever).
+            if not _gdoc_verify_nudged:
+                try:
+                    import codec_gdoc_verify
+                    ok, reason = codec_gdoc_verify.verify_deliverable(checkpoint, history)
+                except Exception:
+                    ok, reason = True, ""
+                if not ok:
+                    _gdoc_verify_nudged = True
+                    history.append({
+                        "step": len(history),
+                        "skill": "", "task": "verify_deliverable",
+                        "result": f"[DELIVERABLE NOT DONE] {reason}",
+                        "is_destructive": False,
+                        "_gdoc_verify_nudge": True,
+                    })
+                    _persist_checkpoint_progress(agent_id, cp_id, history, executed_destructive)
+                    continue
             return history
 
         # Permission gate (raises PermissionViolation if outside manifest).

--- a/codec_gdoc_verify.py
+++ b/codec_gdoc_verify.py
@@ -1,0 +1,100 @@
+"""Completion verifier for "save to Google Drive / Google Doc" deliverables.
+
+Buyer-journey / demo audit (#17): a research Project's checkpoint claimed it had
+"saved the report to Google Drive" but only wrote a local .md file — a false
+completion. This module lets codec_agent_runner refuse to mark such a checkpoint
+done unless a REAL Google Doc was actually produced (its docs.google.com URL
+appears in the checkpoint history, and — best-effort — the doc resolves in Drive).
+
+Pure/stdlib except the optional live existence check, so the gating logic is
+fully unit-testable without Google OAuth.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+# The expected_output asks for a Google-Drive/Doc deliverable (not a local file).
+_WANTS_GDOC_RE = re.compile(
+    r"google\s*docs?|\bgdoc\b|google\s*drive|\bto\s+drive\b|"
+    r"google\s*document|docs\.google",
+    re.IGNORECASE,
+)
+
+# A real Google Doc URL (what create_google_doc returns).
+_DOC_URL_RE = re.compile(r"https://docs\.google\.com/document/d/[a-zA-Z0-9_-]+")
+_DOC_ID_RE = re.compile(r"/document/d/([a-zA-Z0-9_-]+)")
+
+
+def wants_gdoc(expected_output: str) -> bool:
+    """True when the checkpoint's expected_output calls for a Google Doc / Drive
+    deliverable (so a local .md doesn't satisfy it)."""
+    return bool(_WANTS_GDOC_RE.search(expected_output or ""))
+
+
+def find_doc_url(history: Any) -> Optional[str]:
+    """Return the first Google Doc URL found in the checkpoint history (or a raw
+    string). None if no real doc URL was produced."""
+    if isinstance(history, str):
+        m = _DOC_URL_RE.search(history)
+        return m.group(0) if m else None
+    for h in (history or []):
+        text = str((h or {}).get("result", "")) if isinstance(h, dict) else str(h)
+        m = _DOC_URL_RE.search(text)
+        if m:
+            return m.group(0)
+    return None
+
+
+def doc_id_from_url(url: str) -> Optional[str]:
+    m = _DOC_ID_RE.search(url or "")
+    return m.group(1) if m else None
+
+
+def doc_exists(url_or_id: str) -> Optional[bool]:
+    """Best-effort live check that the doc really exists in Drive. Returns
+    True/False if we could check, or None if we couldn't (no creds / offline) —
+    callers treat None as "can't disprove", so a missing OAuth setup never
+    hard-fails a checkpoint that did produce a URL."""
+    doc_id = doc_id_from_url(url_or_id) or url_or_id
+    if not doc_id:
+        return False
+    try:
+        import codec_google_auth
+        svc = codec_google_auth.build_service("docs", "v1")
+        svc.documents().get(documentId=doc_id, fields="documentId").execute()
+        return True
+    except Exception:
+        # 404 → gone; auth/other error → unknown. We can't reliably tell them
+        # apart across client libraries, so be conservative: unknown, not False.
+        return None
+
+
+def verify_deliverable(checkpoint: dict, history: Any, *, live: bool = False) -> tuple[bool, str]:
+    """(ok, reason). ok=False means the checkpoint asked for a Google Doc but no
+    real doc was produced — the agent must actually create one before finishing.
+
+    live=True additionally confirms the doc resolves in Drive (needs OAuth)."""
+    expected = str((checkpoint or {}).get("expected_output", ""))
+    if not wants_gdoc(expected):
+        return True, "deliverable is not a Google Doc"
+
+    url = find_doc_url(history)
+    if not url:
+        return False, (
+            "This checkpoint's deliverable is a Google Doc, but no Google Doc was "
+            "actually created — there is no docs.google.com/document/... link in "
+            "your results, only local text. Do NOT mark this done. Create the real "
+            "doc now with the google_docs skill (e.g. 'create a google doc titled "
+            "<title>' with the report as the body), then return its URL."
+        )
+
+    if live:
+        exists = doc_exists(url)
+        if exists is False:
+            return False, (
+                f"A Google Doc URL was produced ({url}) but it does not resolve in "
+                f"Drive — the doc was not really created. Create it for real with "
+                f"the google_docs skill and return the working URL."
+            )
+    return True, url

--- a/tests/test_gdoc_verify.py
+++ b/tests/test_gdoc_verify.py
@@ -1,0 +1,76 @@
+"""Completion verifier for Google-Doc deliverables (#17).
+
+A research Project once wrote a local .md and claimed "saved to Google Drive".
+These tests pin the gate that refuses that false completion unless a real
+docs.google.com/document/... URL was actually produced.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+import codec_gdoc_verify as gv  # noqa: E402
+
+
+def test_wants_gdoc_detects_drive_deliverables():
+    for ok in ["save it to Google Drive", "produce a Google Doc", "export as a gdoc",
+               "save the report as a Google Document", "put it in docs.google.com"]:
+        assert gv.wants_gdoc(ok), ok
+    for no in ["save to a local file", "write report.md", "print the summary",
+               "save to ~/Downloads/notes.txt"]:
+        assert not gv.wants_gdoc(no), no
+
+
+def test_find_doc_url_in_history():
+    hist = [
+        {"result": "searched the web..."},
+        {"result": "Saved. https://docs.google.com/document/d/1AbC_def-123/edit"},
+    ]
+    url = gv.find_doc_url(hist)
+    # The extractor stops at the doc id (the trailing /edit isn't needed to
+    # identify the doc); that's enough for verification.
+    assert url == "https://docs.google.com/document/d/1AbC_def-123"
+    assert gv.doc_id_from_url(url) == "1AbC_def-123"
+
+
+def test_find_doc_url_none_when_only_local_file():
+    hist = [{"result": "Saved /Users/x/Downloads/report.md (4,200 bytes)."}]
+    assert gv.find_doc_url(hist) is None
+
+
+def test_verify_passes_when_not_a_gdoc_deliverable():
+    ok, _ = gv.verify_deliverable({"expected_output": "a local markdown file"}, [])
+    assert ok is True
+
+
+def test_verify_fails_when_gdoc_wanted_but_only_local_md():
+    """The exact false-completion bug: expected a Drive doc, produced only a .md."""
+    cp = {"expected_output": "the competitor report saved to Google Drive"}
+    hist = [{"result": "Saved /Users/x/Downloads/competitors.md (5 KB)."}]
+    ok, reason = gv.verify_deliverable(cp, hist)
+    assert ok is False
+    assert "google doc" in reason.lower() and "google_docs skill" in reason.lower()
+
+
+def test_verify_passes_when_real_doc_url_present():
+    cp = {"expected_output": "save the report to a Google Doc"}
+    hist = [{"result": "Created https://docs.google.com/document/d/XYZ123/edit"}]
+    ok, url = gv.verify_deliverable(cp, hist)
+    assert ok is True and "docs.google.com" in url
+
+
+def test_doc_exists_returns_none_without_creds(monkeypatch):
+    """No OAuth → can't verify → None (never a hard False that wedges a real URL)."""
+    import builtins
+    real_import = builtins.__import__
+
+    def boom(name, *a, **k):
+        if name == "codec_google_auth":
+            raise ImportError("no creds")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", boom)
+    assert gv.doc_exists("https://docs.google.com/document/d/AAA/edit") is None

--- a/tests/test_runner_loop.py
+++ b/tests/test_runner_loop.py
@@ -197,3 +197,65 @@ def test_extend_budget_caps_cumulative(monkeypatch, temp_codec_dir):
     with pytest.raises(ra.HTTPException) as exc:
         ra.extend_budget("test_agent", ra.ExtendBudgetBody(additional_steps=100))
     assert exc.value.status_code == 409, "extend_budget must 409 once at the cumulative ceiling (B-14)"
+
+
+# ── #17 gdoc completion verifier: a "save to Drive" checkpoint can't finish on a
+# local .md; the agent is nudged once to make the real doc. ──
+def test_gdoc_deliverable_nudges_before_completion(monkeypatch, temp_codec_dir):
+    grants = {"skills": ["web_search"], "read_paths": [], "write_paths": [],
+              "network_domains": ["*"]}
+    gg = {"schema": 1, "version": 0, "skills": [], "read_paths": [],
+          "write_paths": [], "network_domains": []}
+    cp = {"id": "cp0", "title": "report", "description": "d",
+          "expected_output": "save the competitor report to Google Drive",
+          "step_budget": 8}
+
+    calls = {"n": 0}
+
+    def fake_next(plan_dict, checkpoint, history, *a, **k):
+        calls["n"] += 1
+        # 1st: a web_search (produces only local text). 2nd onward: try to finish.
+        if calls["n"] == 1:
+            return car.Action(skill="web_search", task="competitors", kind="skill_call")
+        return car.Action(skill="", task="", kind="checkpoint_done")
+
+    monkeypatch.setattr(car, "_qwen_next_action", fake_next)
+    monkeypatch.setattr(car, "_run_skill",
+                        lambda skill, task, agent_id: "Found 3 competitors: A, B, C")
+
+    history = car._execute_checkpoint(
+        plan_dict={"goals": ["g"]}, checkpoint=cp,
+        agent_grants=grants, global_grants=gg, agent_id="test_agent")
+
+    # The verifier must have injected exactly one nudge (no real doc URL present).
+    nudges = [h for h in history if h.get("_gdoc_verify_nudge")]
+    assert len(nudges) == 1, "must nudge once when a Drive deliverable has no real doc"
+    assert "google doc" in nudges[0]["result"].lower()
+
+
+def test_gdoc_deliverable_accepts_real_doc_url(monkeypatch, temp_codec_dir):
+    grants = {"skills": ["google_docs"], "read_paths": [], "write_paths": [],
+              "network_domains": ["*"]}
+    gg = {"schema": 1, "version": 0, "skills": [], "read_paths": [],
+          "write_paths": [], "network_domains": []}
+    cp = {"id": "cp0", "title": "report", "description": "d",
+          "expected_output": "save the report to a Google Doc", "step_budget": 6}
+
+    step = {"n": 0}
+
+    def fake_next(plan_dict, checkpoint, history, *a, **k):
+        step["n"] += 1
+        if step["n"] == 1:
+            return car.Action(skill="google_docs", task="create doc", kind="skill_call")
+        return car.Action(skill="", task="", kind="checkpoint_done")
+
+    monkeypatch.setattr(car, "_qwen_next_action", fake_next)
+    monkeypatch.setattr(car, "_run_skill",
+                        lambda skill, task, agent_id: "Created https://docs.google.com/document/d/REAL123/edit")
+
+    history = car._execute_checkpoint(
+        plan_dict={"goals": ["g"]}, checkpoint=cp,
+        agent_grants=grants, global_grants=gg, agent_id="test_agent")
+
+    # A real doc URL is present → no verifier nudge, checkpoint completes.
+    assert not [h for h in history if h.get("_gdoc_verify_nudge")], "must not nudge when a real doc exists"


### PR DESCRIPTION
A research Project claimed 'saved to Google Drive' but only wrote a local .md. New codec_gdoc_verify + a checkpoint_done gate refuse that false completion: if the deliverable wants a Google Doc but no real docs.google.com URL is in the history, the agent is nudged once to actually create it (via the existing google_docs skill). 72 tests. Actual doc creation needs live Google OAuth (flagged); the gate logic works regardless.