### PR TITLE
feat(skills): Skills review/approve UI + disk-persisted reviews (beat 21)

### DIFF
--- a/codec_dashboard.html
+++ b/codec_dashboard.html
@@ -142,6 +142,13 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 .tab .ico { opacity: 0.5; }
 .tab.active .ico { opacity: 1; color: var(--accent); }
+.tab-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 16px; height: 16px; padding: 0 5px; margin-left: 1px;
+  background: var(--accent); color: #fff; font-size: 10px; font-weight: 700;
+  border-radius: 8px; line-height: 1;
+}
+.tab-badge.hidden { display: none; }
 
 /* ── Content ── */
 .content { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; }
@@ -282,6 +289,26 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
 .save-config-btn:hover { background: var(--accent-hover); }
 .save-config-btn:active { transform: scale(0.98); }
 .save-config-btn.saved { background: var(--success); }
+
+/* ── Skill Reviews ── */
+.skills-review-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 14px; }
+.skills-review-sub { font-size: 12px; color: var(--text-dim); max-width: 560px; line-height: 1.45; margin-top: 3px; }
+.skills-refresh-btn { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 7px; color: var(--text-dim); cursor: pointer; flex-shrink: 0; display: flex; }
+.skills-refresh-btn:hover { color: var(--accent); border-color: var(--accent); }
+.skill-review-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 14px; overflow: hidden; }
+.skill-review-top { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 12px 14px; border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+.skill-review-name { font-family: var(--mono); font-size: 14px; font-weight: 600; color: var(--text); display: flex; align-items: center; gap: 8px; word-break: break-all; }
+.skill-review-meta { font-size: 11px; color: var(--text-dim); font-family: var(--mono); }
+.skill-review-actions { display: flex; gap: 8px; }
+.skill-btn { border: none; border-radius: 6px; padding: 7px 16px; font-weight: 600; font-size: 12px; cursor: pointer; font-family: var(--font); transition: opacity .15s, background .15s, border-color .15s, color .15s; }
+.skill-btn:hover { opacity: .88; }
+.skill-btn.approve { background: var(--success); color: #fff; }
+.skill-btn.reject { background: var(--surface-2); color: var(--text-muted); border: 1px solid var(--border); }
+.skill-btn.reject:hover { color: var(--danger); border-color: var(--danger); opacity: 1; }
+.skill-btn:disabled { opacity: .5; cursor: default; }
+.skill-review-code { margin: 0; padding: 12px 14px; font-family: var(--mono); font-size: 12px; line-height: 1.5; color: var(--text-muted); white-space: pre; overflow: auto; max-height: 340px; background: var(--bg); }
+.skills-empty { text-align: center; color: var(--text-dim); font-size: 13px; padding: 44px 20px; }
+.skills-empty svg { width: 38px; height: 38px; opacity: .3; margin-bottom: 10px; }
 
 /* ── Prompt Editor ── */
 .prompt-card { background:var(--surface-2);border:1px solid var(--border);border-radius:var(--radius);margin-bottom:10px;overflow:hidden;transition:all .2s }
@@ -601,6 +628,9 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
     <button class="tab" onclick="showTab('cortex')" id="tab-cortex">
       <svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M12 2C9 2 6.5 3.8 5.5 6.5c-1.5.5-2.7 1.5-3.3 3-.6 1.4-.4 3.1.5 4.3-.3 1.5 0 3.1 1 4.3s2.6 1.9 4.2 1.9h.1c1 1.2 2.5 2 4 2s3-.8 4-2h.1c1.6 0 3.2-.7 4.2-1.9s1.3-2.8 1-4.3c.9-1.2 1.1-2.9.5-4.3-.6-1.5-1.8-2.5-3.3-3C17.5 3.8 15 2 12 2z"/></svg>Cortex
     </button>
+    <button class="tab" onclick="showTab('skills')" id="tab-skills">
+      <svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>Skills<span class="tab-badge hidden" id="skillsBadge">0</span>
+    </button>
     <button class="tab" onclick="showTab('settings')" id="tab-settings">
       <svg class="ico ico-sm" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>Settings
     </button>
@@ -666,6 +696,22 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
     <!-- Cortex Panel -->
     <div class="panel" id="panel-cortex">
       <iframe id="cortexFrame" src="" style="width:100%;height:calc(100vh - 160px);border:none;border-radius:8px" allowfullscreen></iframe>
+    </div>
+
+    <!-- Skills Review Panel -->
+    <div class="panel" id="panel-skills">
+      <div class="skills-review-head">
+        <div>
+          <div class="settings-title" style="margin-bottom:0">Skill Reviews</div>
+          <div class="skills-review-sub">Skills generated by voice or chat are staged here. Review the code, then Approve to activate it or Reject to discard. Nothing runs until you approve.</div>
+        </div>
+        <button class="skills-refresh-btn" onclick="loadSkillReviews()" title="Refresh">
+          <svg class="ico ico-sm" viewBox="0 0 24 24"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/></svg>
+        </button>
+      </div>
+      <div id="skillReviewsList">
+        <div class="refreshing">Loading staged skills...</div>
+      </div>
     </div>
 
     <!-- Settings Panel -->
@@ -868,7 +914,112 @@ function showTab(id) {
     var cf = document.getElementById('cortexFrame');
     if (cf && !cf.src.includes('/cortex')) cf.src = '/cortex?embed=1';
   }
+  if (id === 'skills') loadSkillReviews();
   if (id === 'settings') { loadSettings(); renderUIToggles(); loadPrompts(); }
+}
+
+// ── Skill Reviews (staged create_skill output → review → approve/reject) ──
+var _skillReviewsBusy = false;
+function _skillEmptyState() {
+  return '<div class="skills-empty">' +
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>' +
+    '<div>No skills waiting for review.</div>' +
+    '<div style="font-size:12px;margin-top:4px;color:var(--text-dim)">Ask CODEC to "create a skill that..." by voice or chat, and it will appear here.</div>' +
+    '</div>';
+}
+async function loadSkillReviews() {
+  var box = document.getElementById('skillReviewsList');
+  if (!box) return;
+  box.innerHTML = '<div class="refreshing">Loading staged skills...</div>';
+  try {
+    var r = await fetch('/api/skill/reviews');
+    var d = await r.json();
+    var reviews = (d && d.reviews) || [];
+    _setSkillsBadge(reviews.length);
+    if (!reviews.length) { box.innerHTML = _skillEmptyState(); return; }
+    box.innerHTML = reviews.map(function(rev) {
+      var name = _escHtml(rev.filename || rev.id || 'skill.py');
+      var staged = rev.staged_at ? _escHtml(_fmtStaged(rev.staged_at)) : '';
+      var meta = staged ? '<span class="skill-review-meta">staged ' + staged + '</span>' : '';
+      var rid = _escHtml(rev.id || '');
+      return '<div class="skill-review-card" data-rid="' + rid + '">' +
+        '<div class="skill-review-top">' +
+          '<span class="skill-review-name">' + name + ' ' + meta + '</span>' +
+          '<span class="skill-review-actions">' +
+            '<button class="skill-btn approve" onclick="approveSkill(this,\'' + rid + '\')">Approve</button>' +
+            '<button class="skill-btn reject" onclick="rejectSkill(this,\'' + rid + '\')">Reject</button>' +
+          '</span>' +
+        '</div>' +
+        '<pre class="skill-review-code">' + _escHtml(rev.code || '') + '</pre>' +
+      '</div>';
+    }).join('');
+  } catch (e) {
+    box.innerHTML = '<div class="skills-empty">Could not load staged skills: ' + _escHtml(String(e)) + '</div>';
+  }
+}
+function _fmtStaged(iso) {
+  try {
+    var dt = new Date(iso);
+    if (isNaN(dt.getTime())) return iso;
+    return dt.toLocaleString([], {month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'});
+  } catch (e) { return iso; }
+}
+function _setSkillsBadge(n) {
+  var b = document.getElementById('skillsBadge');
+  if (!b) return;
+  b.textContent = n;
+  b.classList.toggle('hidden', !n);
+}
+async function refreshSkillsBadge() {
+  try {
+    var r = await fetch('/api/skill/reviews');
+    var d = await r.json();
+    _setSkillsBadge(((d && d.reviews) || []).length);
+  } catch (e) { /* leave badge as-is */ }
+}
+async function approveSkill(btn, rid) {
+  if (_skillReviewsBusy) return;
+  _skillReviewsBusy = true;
+  var card = btn.closest('.skill-review-card');
+  if (card) card.querySelectorAll('.skill-btn').forEach(function(b){ b.disabled = true; });
+  try {
+    var r = await fetch('/api/skill/approve', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({review_id: rid})
+    });
+    var d = await r.json().catch(function(){ return {}; });
+    if (r.ok) {
+      showToast('Approved: ' + (d.skill || 'skill') + ' is now active');
+    } else {
+      showToast('Approve failed: ' + (d.error || ('HTTP ' + r.status)));
+    }
+  } catch (e) {
+    showToast('Approve failed: ' + String(e));
+  } finally {
+    _skillReviewsBusy = false;
+    loadSkillReviews();
+  }
+}
+async function rejectSkill(btn, rid) {
+  if (_skillReviewsBusy) return;
+  _skillReviewsBusy = true;
+  var card = btn.closest('.skill-review-card');
+  if (card) card.querySelectorAll('.skill-btn').forEach(function(b){ b.disabled = true; });
+  try {
+    var r = await fetch('/api/skill/reject/' + encodeURIComponent(rid), {method: 'POST'});
+    var d = await r.json().catch(function(){ return {}; });
+    if (r.ok) {
+      showToast('Rejected: ' + (d.filename || 'skill') + ' discarded');
+    } else {
+      showToast('Reject failed: ' + (d.error || ('HTTP ' + r.status)));
+    }
+  } catch (e) {
+    showToast('Reject failed: ' + String(e));
+  } finally {
+    _skillReviewsBusy = false;
+    loadSkillReviews();
+  }
 }
 
 var _pendingImage = null; // {base64, name}
@@ -2215,6 +2366,8 @@ window.addEventListener('beforeinstallprompt', function(e) { deferredPrompt = e;
     }).catch(function(){})
   }
   pollNotifCount();setInterval(pollNotifCount,30000);
+  // Skill-review pending count → tab badge (same cadence as notifications)
+  if(typeof refreshSkillsBadge==='function'){refreshSkillsBadge();setInterval(refreshSkillsBadge,30000);}
   var bell=document.getElementById('notifBellBtn');
   if(bell)bell.addEventListener('click',function(){
     fetch('/api/notifications/read-all',{method:'POST'}).catch(function(){});

--- a/routes/skills.py
+++ b/routes/skills.py
@@ -15,6 +15,8 @@ hash + AST check refuses it.
 """
 import json
 import os
+import re
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -24,6 +26,125 @@ from routes._shared import (
 )
 
 router = APIRouter()
+
+
+# ── Staged-review persistence ─────────────────────────────────────────────────
+# Reviews were previously kept ONLY in the in-memory `_pending_skills` dict, so
+# every `codec-dashboard` restart wiped them and there was no way to list/approve
+# a skill staged in an earlier process. They now also live on disk at
+# ~/.codec/skill_reviews/<review_id>.json (atomic via codec_jsonstore) so they
+# survive a restart, and the list/approve/reject endpoints read from there. The
+# in-memory dict is kept as a write-through cache for backward compatibility with
+# callers/tests that populate it directly.
+
+_REVIEWS_DIR = os.path.expanduser("~/.codec/skill_reviews")
+# review_id is `uuid4()[:12]` (hex + one hyphen); this also guards the reject
+# endpoint's path param against traversal — only these chars are ever a filename.
+_REVIEW_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _reviews_dir() -> str:
+    """Directory holding staged skill reviews. A function (not a constant) so
+    tests can monkeypatch it to a tmp dir for isolation."""
+    return _REVIEWS_DIR
+
+
+def _safe_review_id(review_id) -> str | None:
+    """Return `review_id` iff it is a safe single-path-segment filename stem,
+    else None. Defends the on-disk review path against traversal / absolute
+    paths coming from the reject endpoint's URL parameter."""
+    rid = str(review_id or "")
+    if not _REVIEW_ID_RE.match(rid):
+        return None
+    if os.path.basename(rid) != rid:
+        return None
+    return rid
+
+
+def _review_path(review_id) -> str | None:
+    sid = _safe_review_id(review_id)
+    if sid is None:
+        return None
+    return os.path.join(_reviews_dir(), f"{sid}.json")
+
+
+def _persist_review(review_id: str, filename: str, code: str) -> dict:
+    """Write a staged review to disk (atomic). Returns the record. Never raises —
+    a persistence failure degrades to the in-memory dict, not a 500."""
+    rec = {
+        "id": review_id,
+        "filename": filename,
+        "code": code,
+        "staged_at": datetime.now(timezone.utc).isoformat(),
+    }
+    path = _review_path(review_id)
+    if path:
+        try:
+            import codec_jsonstore
+            codec_jsonstore.atomic_write_json(path, rec)
+        except Exception as e:
+            log.warning("Failed to persist skill review %s: %s", review_id, e)
+    return rec
+
+
+def _load_review(review_id):
+    """Return the staged review record (disk first, then the in-memory dict), or
+    None if it isn't staged anywhere."""
+    path = _review_path(review_id)
+    if path:
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            pass
+    mem = _pending_skills.get(review_id)
+    if mem:
+        return {
+            "id": review_id,
+            "filename": mem.get("filename", ""),
+            "code": mem.get("code", ""),
+            "staged_at": mem.get("staged_at", ""),
+        }
+    return None
+
+
+def _delete_review(review_id) -> None:
+    """Remove a staged review from both disk and the in-memory cache. Idempotent."""
+    _pending_skills.pop(review_id, None)
+    path = _review_path(review_id)
+    if path:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            log.warning("Failed to delete skill review %s: %s", review_id, e)
+
+
+def _list_reviews() -> list:
+    """All staged reviews on disk, newest first. A half-written file is never
+    observed (atomic write); an unreadable/corrupt one is skipped, not fatal."""
+    out = []
+    try:
+        names = os.listdir(_reviews_dir())
+    except OSError:
+        return out
+    for fn in names:
+        if not fn.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(_reviews_dir(), fn), encoding="utf-8") as f:
+                rec = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+        out.append({
+            "id": rec.get("id") or fn[:-5],
+            "filename": rec.get("filename", ""),
+            "code": rec.get("code", ""),
+            "staged_at": rec.get("staged_at", ""),
+        })
+    out.sort(key=lambda r: r.get("staged_at", ""), reverse=True)
+    return out
 
 
 def _pinned_builtin_names():
@@ -59,7 +180,11 @@ async def skill_review(request: Request):
         return JSONResponse({"error": "No code provided"}, status_code=400)
     review_id = str(uuid.uuid4())[:12]
     _pending_skills[review_id] = {"code": code, "filename": filename}
-    return {"review_id": review_id, "code": code, "filename": filename}
+    rec = _persist_review(review_id, filename, code)
+    return {
+        "review_id": review_id, "code": code, "filename": filename,
+        "staged_at": rec.get("staged_at", ""),
+    }
 
 
 @router.post("/api/skill/approve")
@@ -67,9 +192,12 @@ async def skill_approve(request: Request):
     """Approve a pending skill review -- writes to disk and removes from pending."""
     body = await request.json()
     review_id = body.get("review_id", "")
-    if review_id not in _pending_skills:
+    # Read disk-first (survives restart), fall back to the in-memory cache. The
+    # review is NOT removed here — only after a successful write below — so a
+    # blocked/invalid approve leaves the staged review in place to retry/reject.
+    pending = _load_review(review_id)
+    if not pending:
         return JSONResponse({"error": "Review not found or already approved"}, status_code=404)
-    pending = _pending_skills.pop(review_id)
     code = pending["code"]
     filename = pending["filename"]
     if "SKILL_DESCRIPTION" not in code or "def run(" not in code:
@@ -110,7 +238,48 @@ async def skill_approve(request: Request):
     path = os.path.join(skill_dir, filename)
     with open(path, "w") as f:
         f.write(code)
+    # Only now that the skill is on disk do we clear the staged review (from both
+    # disk and the in-memory cache) so a crash mid-write leaves it re-approvable.
+    _delete_review(review_id)
+    try:
+        from codec_audit import log_event
+        log_event(
+            "skill_approved", source="codec-routes-skills",
+            message=f"approved skill {filename} ({len(code)} bytes) → {path}",
+            level="info", outcome="ok",
+            extra={"filename": filename, "review_id": review_id, "size": len(code)},
+        )
+    except Exception:
+        pass
     return {"path": path, "skill": filename, "size": len(code)}
+
+
+@router.get("/api/skill/reviews")
+async def skill_reviews():
+    """List every skill staged for review (survives dashboard restart). The PWA
+    Skills panel renders these with Approve / Reject buttons."""
+    reviews = _list_reviews()
+    return {"reviews": reviews, "count": len(reviews)}
+
+
+@router.post("/api/skill/reject/{review_id}")
+async def skill_reject(review_id: str):
+    """Discard a staged skill review without writing it to disk."""
+    pending = _load_review(review_id)
+    if not pending:
+        return JSONResponse({"error": "Review not found"}, status_code=404)
+    _delete_review(review_id)
+    try:
+        from codec_audit import log_event
+        log_event(
+            "skill_review_rejected", source="codec-routes-skills",
+            message=f"rejected staged skill {pending.get('filename', '?')}",
+            level="info", outcome="ok",
+            extra={"review_id": review_id, "filename": pending.get("filename", "")},
+        )
+    except Exception:
+        pass
+    return {"status": "rejected", "id": review_id, "filename": pending.get("filename", "")}
 
 
 @router.get("/api/skills")

--- a/tests/test_skill_reviews_persistence.py
+++ b/tests/test_skill_reviews_persistence.py
@@ -1,0 +1,173 @@
+"""Tests for disk-persisted skill reviews (routes/skills.py).
+
+Reviews used to live only in the in-memory `_pending_skills` dict, so a
+`codec-dashboard` restart wiped them and there was no way to list or approve a
+skill staged in an earlier process. These tests pin the new behavior:
+
+- /api/skill/review writes ~/.codec/skill_reviews/<id>.json (atomic)
+- staged reviews survive a "restart" (in-memory dict cleared)
+- GET  /api/skill/reviews lists them (id, filename, code, staged_at)
+- POST /api/skill/approve reads disk-first and deletes the review file
+- POST /api/skill/reject/{id} discards without writing a skill
+- the review_id filename is traversal-safe
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from routes import skills as skills_routes  # noqa: E402
+
+_VALID_SKILL = (
+    'SKILL_NAME = "moon_phase"\n'
+    'SKILL_DESCRIPTION = "Report the current moon phase"\n'
+    'SKILL_TRIGGERS = ["moon phase"]\n'
+    '\n'
+    'def run(task, app="", ctx=""):\n'
+    '    return "waxing gibbous"\n'
+)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """A TestClient whose skills dir and review store are both isolated to tmp,
+    with the in-memory cache emptied so each test starts clean."""
+    skills_dir = tmp_path / "skills"
+    reviews_dir = tmp_path / "skill_reviews"
+    skills_dir.mkdir()
+    monkeypatch.setattr(skills_routes, "_get_skills_dir", lambda: str(skills_dir))
+    monkeypatch.setattr(skills_routes, "_reviews_dir", lambda: str(reviews_dir))
+    skills_routes._pending_skills.clear()
+    app = FastAPI()
+    app.include_router(skills_routes.router)
+    c = TestClient(app)
+    c._skills_dir = skills_dir       # type: ignore[attr-defined]
+    c._reviews_dir = reviews_dir     # type: ignore[attr-defined]
+    return c
+
+
+def _stage(client, filename="moon_phase.py", code=_VALID_SKILL):
+    r = client.post("/api/skill/review", json={"code": code, "filename": filename})
+    assert r.status_code == 200, r.text
+    return r.json()["review_id"]
+
+
+# ── persistence ───────────────────────────────────────────────────────────────
+
+
+def test_review_writes_json_to_disk(client):
+    rid = _stage(client)
+    review_file = client._reviews_dir / f"{rid}.json"
+    assert review_file.exists(), "review must be persisted to disk"
+    import json
+    rec = json.loads(review_file.read_text())
+    assert rec["id"] == rid
+    assert rec["filename"] == "moon_phase.py"
+    assert "def run(" in rec["code"]
+    assert rec["staged_at"], "staged_at timestamp must be recorded"
+
+
+def test_reviews_survive_restart(client):
+    """The list must still show a staged review after the in-memory cache is
+    wiped (simulating a dashboard restart)."""
+    _stage(client)
+    skills_routes._pending_skills.clear()  # restart wipes RAM, disk survives
+    r = client.get("/api/skill/reviews")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 1
+    assert body["reviews"][0]["filename"] == "moon_phase.py"
+    assert body["reviews"][0]["code"].startswith("SKILL_NAME")
+
+
+def test_list_reviews_shape(client):
+    _stage(client, filename="alpha.py")
+    _stage(client, filename="beta.py")
+    r = client.get("/api/skill/reviews")
+    body = r.json()
+    assert body["count"] == 2
+    for rec in body["reviews"]:
+        assert set(rec) >= {"id", "filename", "code", "staged_at"}
+    names = {rec["filename"] for rec in body["reviews"]}
+    assert names == {"alpha.py", "beta.py"}
+
+
+# ── approve ───────────────────────────────────────────────────────────────────
+
+
+def test_approve_writes_skill_and_deletes_review(client):
+    rid = _stage(client)
+    r = client.post("/api/skill/approve", json={"review_id": rid})
+    assert r.status_code == 200, r.text
+    assert (client._skills_dir / "moon_phase.py").exists(), "skill must be written"
+    assert not (client._reviews_dir / f"{rid}.json").exists(), "review file must be deleted"
+    # and it must vanish from the list
+    assert client.get("/api/skill/reviews").json()["count"] == 0
+
+
+def test_approve_reads_from_disk_after_restart(client):
+    """Approve must succeed reading only the on-disk record (cache wiped)."""
+    rid = _stage(client)
+    skills_routes._pending_skills.clear()
+    r = client.post("/api/skill/approve", json={"review_id": rid})
+    assert r.status_code == 200, r.text
+    assert (client._skills_dir / "moon_phase.py").exists()
+
+
+def test_approve_unknown_review_404(client):
+    r = client.post("/api/skill/approve", json={"review_id": "does-not-exist"})
+    assert r.status_code == 404
+
+
+def test_blocked_approve_leaves_review_pending(client):
+    """A dangerous-code approve must be refused AND leave the review staged so it
+    can still be inspected/rejected (old behavior popped it on any failure)."""
+    dangerous = (
+        'SKILL_DESCRIPTION = "bad"\n'
+        'import os\n'
+        'def run(task, app="", ctx=""):\n'
+        '    os.system("rm -rf /")\n'
+        '    return "x"\n'
+    )
+    rid = _stage(client, filename="danger.py", code=dangerous)
+    r = client.post("/api/skill/approve", json={"review_id": rid})
+    assert r.status_code == 400
+    assert not (client._skills_dir / "danger.py").exists()
+    assert (client._reviews_dir / f"{rid}.json").exists(), "blocked review must stay staged"
+    assert client.get("/api/skill/reviews").json()["count"] == 1
+
+
+# ── reject ────────────────────────────────────────────────────────────────────
+
+
+def test_reject_discards_without_writing(client):
+    rid = _stage(client)
+    r = client.post(f"/api/skill/reject/{rid}")
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "rejected"
+    assert not (client._skills_dir / "moon_phase.py").exists(), "reject must not write a skill"
+    assert not (client._reviews_dir / f"{rid}.json").exists(), "review file must be gone"
+    assert client.get("/api/skill/reviews").json()["count"] == 0
+
+
+def test_reject_unknown_returns_404(client):
+    r = client.post("/api/skill/reject/nope-nope")
+    assert r.status_code == 404
+
+
+# ── traversal safety (unit) ───────────────────────────────────────────────────
+
+
+def test_review_id_is_traversal_safe():
+    assert skills_routes._safe_review_id("f47ac10b-58c") == "f47ac10b-58c"
+    assert skills_routes._safe_review_id("../../etc/passwd") is None
+    assert skills_routes._safe_review_id("a/b") is None
+    assert skills_routes._safe_review_id("") is None
+    assert skills_routes._review_path("../../etc/passwd") is None

--- a/tests/test_skill_routes.py
+++ b/tests/test_skill_routes.py
@@ -120,6 +120,10 @@ def test_skill_approve_writes_only_after_review(tmp_path, monkeypatch):
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
     monkeypatch.setattr(skills_routes, "_get_skills_dir", lambda: str(skills_dir))
+    # Isolate the staged-review store to a tmp dir so the review→approve round
+    # trip doesn't touch the real ~/.codec/skill_reviews/.
+    reviews_dir = tmp_path / "skill_reviews"
+    monkeypatch.setattr(skills_routes, "_reviews_dir", lambda: str(reviews_dir))
 
     client = _make_client()
     valid_skill = (


### PR DESCRIPTION
## What & why

Demo beat 21: `create_skill` tells the user *"Open Dashboard → Skills to review and approve it"* — but there was **no such UI**, and staged reviews lived only in an in-memory dict that was wiped on every `codec-dashboard` restart. This ships both halves so the working chat/voice `create_skill` path actually dead-ends into a real review surface.

## Backend (`routes/skills.py`)
- `POST /api/skill/review` now also persists to `~/.codec/skill_reviews/<id>.json` (atomic via `codec_jsonstore`) — survives restart. In-memory dict kept as a write-through cache for back-compat.
- `POST /api/skill/approve` reads **disk-first** (falls back to cache), keeps the `is_dangerous_skill_code` + pinned-builtin gates, and deletes the review file **only after** a successful write (a blocked approve stays re-approvable).
- **new** `GET /api/skill/reviews` → list staged reviews (`id, filename, code, staged_at`).
- **new** `POST /api/skill/reject/{id}` → discard without writing.
- `review_id` is filename-sanitized (path-traversal-safe) for the reject param.
- All POSTs ride the existing AuthMiddleware CSRF (the PWA fetch wrapper auto-injects `x-csrf-token`).

## UI (`codec_dashboard.html`)
- New **Skills** tab + panel: each staged skill shows name, staged time, and full code (monospace, scrollable) with **Approve** / **Reject**; toasts the result and refreshes the list.
- Pending-review **count badge** on the tab, polled on the existing 30s cadence.
- Line-SVG icons, **no emoji**.

## Tests
- New `tests/test_skill_reviews_persistence.py`: persistence, restart survival, list shape, approve-writes-and-deletes, blocked-approve-stays-staged, reject-discards, traversal safety.
- Existing skill-route tests kept green (87 passed locally; ruff clean).

## Verification
End-to-end in a browser against the **real** router: staged `moon_phase.py` → Approve wrote it to the skills dir, deleted the review, cleared the badge; staged a second review → Reject discarded it with nothing written. No console errors.

Note: the separate "create_skill over the external MCP connector 401s" bug is **not** in scope here — that's task_01fc823a. This PR is only the review/approve UI + persistence, which the working chat/voice path needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)