### PR TITLE
fix(license): point client at codec-license.avadigital.ai (off client domain)

### DIFF
--- a/codec_license.py
+++ b/codec_license.py
@@ -47,7 +47,10 @@ PUBKEY_CACHE     = CODEC_HOME / "license_pubkey.pem"
 GRACE_STATE_PATH = CODEC_HOME / ".license_state.json"
 
 GRACE_SECONDS    = 7 * 24 * 3600            # 7-day offline grace (operator choice)
-PUBKEY_URL_DEFAULT = "https://ava-license.lucyvpa.com/public-key"
+# License host migrated off the client domain lucyvpa.com (2026-07-13).
+# ava-license.lucyvpa.com remains a permanent alias on the same backend, and
+# ~/.codec/config.json:license_base_url overrides this default per-install.
+PUBKEY_URL_DEFAULT = "https://codec-license.avadigital.ai/public-key"
 
 # Features that require a valid paid license. Everything not listed is always
 # allowed (the app shell, settings, viewing, etc. — read-only never locks out).
@@ -105,7 +108,7 @@ def _license_token(cfg: dict) -> str:
 
 
 def _pubkey_url(cfg: dict) -> str:
-    base = cfg.get("license_base_url") or "https://ava-license.lucyvpa.com"
+    base = cfg.get("license_base_url") or "https://codec-license.avadigital.ai"
     return base.rstrip("/") + "/public-key"
 
 

--- a/codec_slash_commands.py
+++ b/codec_slash_commands.py
@@ -322,7 +322,7 @@ def _cmd_status(args: list[str]) -> str:
         ("Whisper STT", "http://localhost:8084/v1/models"),
         ("Kokoro TTS", "http://localhost:8085/v1/models"),
         ("AVA proxy", "https://ava-proxy.lucyvpa.com/health"),
-        ("AVA license", "https://ava-license.lucyvpa.com/health"),
+        ("AVA license", "https://codec-license.avadigital.ai/health"),
     ]
     rows = []
     for name, url in services:


### PR DESCRIPTION
Client half of the license-host migration (server half: AVADSA25/ava-stack#1).

- `codec_license.py`: `PUBKEY_URL_DEFAULT` + `_pubkey_url()` base → `codec-license.avadigital.ai`
- `codec_slash_commands.py`: `/health` list AVA-license URL

Old host `ava-license.lucyvpa.com` remains a permanent alias on the same backend — existing installs keep validating; `license_base_url` in `~/.codec/config.json` still overrides. `codec_ava_client.verify_license` (proxy-derived URL) intentionally untouched; migrates with ava-proxy later.

Test: `pytest tests/test_license.py tests/test_slash_commands.py` → 51 passed; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)