### PR TITLE
docs(demo): beat 13 gets a real Pilot chore; beat 18 GitHub can't OAuth

### DIFF
--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -36,7 +36,7 @@
 | 10 | **Project mode** | Project: "Research Notion, Figma and Linear; draft a personalized Head-of-Growth outreach email to each; save as Gmail drafts." Approve the plan once. | Approve once → runs autonomously → 3 Gmail drafts appear | ✅ |
 | 11 | Chat auto-escalation | Chat: "plan and build me a 5-page competitor report with charts." | CODEC offers "Start as Project?" + asks the clarifying questions | ✅ |
 | 12 | **Vibe** live coding | Vibe: "Build me a snake game." | Code writes itself live in Monaco; preview plays | ✅ |
-| 13 | **Pilot** — teach by doing + self-healing replay | Pilot tab → **click directly on the live view** to drive the browser → Record → replay | You click what you see; CODEC compiles those clicks into a reusable skill and replays it, self-healing if the page changed | ✅ click-through live (verified: a click at (297,207) resolved to the link and navigated example.com → iana.org) |
+| 13 | **Pilot** — teach by doing + self-healing replay | Pilot tab → **click directly on the live view** to drive the browser. Then hand it a real chore: *"feed these prompts into Google Flow: 1. a drone shot over Marbella at golden hour 2. the same shot at night 3. a close up of the marina"* | You click what you see; CODEC compiles those clicks into a reusable skill. Then it types each prompt in for you, one at a time, waiting for each result — you watch it happen | ✅ click-through verified (a click at (297,207) navigated example.com → iana.org) · ✅ prompt-feeder verified live on Gemini (3 sent, 3 answered) |
 
 ## Act 4 — The nerve center & oversight
 
@@ -51,7 +51,7 @@
 | # | Feature | TRY (live) | EXPECT | Status |
 |---|---|---|---|---|
 | 17 | **CODEC as MCP server** (Claude drives your Mac) | Claude Desktop (CODEC connector on): "Research the 3 best noise-cancelling headphones, then use CODEC to save the summary to my Desktop, add a calendar reminder, and dim my office lights." | Claude thinks; CODEC acts locally: file saved, reminder set, lights dim | ✅ confirmed working (connector set to **Always Allow**) |
-| 18 | **Connector tab** (CODEC drives other MCP servers) | Connector tab → toggle Notion on → **Sign in** → say "list tools on notion" | Card flips to **● Connected** with a **Disconnect** option; CODEC lists Notion's tools | ✅ full state machine + Keychain-persistent tokens. **Sign in once more** — the old token was in-memory and is gone; this one survives restarts |
+| 18 | **Connector tab** (CODEC drives other MCP servers) | Connector tab → toggle Notion on → **Sign in** → say "list tools on notion" | Card flips to **● Signed in** with a **Sign out** option; CODEC lists Notion's tools | ✅ state machine + Keychain-persistent tokens. **Sign in to Notion once before filming.** Toggle **GitHub OFF** — its MCP server publishes no OAuth metadata, so sign-in is impossible without a personal access token |
 | 19 | Observer recall | "Hey CODEC, what was I doing 20 minutes ago?" | "Over the last 9 minutes, you were in Claude the whole time. You touched 4 files: …" — conversational, and honest if you ask outside its ~10-min window | ✅ |
 
 ## Act 6 — Self-improvement, voice duplex, finale
@@ -83,7 +83,7 @@
 - **Live webcam vision** (ex-beat 8) — removed 2026-07-16. The capture was soft (the Anker C200's lens, not code) and it landed as a gadget rather than a capability. Nothing else depends on it.
 
 ## Decide before filming
-- **Beat 18** — sign in to Notion once in the Connector tab (it persists now).
+- **Beat 18** — sign in to Notion once in the Connector tab (it persists now). Toggle **GitHub off** — it can't OAuth (needs a PAT).
 - **Beat 21 (Compare)** — does the demo machine show 3+ models side by side? If not, cut it.
 - **Beat 22** — re-confirm voice interrupt.
 
@@ -96,6 +96,7 @@
 - Notion signed in (Connector tab, beat 18); Philips Hue reachable; Spotify authorized (finale)
 - Vision Mouse tested 10× on the Cloudflare DNS button
 - Observer running with a populated buffer
+- **Pilot browser signed in to Google** (Pilot tab → open Flow/Gemini → sign in once) — otherwise Flow/Gemini refuse to generate for beat 13
 - Cortex map open on a 2nd screen (persistent visual anchor)
 - Fresh Deep-Research + Project chat windows open
 


### PR DESCRIPTION
Beat 13 now demos an actual job rather than a click — hand Pilot a shot list and it feeds each prompt into Google Flow one at a time while you watch. Verified live on Gemini (3 sent, 3 answered).

Beat 18: toggle **GitHub off** before filming — its MCP server publishes no OAuth metadata, so sign-in is impossible without a PAT. Leaving it on gives the audience a button that can only fail.

Pre-record adds: sign the Pilot browser in to Google, or Flow/Gemini refuse to generate.

Docs-only. Beats verified 1→24, no gaps.