### PR TITLE
fix(create_skill): send internal token to the review gate (beat 24)

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -33,7 +33,7 @@
     "cookbook_scan.py": "9bc1fe32073267c45c20d6dca67e293ed07f5c04dfff0109b480f778ffeaa3bb",
     "cookbook_serve.py": "8a08bb5deecd988431da421b1b4825cd411c7e9c7658bc547aa16ce74c0e1ddd",
     "cookbook_stop.py": "8b51e04ef08e08899df24d032af7a609bef7bf02ad72be5badf95eb0a2b1ce64",
-    "create_skill.py": "28070280abfe2179d5c9b33eee74b4db5a5dd085f76a09f02d516302ba330036",
+    "create_skill.py": "de62b38e3e63d638ac075be012d425864a235fe2591a83626212588f9305c66e",
     "daily_kickoff.py": "c649a0597265f284a876512c5689c2b210eb894ffddbd8da6b95f5e36a8cedab",
     "delegate.py": "7c595d5605cd9913a8afa331ae0013861d6996f378f8a59aca0249f1b2f3a474",
     "email_triage.py": "d7b9032b81179f58c5aff660c34f9b8edf212a8ce7651d307306e4757a8daaf2",

--- a/skills/create_skill.py
+++ b/skills/create_skill.py
@@ -134,11 +134,20 @@ The skill should: {description}"""
             return f"Skill {skill_name} already exists. Delete it first or choose a different name."
 
         # ── ROUTE THROUGH REVIEW GATE ──
-        # Stage for human review via dashboard API — NEVER write directly to disk
+        # Stage for human review via dashboard API — NEVER write directly to disk.
+        # The review endpoint sits behind AuthMiddleware (PR-2D): internal callers
+        # must present the per-process HMAC token or the request 401s. Without this
+        # header, create_skill over MCP/voice got "Not authenticated".
         try:
+            try:
+                from codec_keychain import get_internal_token
+                _ipc_token = get_internal_token() or ""
+            except Exception:
+                _ipc_token = ""
             review_resp = requests.post(
                 "http://localhost:8090/api/skill/review",
                 json={"code": code, "filename": f"{skill_name}.py"},
+                headers={"x-internal-token": _ipc_token},
                 timeout=10,
             )
             if review_resp.status_code == 200:


### PR DESCRIPTION
## Bug (found live-testing demo beat 24)

`skills/create_skill.py` POSTed to `http://localhost:8090/api/skill/review` with **no auth header**. Behind `AuthMiddleware` (PR-2D) the request 401s → the skill is generated but the review-gate call returns `{"error":"Not authenticated"}`, so nothing gets staged. Beat 24 ("CODEC writes itself a new skill") fails over MCP/voice.

## Fix

Send the per-process HMAC token via `x-internal-token`, exactly like `skills/health_check.py` and `skills/notification_reader.py` already do. Graceful fallback to `""` if keychain is unavailable (still 401s, but no crash).

Manifest regenerated (D-1 gate) — 88 skills, unchanged count.

## Test

`pytest -k "create_skill or skill_review"` → 8 passed. `ruff` clean. Will re-verify live over the CODEC MCP connector after merge + `codec-dashboard` restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)