### PR TITLE
feat(connector): OAuth sign-in for auth connectors (Notion, GitHub, …) (beat 19)

### DIFF
--- a/codec_dashboard.html
+++ b/codec_dashboard.html
@@ -1084,13 +1084,17 @@ async function renderConnectors() {
         authNote = '<div class="mcp-auth"><svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>Needs ' + kind + '</div>';
       }
       var note = s.note ? '<div class="mcp-note">' + escHtml(s.note) + '</div>' : '';
+      // OAuth connectors get a "Sign in" button (only when enabled) that opens
+      // the browser authorize flow — toggling on alone doesn't authenticate.
+      var signinBtn = (s.enabled && s.needs_auth && s.auth === 'oauth') ?
+        '<button data-signin="' + escHtml(s.name) + '" style="margin-top:8px;padding:4px 12px;background:var(--accent,#f0641e);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600">Sign in</button>' : '';
       return '<div class="mcp-card">' +
         '<div class="mcp-card-main">' +
           '<div class="mcp-card-top"><span class="mcp-name">' + escHtml(s.name) + '</span>' +
           '<span class="mcp-badge">' + badge + '</span></div>' +
           note +
           '<div class="mcp-url">' + escHtml(s.url || '') + '</div>' +
-          authNote +
+          authNote + signinBtn +
         '</div>' +
         '<label class="mcp-switch" title="Enable / disable connector">' +
           '<input type="checkbox" ' + checked + ' data-mcp="' + escHtml(s.name) + '">' +
@@ -1102,6 +1106,9 @@ async function renderConnectors() {
     // break out of the attribute quoting.
     box.querySelectorAll('input[type="checkbox"][data-mcp]').forEach(function(cb) {
       cb.addEventListener('change', function() { toggleConnector(this.dataset.mcp, this); });
+    });
+    box.querySelectorAll('button[data-signin]').forEach(function(b) {
+      b.addEventListener('click', function() { mcpSignin(this.dataset.signin, this); });
     });
   } catch (e) {
     box.innerHTML = '<div class="mcp-empty">Could not load connectors: ' + escHtml(String(e)) + '</div>';
@@ -1128,6 +1135,26 @@ async function toggleConnector(name, el) {
     el.checked = !enabled; // revert on network error
   } finally {
     el.disabled = false;
+  }
+}
+
+// OAuth sign-in: opens the server's authorize page in the browser (fastmcp runs
+// the flow + caches the token). Can take a while — the user has to authorize.
+async function mcpSignin(name, btn) {
+  btn.disabled = true; var orig = btn.textContent; btn.textContent = 'Opening browser…';
+  try {
+    var csrf = (document.cookie.match(/codec_csrf=([^;]+)/) || [])[1] || '';
+    var r = await fetch('/api/mcp/servers/' + encodeURIComponent(name) + '/signin', {
+      method: 'POST', headers: {'Content-Type': 'application/json', 'x-csrf-token': csrf}
+    });
+    var d = await r.json().catch(function() { return {}; });
+    var okay = r.ok && d.ok !== false;
+    showToast(d.message || (okay ? 'Signed in.' : 'Sign-in failed.'), !okay);
+    if (okay) renderConnectors();
+  } catch (e) {
+    showToast('Sign-in failed: ' + e, true);
+  } finally {
+    btn.disabled = false; btn.textContent = orig;
   }
 }
 

--- a/routes/mcp.py
+++ b/routes/mcp.py
@@ -134,3 +134,28 @@ async def mcp_toggle(name: str, request: Request):
         pass
 
     return {"ok": True, "name": target, "enabled": enabled}
+
+
+@router.post("/api/mcp/servers/{name}/signin")
+async def mcp_signin(name: str):
+    """Trigger the OAuth sign-in for one connector. fastmcp opens the user's
+    browser to the server's authorize page, runs a localhost callback, and caches
+    the token — so this can block for a while (the user has to authorize). Loads
+    skills/mcp_connect.py by path (skills/ isn't an importable package)."""
+    import asyncio
+
+    def _do():
+        import importlib.util
+        from codec_config import SKILLS_DIR
+        path = os.path.join(SKILLS_DIR, "mcp_connect.py")
+        spec = importlib.util.spec_from_file_location("mcp_connect_signin", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.signin_server(name)
+
+    try:
+        msg = await asyncio.to_thread(_do)
+        ok = not msg.lower().startswith(("no mcp server", "signed in to  "))
+        return {"ok": ok, "message": msg}
+    except Exception as e:
+        return {"ok": False, "message": f"Sign-in failed: {e}"}

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -52,7 +52,7 @@
     "health_check.py": "01ac95da13770e2419460b4aaf1bd79c6628b6bc5413a5608153b81feee81568",
     "imessage_send.py": "862f7031a525faed4cec7cb703ef32f5d8bdc1045326f880d50455baf4cfcf86",
     "json_formatter.py": "42a770a1455a574d33e2f96f34c63ae7a83845f70789862e5e5198d0b429fde2",
-    "mcp_connect.py": "673c2b19b8c5de631b2d1f29637af4cb00824896e1f05e8a370150d9993806d8",
+    "mcp_connect.py": "5ec24a905eb125fd0db3a1a69b29b1a87413a9ebcbf06e590e989cba1d912d4a",
     "memory_entities.py": "252ad5861d614b916504b8af6300c4a8c62622c9f6c15238b11d6c6a052bada7",
     "memory_history.py": "a2762c03c325517d10907f8aa9511103a5716a29f9e956d48473b817105fb65c",
     "memory_save.py": "3d801338bfd0818aaf1e65e692e404af0a0fba6886d26150f0fb66e4b4fde424",

--- a/skills/mcp_connect.py
+++ b/skills/mcp_connect.py
@@ -115,6 +115,20 @@ def _client_for(server: dict):
         url = server.get("url")
         if not url:
             raise ValueError(f"server '{server.get('name')}' has no url")
+        # OAuth servers (Notion, GitHub, Linear, Atlassian, …): use fastmcp's
+        # built-in OAuth — it discovers the auth server from the MCP endpoint,
+        # opens the browser for the user to authorize, runs a localhost callback,
+        # and caches the token so later connects are silent. Without this, hitting
+        # https://mcp.notion.com/mcp just returns {"error":"invalid_token"}.
+        if server.get("auth") == "oauth":
+            try:
+                from fastmcp.client.auth import OAuth
+                return Client(url, auth=OAuth(mcp_url=url))
+            except Exception as e:  # OAuth unavailable → fall through to plain
+                import logging
+                logging.getLogger("codec").warning(
+                    "mcp_connect: OAuth unavailable for '%s' (%s) — trying plain",
+                    server.get("name"), e)
         # fastmcp infers HTTP vs SSE from the URL; headers carry API-key auth.
         try:
             return Client(url, headers=headers)
@@ -151,6 +165,30 @@ async def _alist_tools(server: dict) -> list:
 async def _acall_tool(server: dict, tool: str, args: dict):
     async with _client_for(server) as client:
         return await client.call_tool(tool, args or {})
+
+
+def signin_server(name: str) -> str:
+    """Trigger the OAuth sign-in for one server: open a client (fastmcp runs the
+    OAuth browser flow + localhost callback + token cache) and list its tools.
+    Uses a longer timeout than the normal 60s so the user has time to authorize
+    in the browser. Public — called by the Connector tab's "Sign in" button."""
+    target = str(name or "").strip().lower()
+    server = next((s for s in _servers()
+                   if str(s.get("name", "")).strip().lower() == target), None)
+    if not server:
+        return f"No MCP server named '{name}'."
+
+    def _target():
+        import asyncio
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(_alist_tools(server))
+        finally:
+            loop.close()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        tools = ex.submit(_target).result(timeout=180)
+    return f"Signed in to {name} — {len(tools)} tool(s) available. Drive it by voice/chat: \"list tools on {name}\"."
 
 
 def _fmt_tools(tools) -> str:


### PR DESCRIPTION
## What (Mickael's ask)
Toggling Notion on gave `{"error":"invalid_token"}` — enabling a connector didn't log you in. His ask: *"the URL should automatically open to authorize and put your credentials as soon as a connector is activated."*

## Fix
- **`skills/mcp_connect.py` `_client_for`:** for `auth: "oauth"` servers, use fastmcp's built-in `OAuth(mcp_url=url)` — it discovers the auth server from the MCP endpoint, **opens the browser to authorize**, runs a localhost callback, and uses the token. `signin_server(name)` runs it with a 180s timeout (the user has to authorize).
- **`routes/mcp.py`:** `POST /api/mcp/servers/{name}/signin`.
- **`codec_dashboard.html`:** enabled OAuth connectors show a **Sign in** button → opens the browser flow → re-renders on success. No emoji.

## Verified
`_client_for(notion)` builds an OAuth-wired client (fastmcp engages its OAuth, per the token-storage warning). Manifest regenerated (88). `pytest -k mcp` → **42 passed**. ruff clean. The actual browser authorize is the user's step (can't be headless-verified).

## ⚠️ Known limitation (follow-up)
fastmcp defaults to **in-memory** token storage → a `codec-dashboard` restart requires re-auth. Persistent storage (an encrypted AsyncKeyValue backend, e.g. Keychain-backed) is the next step for durable sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)