### PR TITLE
fix(overlay+webcam): Cmd-V paste in F16 input; warm up webcam capture (demo beats 8 + F16)

### DIFF
--- a/routes/media.py
+++ b/routes/media.py
@@ -16,6 +16,7 @@ import base64
 import json
 import os
 import subprocess
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
@@ -119,12 +120,34 @@ async def webcam_snapshot():
         cap = cv2.VideoCapture(0)
         if not cap.isOpened():
             return None, None
-        ret, frame = cap.read()
-        cap.release()
-        if not ret:
-            return None, None
-        _, jpeg = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
-        return jpeg.tobytes(), True
+        try:
+            # Request a high-res frame. The cv2 default is often 640x480, which
+            # reads soft/blurry once scaled up for vision analysis.
+            cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1920)
+            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 1080)
+            try:
+                cap.set(cv2.CAP_PROP_AUTOFOCUS, 1)  # keep AF on (AVFoundation may ignore)
+            except Exception:
+                pass
+            # Warm up before grabbing the keeper frame: the first frames after
+            # opening the device are dark and out of focus while auto-exposure,
+            # white-balance and autofocus converge. Reading and discarding ~1.2s
+            # of frames lets the sensor settle so the still is sharp and correctly
+            # exposed — this is the root fix for the blurry webcam capture.
+            frame = None
+            for _ in range(25):
+                ret, f = cap.read()
+                if ret and f is not None:
+                    frame = f
+                time.sleep(0.05)
+            if frame is None:
+                return None, None
+            # High JPEG quality — this is a single still for vision, not a stream,
+            # so don't over-compress and throw away the detail we just waited for.
+            _, jpeg = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, 92])
+            return jpeg.tobytes(), True
+        finally:
+            cap.release()
 
     loop = asyncio.get_event_loop()
     data, ok = await loop.run_in_executor(ThreadPoolExecutor(1), _capture)

--- a/swift-overlay/Sources/main.swift
+++ b/swift-overlay/Sources/main.swift
@@ -369,6 +369,33 @@ final class InputPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
 
+    // ⌘V / ⌘C / ⌘X / ⌘A in the F16 field. This is a borderless panel inside an
+    // accessory (LSUIElement) app that builds only a status-bar menu — there is
+    // no Edit menu, so AppKit never translates the standard editing shortcuts
+    // into paste:/copy:/cut:/selectAll: (the field editor only got them from the
+    // right-click context menu, which is why the mouse worked but ⌘V didn't).
+    // Intercept the plain command-key equivalents here and send the matching
+    // action down the responder chain to the field editor.
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.type == .keyDown {
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let key = event.charactersIgnoringModifiers?.lowercased()
+            if flags == .command {
+                switch key {
+                case "v": if NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: self) { return true }
+                case "c": if NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: self) { return true }
+                case "x": if NSApp.sendAction(#selector(NSText.cut(_:)), to: nil, from: self) { return true }
+                case "a": if NSApp.sendAction(#selector(NSResponder.selectAll(_:)), to: nil, from: self) { return true }
+                case "z": if NSApp.sendAction(Selector(("undo:")), to: nil, from: self) { return true }
+                default: break
+                }
+            } else if flags == [.command, .shift], key == "z" {
+                if NSApp.sendAction(Selector(("redo:")), to: nil, from: self) { return true }
+            }
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
     private func setupUI() {
         vfx.material = .hudWindow
         vfx.blendingMode = .behindWindow


### PR DESCRIPTION
Two macOS demo bugs Mickael flagged. **BUG 1 fully fixed + verified live. BUG 2 partially fixed (exposure) with an important finding — see caveat.**

## BUG 1 — Cmd-V doesn't paste in the F16 text input ✅ FIXED + VERIFIED
`swift-overlay/Sources/main.swift` · `InputPanel`

**Root cause:** the F16 panel is a borderless `NSPanel` inside an accessory (LSUIElement) app that builds only a *status-bar* menu — there is **no Edit menu**. AppKit only turns Cmd-V/C/X/A into `paste:`/`copy:`/`cut:`/`selectAll:` by routing them through an Edit menu's key-equivalents, so those shortcuts were silently swallowed. The right-click menu worked because `NSTextView` supplies its own context menu.

**Fix:** override `performKeyEquivalent(with:)` on the panel to route the plain command-key equivalents to the field editor via `NSApp.sendAction(..., to: nil)` (the responder chain). Adds Cmd-Z / Cmd-Shift-Z too.

**Verified end-to-end** against the running overlay (triggered the panel via `~/.codec/overlay_events.jsonl`, injected keystrokes, read back the panel's submitted text):
- Cmd-V → fresh clipboard sentinel pasted into the empty field and submitted (exact match) ✅
- Cmd-A + Cmd-C → clipboard received the field's text ✅
- Cmd-A + Cmd-X → field emptied ✅

## BUG 2 — webcam still is blurry / washed out (demo beat 8) ⚠️ PARTIAL
`routes/media.py` · `/api/webcam/snapshot`

**First finding:** the capture is **Python OpenCV** (`cv2.VideoCapture(0)`), **not Swift** — the DEMO_SCRIPT "Swift fix pending" note for beat 8 was wrong. The Swift overlay has no camera code.

**Root cause (from the saved demo frames in `~/.codec/photos`):** the endpoint opened the camera and grabbed the **very first frame**, before auto-exposure / autofocus converge. Evidence:
- an early frame is **blown out to white** + soft (AE not settled)
- a frame ~7s later is **correctly exposed but still soft** (AE settled, AF never converged)

**Fix here:** request a high-res frame, enable autofocus, read+discard ~1.2s of frames so the sensor settles before grabbing the keeper, encode at JPEG q92. This resolves the **exposure wash-out** (verified cause).

**Caveat — not fully closed, and NOT live-verified:**
- The **focus softness is depth-uniform and never converges** even after seconds of streaming → looks like the Anker C200's AF over UVC (OpenCV's AVFoundation backend barely controls AF) or a **physical lens issue (protective film / smudge)**. Warmup does not fix this.
- I could **not live-verify** the capture: the C200 is currently returning the macOS "camera unavailable" placeholder (device off/covered/busy), so both test captures were the placeholder, not a real frame. Needs a re-test with the webcam actually on.

## Tests
- `swift build -c release` clean from `origin/main`
- `pytest tests/test_route_extractions_d.py` → 24 passed
- `ruff` clean on `routes/media.py`

## After merge
Rebuild + relaunch the overlay to pick up BUG 1:
`cd swift-overlay && swift build -c release && pm2 restart codec-overlay`
(BUG 2's `media.py` is already live on this machine — dashboard was restarted during testing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)