### PR TITLE
feat(mcp-http): log the skills dir the registry actually scanned (beat-24 follow-up)

### DIFF
--- a/codec_mcp_http.py
+++ b/codec_mcp_http.py
@@ -209,6 +209,14 @@ def main():
     log.info("CODEC MCP HTTP (OAuth 2.1) starting on %s:%s", host, port)
     log.info("Public base: %s", public_base)
     log.info("Tools exposed: %d", tool_count)
+    # Observability (beat-24 follow-up): log the skills dir the registry
+    # ACTUALLY scanned, plus repo + cwd. A daemon accidentally running from a
+    # worktree, an .app bundle, or a stale cwd loads a different create_skill.py
+    # than the maintained repo copy — this line makes that mismatch obvious at
+    # a glance instead of via a multi-session "which file loads?" hunt.
+    from codec_mcp import _mcp_registry as _reg
+    log.info("Skills dir (scanned): %s  |  repo: %s  |  cwd: %s",
+             getattr(_reg, "skills_dir", "?"), _REPO_DIR, os.getcwd())
     log.info("Rate limit: %d req/min per IP", _RATE_LIMIT)
     log.info("OAuth metadata: %s/.well-known/oauth-authorization-server", public_base)
     log.info("MCP endpoint:   %s/mcp", public_base)


### PR DESCRIPTION
## Why

Beat-24 `create_skill` 401s (\"review gate returned error: {\"error\":\"Not authenticated\"}\") were chased across **three** sessions (#248, #249, and a third) as a *\"wrong file loads\"* code bug. This session's investigation proved otherwise:

- The committed `skills/create_skill.py` (#249) is correct — it fetches `get_internal_token()` and sends `x-internal-token`.
- `skills/.manifest.json` correctly trusts it (`c94f75d0…` == disk).
- The HTTP-daemon code path (`CODEC_MCP_TRANSPORT=http`, repo cwd) loads **`~/codec-repo/skills/create_skill.py`** and returns `staged for review` — verified with 4 consecutive live runs, **zero 401s**.

**Root cause was operational, not code:** an *earlier* `codec-mcp-http` incarnation served a stale, self-consistent old copy (pre-#248, no token, old error format) while the repo copy was already fixed. The dual-marker test looked like a \"third file\" because editing a copy breaks its manifest hash → the PR-1A AST gate blocks it (`skill_load_blocked: \"Dangerous import: os\"` is in the audit log), so the running daemon kept serving its own cached/old copy.

The startup banner logged the tool **count** but never the **resolved skills dir** — so a daemon running from a worktree, an `.app` bundle, or a stale cwd was invisible in the logs. That opacity is what cost three sessions.

## What

One startup line printing the skills dir the registry **actually scanned**, plus repo dir + cwd:

\`\`\`
[codec-mcp-http] Skills dir (scanned): /Users/…/codec-repo/skills  |  repo: /Users/…/codec-repo  |  cwd: /Users/…/codec-repo
\`\`\`

- Observability only — **no behavior change**.
- `skills/` untouched → **no manifest regen** needed.
- ruff clean, `py_compile` ok, MCP + skill-registry/route/review tests pass (43 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)