### PR TITLE
fix(observer): route "what was I doing?" to observer_recall + honest empty-buffer (beat 20)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -427,6 +427,10 @@ CHAT_SKILL_ALLOWLIST = {
     "create_skill", "delegate",
     # Phase 2 Step 7 — end-of-day shift report (read-only, no destructive side effects)
     "shift_report",
+    # Observer recall — "what was I doing 20 min ago?" (read-only, reads the
+    # observer buffer). Without this the phrase fell through to the LLM, which
+    # fabricated an answer from chat memory instead of the real buffer.
+    "observer_recall",
     # Phase 2 Step 6 — first declarative trigger (clipboard URL → web_fetch).
     # Read-only network fetch, gated by codec_ask_user.ask consent on auto-fire.
     "clipboard_url_fetch",

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -62,7 +62,7 @@
     "network_info.py": "bd776b619cf7c18d67fe03cb0f0456cf9c4f9bf71475740a233a9ca1e6672fcd",
     "notes.py": "7d50d1544ea955f59917a1f0e7902d115e9dbccd3188b641057a55b6a5b2803a",
     "notification_reader.py": "681208ae4253dfe549512cce4c722c76ca85f2bbbdb8737e37c026ec9444c972",
-    "observer_recall.py": "7812db351063c96c11ac22fed862d9d4b690ffd779d7179ae958d4ad76761b85",
+    "observer_recall.py": "3744907b24ffbfbb385a630791c08ecd440f6107f21894af80ceb07191f5eb1f",
     "password_generator.py": "f11a917299e14cbd2560111da0bb748cd08792cf715cc4098c64eb62da8c54e3",
     "philips_hue.py": "fa831712c39dc6327c84199d8f0aeb09a169a264ce3d936cc337a5c5d6632f7e",
     "pilot.py": "f9967890f138bc7a48ae4abc8b4170dca13961b81659ef4e530dc619c1cf90d4",

--- a/skills/observer_recall.py
+++ b/skills/observer_recall.py
@@ -114,6 +114,19 @@ def _summarise(entries: list) -> str:
         out.append("Files touched: " + ", ".join(sorted(files_seen)[:8]) + ".")
     if ocr_bits:
         out.append('On screen (excerpt): "' + ocr_bits[-1] + '"')
+    if not out:
+        # Entries exist but carry no window/title/OCR/file content — the observer
+        # is polling but capturing nothing. This is almost always a macOS
+        # permission gap (Screen Recording / Automation / Accessibility not
+        # granted to the codec-observer process). Say so honestly rather than
+        # returning an empty string that lets a caller fabricate an answer.
+        return (
+            f"The observer captured {len(entries)} snapshot(s) in that window but "
+            "no window titles, on-screen text, or files — it's polling but seeing "
+            "nothing. Grant the codec-observer process Screen Recording + "
+            "Automation + Accessibility in System Settings → Privacy & Security, "
+            "then restart it (pm2 restart codec-observer)."
+        )
     return "\n".join(out)
 
 


### PR DESCRIPTION
## Bug (live-testing beat 20)

User asked "what was I doing 20 minutes ago?" and CODEC fabricated a detailed "Reflection AI $6.3B SpaceX deal" answer — pulled from chat memory (the beat-12 competitor report), **not** the observer buffer.

Root cause = two bugs:
1. **`observer_recall` was not in `CHAT_SKILL_ALLOWLIST`** (routes/chat.py) — its triggers include "what was i doing", but the pre-LLM skill hijack gates on the allowlist, so the phrase fell through to the LLM.
2. Even routed, the observer buffer is **empty** (10 snapshots, all `app=None`, `ocr=""`) — `codec-observer` is polling but capturing nothing (macOS Screen Recording / Automation / Accessibility not granted to it). `_summarise` returned `""` in that case, which invites fabrication.

## Fix
1. Add `observer_recall` to the allowlist.
2. `_summarise` now returns an honest message ("captured N snapshots but no window titles / screen text — grant the observer these permissions…") instead of an empty string.

Manifest regenerated (88 skills). `py_compile` + `ruff` clean.

**Follow-up (user action):** grant `codec-observer` Screen Recording + Automation + Accessibility in System Settings so the buffer actually fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)