### PR TITLE
fix(compare): graceful message when only the local model is available

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -26,7 +26,7 @@
     "chrome_tabs.py": "bf971798a8455215655d37edb6bb326d908f4d33c0e3b232eb37d267fec68d7a",
     "clipboard.py": "f5ef9cc501fe38a3de95bf0b49896b928250c0e272060173668f6b195728d131",
     "clipboard_url_fetch.py": "c2733a92d6e99a0346b91c67bb70698e491be9570305377a82096a0ceb153488",
-    "compare.py": "859765d27fb631b06b15df7bdf50473e0ee544a68d0c0376b7c7d89c5a6ae23e",
+    "compare.py": "7f1599bf7817e636e0a42726ef36df4f7069aa76e7af5be56dc8e6d10d558ff0",
     "cookbook_download.py": "8fd9c8a5b82f8e910cc0721904b908f2d201908ff0ac6373994be922598c382c",
     "cookbook_list.py": "23c19b92742bfd88a801e74bd79e8bbd70f88d49ac1951f1c30e4857cc693a79",
     "cookbook_recommend.py": "66b09eac0510ca9ca1e19f5619ab10a167bda6e34d17be13bda77ba7ffe0b5e3",

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -26,7 +26,7 @@
     "chrome_tabs.py": "bf971798a8455215655d37edb6bb326d908f4d33c0e3b232eb37d267fec68d7a",
     "clipboard.py": "f5ef9cc501fe38a3de95bf0b49896b928250c0e272060173668f6b195728d131",
     "clipboard_url_fetch.py": "c2733a92d6e99a0346b91c67bb70698e491be9570305377a82096a0ceb153488",
-    "compare.py": "f0ff94cfcdc3dd5a4f0dd88d641e042303982888a9838fb4b1781067a9c46839",
+    "compare.py": "859765d27fb631b06b15df7bdf50473e0ee544a68d0c0376b7c7d89c5a6ae23e",
     "cookbook_download.py": "8fd9c8a5b82f8e910cc0721904b908f2d201908ff0ac6373994be922598c382c",
     "cookbook_list.py": "23c19b92742bfd88a801e74bd79e8bbd70f88d49ac1951f1c30e4857cc693a79",
     "cookbook_recommend.py": "66b09eac0510ca9ca1e19f5619ab10a167bda6e34d17be13bda77ba7ffe0b5e3",

--- a/skills/compare.py
+++ b/skills/compare.py
@@ -48,6 +48,21 @@ def run(task, app="", ctx=""):
     if not results:
         return f"No model endpoints available to compare ({res.get('note', 'none configured')})."
 
+    # Graceful degrade: with no cloud license only the local tier answers, and
+    # "Compared 1 model" reads like the feature is broken. Say what's actually
+    # happening — there's nothing to compare against yet — and how to unlock it.
+    # Never in blind mode: blind deliberately hides identities, and a
+    # "you need a license" line would defeat the point.
+    if not blind and len(results) == 1 and results[0].get("tier") == "local":
+        r = results[0]
+        body = r.get("response", "") if r.get("ok") else f"✗ {r.get('error', 'failed')}"
+        return (
+            "Only the local model is available on this machine, so there's "
+            "nothing to compare it against yet. Connect an AVA license and the "
+            "same prompt lines up side by side against Claude, GPT and Gemini.\n\n"
+            f"### local  ({r.get('elapsed_ms')}ms)\n{body}"
+        )
+
     head = (f"Compared {len(results)} model{'s' if len(results) != 1 else ''}"
             + (" — blind" if blind else "") + f" on: {res['prompt']}")
     lines = [head]

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -155,11 +155,17 @@ class TestSkill:
         assert reg.get_mcp_expose("compare") is True
 
     def test_parses_prompt_and_formats_labeled(self, monkeypatch):
+        # Two tiers so this exercises the LABELED multi-model format (its point).
+        # A single local result now takes the graceful-degrade path — covered by
+        # test_single_local_degrades_gracefully below.
         import skills.compare as sc
         monkeypatch.setattr(sc, "compare", lambda prompt, blind=False: {
             "prompt": prompt, "blind": blind,
-            "results": [{"label": "local", "display": "local", "tier": "local",
-                         "ok": True, "response": "42", "elapsed_ms": 10}]})
+            "results": [
+                {"label": "local", "display": "local", "tier": "local",
+                 "ok": True, "response": "42", "elapsed_ms": 10},
+                {"label": "cloud-pro", "display": "cloud-pro", "tier": "cloud",
+                 "ok": True, "response": "forty-two", "elapsed_ms": 20}]})
         out = sc.run("compare models: meaning of life")
         assert "meaning of life" in out and "local" in out and "42" in out
 
@@ -185,3 +191,45 @@ class TestSkill:
                          "ok": False, "error": "license expired", "elapsed_ms": 3}]})
         out = sc.run("compare models hello")
         assert "✗" in out and "license expired" in out
+
+    def test_single_local_degrades_gracefully(self, monkeypatch):
+        """No license → only local answers. Must explain, not say 'Compared 1
+        model' (which reads like the feature is broken)."""
+        import skills.compare as sc
+        monkeypatch.setattr(sc, "compare", lambda prompt, blind=False: {
+            "prompt": prompt, "blind": False,
+            "results": [{"label": "local", "display": "local", "tier": "local",
+                         "ok": True, "response": "Blue", "elapsed_ms": 42}]})
+        out = sc.run("compare models name a color")
+        assert "Compared 1 model" not in out
+        assert "Only the local model" in out
+        assert "AVA license" in out
+        assert "Blue" in out               # the answer is still shown
+
+    def test_two_models_still_uses_normal_header(self, monkeypatch):
+        """The multi-model path is untouched: the degrade branch is single-local
+        ONLY."""
+        import skills.compare as sc
+        monkeypatch.setattr(sc, "compare", lambda prompt, blind=False: {
+            "prompt": prompt, "blind": False,
+            "results": [
+                {"label": "local", "display": "local", "tier": "local",
+                 "ok": True, "response": "A", "elapsed_ms": 5},
+                {"label": "cloud-pro", "display": "cloud-pro", "tier": "cloud",
+                 "ok": True, "response": "B", "elapsed_ms": 9}]})
+        out = sc.run("compare models hi")
+        assert "Compared 2 models" in out
+        assert "Only the local model" not in out
+
+    def test_single_cloud_is_not_degraded(self, monkeypatch):
+        """A single NON-local result (e.g. cookbook-only) is a real comparison
+        surface, not the no-license state — keep the normal header."""
+        import skills.compare as sc
+        monkeypatch.setattr(sc, "compare", lambda prompt, blind=False: {
+            "prompt": prompt, "blind": False,
+            "results": [{"label": "cookbook-1", "display": "cookbook-1",
+                         "tier": "cookbook", "ok": True, "response": "X",
+                         "elapsed_ms": 7}]})
+        out = sc.run("compare models hi")
+        assert "Only the local model" not in out
+        assert "Compared 1 model" in out


### PR DESCRIPTION
Beat 21 tested on the dev Mac produced **"Compared 1 model"** with a bare local answer — it reads like the feature broke, when really the cloud tiers are just license-gated (`ava.is_ready()` is False here, no `compare.cloud_tiers` configured).

Now the single-local case says what's actually happening and how to unlock the rest, and still shows the answer:

> Only the local model is available on this machine, so there's nothing to compare it against yet. Connect an AVA license and the same prompt lines up side by side against Claude, GPT and Gemini.
>
> ### local  (630ms)
> Blue

**Guarded on `not blind`** — blind mode deliberately hides identities, so a "you need a license" line would defeat it; blind keeps its original path. The multi-model path is untouched (degrade is single-local-only).

Tests (22 pass): single-local degrades · two models → normal header · single **non-local** (cookbook-only) is a real comparison surface, not degraded · blind single-local keeps blind formatting. The existing labeled-format test now uses two tiers so it still exercises the multi-model path it's named for. Manifest regenerated.

Doesn't force the beat-21 keep/cut decision — it just means that even if kept on an unlicensed machine, it degrades honestly instead of looking broken.
