### PR TITLE
fix(create_skill): make internal-token failure visible, harden sys.path (beat 24)

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -33,7 +33,7 @@
     "cookbook_scan.py": "9bc1fe32073267c45c20d6dca67e293ed07f5c04dfff0109b480f778ffeaa3bb",
     "cookbook_serve.py": "8a08bb5deecd988431da421b1b4825cd411c7e9c7658bc547aa16ce74c0e1ddd",
     "cookbook_stop.py": "8b51e04ef08e08899df24d032af7a609bef7bf02ad72be5badf95eb0a2b1ce64",
-    "create_skill.py": "de62b38e3e63d638ac075be012d425864a235fe2591a83626212588f9305c66e",
+    "create_skill.py": "c94f75d0fb1e5a2db9aab9cfb93d7f9f387b751c7557238e0b9dcc45abe26ee7",
     "daily_kickoff.py": "c649a0597265f284a876512c5689c2b210eb894ffddbd8da6b95f5e36a8cedab",
     "delegate.py": "7c595d5605cd9913a8afa331ae0013861d6996f378f8a59aca0249f1b2f3a474",
     "email_triage.py": "d7b9032b81179f58c5aff660c34f9b8edf212a8ce7651d307306e4757a8daaf2",

--- a/skills/create_skill.py
+++ b/skills/create_skill.py
@@ -9,9 +9,22 @@ SKILL_MCP_EXPOSE = True
 SKILL_TRIGGERS = ["create a skill", "make a skill", "new skill", "build a skill",
                    "create skill", "write a skill", "add a skill"]
 import os
+import sys
 import requests
 import json
+import logging
 import re
+
+# Ensure the repo root is importable regardless of the caller's sys.path state
+# (mirrors the proven pattern in health_check.py / notification_reader.py). The
+# MCP daemon already puts the repo on sys.path, but a sandboxed subprocess or a
+# future caller may not — and this module's `from codec_keychain import ...`
+# below MUST resolve or the review POST silently loses its auth token.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+log = logging.getLogger("codec")
 
 SKILLS_DIR = os.path.expanduser("~/.codec/skills")
 CONFIG_PATH = os.path.expanduser("~/.codec/config.json")
@@ -139,11 +152,20 @@ The skill should: {description}"""
         # must present the per-process HMAC token or the request 401s. Without this
         # header, create_skill over MCP/voice got "Not authenticated".
         try:
+            _ipc_token = ""
             try:
                 from codec_keychain import get_internal_token
                 _ipc_token = get_internal_token() or ""
-            except Exception:
-                _ipc_token = ""
+            except Exception as _tok_err:
+                # NEVER swallow this silently: an empty token makes the review
+                # POST 401 with a misleading "review gate returned error", which
+                # is exactly what turned beat-24's one-line auth miss into a
+                # multi-hour debug. Make the failure visible in the logs.
+                log.warning(
+                    "create_skill: internal IPC token fetch failed (%s: %s) — "
+                    "review POST will 401",
+                    type(_tok_err).__name__, _tok_err,
+                )
             review_resp = requests.post(
                 "http://localhost:8090/api/skill/review",
                 json={"code": code, "filename": f"{skill_name}.py"},
@@ -157,7 +179,16 @@ The skill should: {description}"""
                     f"Open the Dashboard → Skills to review and approve it before it becomes active."
                 )
             else:
-                return f"Skill generated but review gate returned error: {review_resp.text[:100]}"
+                # Surface the empty-token case explicitly so the next operator
+                # isn't misled by a bare "Not authenticated" from the gate.
+                _hint = (
+                    " (internal auth token was empty — check codec_keychain / "
+                    "repo on sys.path)" if not _ipc_token else ""
+                )
+                return (
+                    f"Skill generated but review gate returned error: "
+                    f"{review_resp.text[:100]}{_hint}"
+                )
         except requests.ConnectionError:
             return (
                 f"Skill '{skill_name}' generated but dashboard is unreachable for review. "


### PR DESCRIPTION
## Root cause (not what the ticket suspected)

Beat 24 (\`create_skill\` over MCP) returned \`{"error":"Not authenticated"}\` from the review gate. The suspected cause was a **sandboxed subprocess** stripping the repo root from \`sys.path\`. That's **disproven**: the MCP path runs the skill **in-process** via \`registry.load()\` + \`mod.run()\` (\`codec_mcp.py:233-238\`) — it never routes through \`codec_sandbox\`. \`codec_mcp.py\` already puts the repo root on \`sys.path\`.

Proven by reproduction — a fresh process mimicking the daemon:
- loads the **repo copy** of \`create_skill.py\` (with #248's fix),
- \`run()\` carries the \`x-internal-token\` header,
- \`get_internal_token()\` returns a valid 43-char token,
- \`/api/skill/review\` returns **401 without token, 200 with token**.

A **live \`mcp__codec__create_skill\` call now succeeds** ("staged for review (ID: …)").

So #248's code was already correct. The "still broken" symptom was a **stale MCP process** that had cached the *pre-#248* \`create_skill\` module (lazy-load caches modules in \`_modules\` for the process's life). The DIAG test that "never appeared" hit a stdio \`codec_mcp.py\` process, not the \`codec-mcp-http\` daemon that was restarted. Cure = restart the process serving the connector (done for \`codec-dashboard\` + \`codec-mcp-http\`).

## What this PR changes (defense-in-depth)

The real defect this PR fixes is **diagnosability** — the token fetch swallowed its exception silently, turning a one-line auth miss into a multi-hour debug:

- **Repo-root \`sys.path\` guard** at module top, mirroring the proven pattern in \`health_check.py\` / \`notification_reader.py\`, so \`from codec_keychain import get_internal_token\` resolves regardless of caller sys.path state (sandbox, dashboard, future callers).
- **Visible token failure**: log a warning on fetch failure, and append an empty-token hint to the gate-error return so it's distinguishable from a real gate error.

## Verification
- \`skills/.manifest.json\` regenerated (built-in skill edit) — **88 skills, count unchanged**.
- \`pytest -k "create_skill or skill_review or manifest"\` → **23 passed, 3 skipped**.
- \`ruff check skills/create_skill.py\` → clean.
- Fresh-registry load: create_skill loads as trusted-manifest with all hardening present.
- Live MCP re-verify after daemon restart → **"staged for review (ID: da0e9703-085)"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)