### PR TITLE
feat(chat): let "feed these prompts into X" reach prompt_feeder

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -437,6 +437,12 @@ CHAT_SKILL_ALLOWLIST = {
     # Daybreak — morning kickoff (read-only aggregation) + working-thread
     # capture (facts-table writes only). docs/DAYBREAK-DESIGN.md.
     "daily_kickoff", "thread_note",
+    # Prompt feeder — "feed these prompts into Google Flow: 1… 2… 3…". Drives
+    # the Pilot browser only (typing into a page the user is watching live); it
+    # touches no filesystem and runs no code. Without this the phrase falls
+    # through to the LLM, which answers the prompts ITSELF instead of feeding
+    # them to the tool the user actually asked for.
+    "prompt_feeder",
 }
 
 


### PR DESCRIPTION
One-line allowlist entry so the chat surface can fire `prompt_feeder`.

Without it the phrase falls through to the LLM, which **answers the prompts itself** instead of feeding them to the tool the user asked for — exactly the failure mode `observer_recall` had in #250/#256.

Safe to auto-fire: `prompt_feeder` only drives the Pilot browser (typing into a page the user is watching live). No filesystem, no code execution — unlike `python_exec`/`skill_forge`, which are deliberately excluded.

39 allowlist/chat-skill tests pass.
