### PR TITLE
fix(pilot): send x-csrf-token on Pilot POSTs — unblocks navigate/click/run (beat 14)

### DIFF
--- a/codec_tasks.html
+++ b/codec_tasks.html
@@ -1229,6 +1229,12 @@ function _pilotFetch(path, opts) {
     xhr.open(opts.method || 'GET', _pilotBase + path, true);
     if (opts.method && opts.method !== 'GET') {
       xhr.setRequestHeader('Content-Type', 'application/json');
+      // The dashboard AuthMiddleware requires x-csrf-token on every POST/PUT/
+      // DELETE. We deliberately bypass the global fetch wrapper (it E2E-encrypts
+      // bodies → runner 422), so we must add JUST this header ourselves — without
+      // it every Pilot action (navigate/click/type/run/record) 403s silently.
+      var _csrf = document.cookie.match(/codec_csrf=([^;]+)/);
+      if (_csrf) xhr.setRequestHeader('x-csrf-token', _csrf[1]);
     }
     xhr.onload = function() {
       var text = xhr.responseText;
@@ -1323,8 +1329,10 @@ function pilotNavigate() {
     headers: {'Content-Type':'application/json'},
     body: JSON.stringify({url: url})
   })
-  .then(function(r){ return r.json(); })
-  .then(function(d) {
+  .then(function(r){ return r.json().then(function(d){ return {ok:r.ok, status:r.status, d:d}; }); })
+  .then(function(res) {
+    if (!res.ok) { showToast('Navigate failed (' + res.status + '): ' + ((res.d && res.d.error) || 'refresh the page'), true); return; }
+    var d = res.d;
     showToast('Navigated: ' + (d.title || url) + ' (' + (d.element_count||0) + ' elements)');
     pilotRefreshScreenshot();
     setTimeout(pilotSnapshot, 500);


### PR DESCRIPTION
## Bug (live-testing beat 14 — "Pilot forever not working, I type google.com, nothing happens")

The Pilot tab's `_pilotFetch()` (codec_tasks.html) intentionally bypasses CODEC's global `fetch` wrapper — because that wrapper E2E-encrypts POST bodies, which the runner's pydantic model can't parse (the old 422). But bypassing it also dropped the **`x-csrf-token`** header that the dashboard's `AuthMiddleware` requires on **every** POST/PUT/DELETE.

Result: every Pilot **action** is a POST (`/navigate`, `/click`, `/type`, `/run`, `/record/start`, HITL controls) → all **403** "CSRF token mismatch". GETs (`/health`, `/snapshot`, `/screenshot/stream`, `/status`) have no CSRF gate → they pass, so the status dot shows Online and the live view streams. That's the exact **half-broken** symptom. And `pilotNavigate()` never checked `r.ok`, so on the 403 it still fired a **false "Navigated" toast** → silent no-op.

Proven end-to-end: runner `POST /navigate` + token → 200 (page changes); proxy `POST /api/pilot/navigate` with cookies but no `x-csrf-token` → **403**; with the header → passes CSRF. The runner + proxy were both healthy.

## Fix
1. `_pilotFetch`: add **only** the `x-csrf-token` header for non-GET (keep body plain JSON — avoids the 422). This unblocks the entire Pilot write surface at once.
2. `pilotNavigate`: check `r.ok` and surface real errors instead of a false success toast.

## Verify
Hard-refresh the Pilot tab → type `google.com` → Go → the pane navigates; DevTools shows `POST /api/pilot/navigate` → **200** (was 403). `Record`, `Start Run`, click/type all work too (same gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)