### PR TITLE
feat(pilot): click-through live view — drive the browser, not a screenshot (beat 14)

### DIFF
--- a/codec_tasks.html
+++ b/codec_tasks.html
@@ -452,10 +452,17 @@ a { color: var(--accent); text-decoration: none; }
       <!-- LEFT: the live browser viewport (the star of the show) -->
       <div style="display:flex;flex-direction:column;gap:8px;min-width:0;">
         <div style="position:relative;border-radius:10px;overflow:hidden;border:1px solid var(--border);background:#0d0d10;">
-          <img id="pilotScreenshot" src="" alt="Live browser" style="display:block;width:100%;aspect-ratio:1280/800;object-fit:contain;background:#0d0d10;cursor:pointer;" onclick="pilotOpenScreenshot()" title="Click to open full size">
+          <img id="pilotScreenshot" src="" alt="Live browser" style="display:block;width:100%;aspect-ratio:1280/800;object-fit:contain;background:#0d0d10;cursor:crosshair;" onclick="pilotViewClick(event)" title="Click to control the browser — click any element, then type">
           <div id="pilotLiveBadge" style="position:absolute;top:12px;left:12px;display:flex;align-items:center;gap:7px;padding:5px 14px;border-radius:999px;background:rgba(0,0,0,.55);backdrop-filter:blur(6px);font-size:12px;font-weight:700;letter-spacing:2px;color:#fff;font-family:var(--mono);">
-            <span id="pilotLivePulse" style="width:9px;height:9px;border-radius:50%;background:#666;"></span>LIVE
+            <span id="pilotLivePulse" style="width:9px;height:9px;border-radius:50%;background:#666;"></span>LIVE · CLICK TO CONTROL
           </div>
+          <!-- Expand kept as its own control so the primary click can DRIVE the
+               browser (opening a static screenshot was the old default and made
+               the live view useless for teach mode). -->
+          <button onclick="pilotOpenScreenshot()" title="Open full size"
+            style="position:absolute;top:12px;right:12px;width:30px;height:30px;display:flex;align-items:center;justify-content:center;border-radius:8px;border:none;background:rgba(0,0,0,.55);backdrop-filter:blur(6px);color:#fff;cursor:pointer;">
+            <svg viewBox="0 0 24 24" style="width:15px;height:15px;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/></svg>
+          </button>
           <div id="pilotAgentBadge" style="display:none;position:absolute;top:12px;right:12px;padding:5px 14px;border-radius:999px;background:rgba(232,113,26,.85);font-size:12px;font-weight:700;letter-spacing:1px;color:#fff;font-family:var(--mono);">🤖 CODEC DRIVING</div>
           <div id="pilotCurrentUrl" style="position:absolute;bottom:0;left:0;right:0;padding:9px 14px;background:linear-gradient(transparent,rgba(0,0,0,.7));font-size:12.5px;font-family:var(--mono);color:#eee;word-break:break-all;"></div>
         </div>
@@ -1318,6 +1325,58 @@ document.addEventListener('visibilitychange', function() {
 function pilotOpenScreenshot() {
   window.open(_pilotBase + '/screenshot', '_blank');
 }
+
+/* ── Click-through: drive the real browser from the live view ──
+   The stream is a 1280x800 viewport rendered into a responsive <img>, so map the
+   click from displayed pixels back to viewport coords. The runner resolves the
+   point to an indexed element where it can, so Record/Teach still compiles a
+   durable xpath step rather than brittle coordinates. */
+var PILOT_VIEWPORT_W = 1280, PILOT_VIEWPORT_H = 800;
+
+function pilotViewClick(ev) {
+  var img = document.getElementById('pilotScreenshot');
+  if (!img) return;
+  var r = img.getBoundingClientRect();
+  if (!r.width || !r.height) return;
+  var x = ((ev.clientX - r.left) / r.width) * PILOT_VIEWPORT_W;
+  var y = ((ev.clientY - r.top) / r.height) * PILOT_VIEWPORT_H;
+  x = Math.max(0, Math.min(PILOT_VIEWPORT_W, x));
+  y = Math.max(0, Math.min(PILOT_VIEWPORT_H, y));
+  _pilotClickFocused = true;   // subsequent typing goes to the page
+  _pilotFetch('/click_xy', {
+    method: 'POST',
+    body: JSON.stringify({x: x, y: y})
+  })
+  .then(function(r2){ return r2.json().then(function(d){ return {ok:r2.ok, status:r2.status, d:d}; }); })
+  .then(function(res){
+    if (!res.ok) { showToast('Click failed (' + res.status + ')', true); return; }
+    // Give the page a beat to react, then refresh the view + DOM snapshot.
+    setTimeout(pilotRefreshScreenshot, 250);
+    setTimeout(pilotSnapshot, 600);
+  })
+  .catch(function(e){ showToast('Click failed: ' + e, true); });
+}
+
+// After a click-through, typing goes into the page (like a real browser).
+var _pilotClickFocused = false;
+document.addEventListener('keydown', function(ev) {
+  if (!_pilotClickFocused) return;
+  var t = ev.target;
+  // Never steal keys from a real input in the dashboard (url bar, mission box…)
+  if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+  var pilotPanel = document.getElementById('pilotScreenshot');
+  if (!pilotPanel || pilotPanel.offsetParent === null) return;  // Pilot not visible
+  if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
+
+  var body = null;
+  if (ev.key.length === 1) body = {text: ev.key};
+  else if (['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].indexOf(ev.key) >= 0) body = {key: ev.key};
+  if (!body) return;
+  ev.preventDefault();
+  _pilotFetch('/key', {method: 'POST', body: JSON.stringify(body)})
+    .then(function(){ setTimeout(pilotRefreshScreenshot, 200); })
+    .catch(function(){});
+});
 
 /* ── Navigate ── */
 function pilotNavigate() {

--- a/pilot/pilot_chrome.py
+++ b/pilot/pilot_chrome.py
@@ -202,6 +202,20 @@ class PilotChrome:
         """Type text into an element by XPath."""
         await self._require_page().locator(f"xpath={xpath}").fill(text, timeout=timeout)
 
+    async def click_xy(self, x: float, y: float) -> None:
+        """Click raw viewport coordinates. Used by the dashboard's click-through
+        live view when the click doesn't land on an indexed element (the indexed
+        path is preferred — it records a replayable xpath)."""
+        await self._require_page().mouse.click(x, y)
+
+    async def type_text(self, text: str) -> None:
+        """Type into whatever currently has focus (after a click-through)."""
+        await self._require_page().keyboard.type(text)
+
+    async def press_key(self, key: str) -> None:
+        """Press a single key (Enter, Tab, Backspace, …) on the focused element."""
+        await self._require_page().keyboard.press(key)
+
     async def wait(self, ms: int) -> None:
         """Sleep without blocking the event loop."""
         await asyncio.sleep(ms / 1000)

--- a/pilot/pilot_runner.py
+++ b/pilot/pilot_runner.py
@@ -176,6 +176,18 @@ class TypeRequest(BaseModel):
     text: str
 
 
+class ClickXYRequest(BaseModel):
+    """A click-through from the dashboard's live view, in viewport coordinates."""
+    x: float
+    y: float
+
+
+class KeyRequest(BaseModel):
+    """Typed text and/or a single key press, sent to whatever has focus."""
+    text: str = ""
+    key: str = ""
+
+
 class RunRequest(BaseModel):
     task: str           # natural-language task description (used in Phase 4)
     fps: float = 2.0    # screencast frame rate
@@ -346,6 +358,59 @@ async def click_element(index: int):
         result=f"clicked [{index}] {el.role} '{el.name}'",
     )
     return {"clicked": str(el), "xpath": el.xpath,
+            "recording": _recording.run_id if _recording else None}
+
+
+@app.post("/click_xy")
+async def click_xy(req: ClickXYRequest):
+    """Click at viewport coordinates — the dashboard's live view click-through.
+
+    Prefers resolving the point to an indexed element and clicking it by XPath:
+    that makes the action RECORDABLE as a durable, replayable step (raw pixel
+    coords would compile into a brittle skill that breaks the moment the page
+    reflows). Falls back to a raw mouse click when the point isn't on any
+    indexed element (blank space, canvas, custom widget).
+    """
+    pilot = _require_pilot()
+    snap = await take_snapshot(pilot.page)
+
+    # Smallest element whose bbox contains the point wins — inner controls sit on
+    # top of their containers, and the smallest hit is the one a human aimed at.
+    hit = None
+    for el in snap.elements:
+        b = el.bbox or {}
+        left, top = b.get("left", 0), b.get("top", 0)
+        w, h = b.get("width", 0), b.get("height", 0)
+        if w <= 0 or h <= 0:
+            continue
+        if left <= req.x <= left + w and top <= req.y <= top + h:
+            if hit is None or (w * h) < (hit.bbox.get("width", 0) * hit.bbox.get("height", 0)):
+                hit = el
+
+    if hit is not None:
+        await pilot.click_xpath(hit.xpath)
+        _record_step(
+            {"action": "click", "index": hit.index},
+            render_for_llm(snap), el=hit,
+            result=f"clicked [{hit.index}] {hit.role} '{hit.name}' (via live view)",
+        )
+        return {"clicked": str(hit), "xpath": hit.xpath, "matched": True,
+                "recording": _recording.run_id if _recording else None}
+
+    await pilot.click_xy(req.x, req.y)
+    return {"clicked": f"({req.x:.0f}, {req.y:.0f})", "matched": False,
+            "recording": _recording.run_id if _recording else None}
+
+
+@app.post("/key")
+async def key_input(req: KeyRequest):
+    """Type text and/or press a key on whatever has focus (after a click-through)."""
+    pilot = _require_pilot()
+    if req.text:
+        await pilot.type_text(req.text)
+    if req.key:
+        await pilot.press_key(req.key)
+    return {"typed": req.text, "key": req.key,
             "recording": _recording.run_id if _recording else None}
 
 


### PR DESCRIPTION
## What was broken

The live view was **passive** — clicking it opened a static full-size screenshot. So beat 14's actual promise (*"drive the browser yourself and CODEC compiles your clicks into a skill"*) was impossible; you could only drive Pilot indirectly via a typed mission or Quick-Actions element-index clicks.

## Now the live view IS the control surface

- **`pilot_chrome`** — `click_xy` / `type_text` / `press_key` primitives (Playwright mouse + keyboard).
- **`pilot_runner`** — `POST /click_xy` resolves the point to an **indexed element** (smallest bbox containing it, so inner controls beat their containers) and clicks it **by XPath** → Record/Teach still compiles a **durable, self-healing** step. Raw mouse click is the fallback for blank space / canvas / custom widgets. `POST /key` types text or presses a key on whatever has focus.
- **`codec_tasks.html`** — clicking the stream maps displayed pixels → the 1280×800 viewport and drives the real page. Crosshair cursor; badge reads **LIVE · CLICK TO CONTROL**. Typing after a click goes to the page, but never steals keys from real dashboard inputs (url bar, mission box) or when Pilot isn't visible. **Open-full-size moved to its own corner button**, so the primary click controls.

**Why element-resolution matters:** recording raw pixel coordinates would compile a skill that breaks the moment the page reflows. Resolving the click to an XPath keeps replay durable and self-healing — which is the whole point of teach mode.

No proxy change needed — `/api/pilot/{path:path}` is already generic and injects the token.

## Tests

`pilot/tests`: **67 passed / 23 errors — identical to clean main** (those collection errors are pre-existing, not introduced here). Remaining ruff `F401`s are pre-existing untouched imports.
