### PR TITLE
fix(create_skill): stop inventing API endpoints — prefer local computation

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -33,7 +33,7 @@
     "cookbook_scan.py": "9bc1fe32073267c45c20d6dca67e293ed07f5c04dfff0109b480f778ffeaa3bb",
     "cookbook_serve.py": "8a08bb5deecd988431da421b1b4825cd411c7e9c7658bc547aa16ce74c0e1ddd",
     "cookbook_stop.py": "8b51e04ef08e08899df24d032af7a609bef7bf02ad72be5badf95eb0a2b1ce64",
-    "create_skill.py": "c94f75d0fb1e5a2db9aab9cfb93d7f9f387b751c7557238e0b9dcc45abe26ee7",
+    "create_skill.py": "865cee32d124f57cbbfef34ad6d568415d88a83fa2f706319f920d84a019b9ad",
     "daily_kickoff.py": "c649a0597265f284a876512c5689c2b210eb894ffddbd8da6b95f5e36a8cedab",
     "delegate.py": "7c595d5605cd9913a8afa331ae0013861d6996f378f8a59aca0249f1b2f3a474",
     "email_triage.py": "d7b9032b81179f58c5aff660c34f9b8edf212a8ce7651d307306e4757a8daaf2",

--- a/skills/create_skill.py
+++ b/skills/create_skill.py
@@ -109,10 +109,21 @@ RULES:
 - ONLY output the Python code, nothing else
 - No markdown, no backticks, no explanation
 - The run() function must return a string
-- Use requests for HTTP calls (NOT subprocess, os.system, eval, or exec)
 - Keep it simple and functional
 - SKILL_NAME must be lowercase with underscores only
 - Do NOT use subprocess, os.system, eval, exec, or __import__
+
+NETWORK — this is the most important rule:
+- PREFER computing the answer locally with the Python standard library
+  (math, datetime, statistics, json, re, ...). Most things people ask for —
+  dates, moon phases, conversions, formatting, sums, timers — are pure
+  computation and need no network at all.
+- NEVER invent an API URL. Do not guess a hostname or an endpoint path. If you
+  are not CERTAIN a public endpoint exists at exactly that URL, do not call it.
+  A skill that calls a made-up endpoint fails every single time it runs, and
+  looks like the skill is broken.
+- Only use `requests` when the data genuinely cannot be computed locally (live
+  weather, prices, news) AND you are certain of the real endpoint.
 
 The skill should: {description}"""
 


### PR DESCRIPTION
Asked for a moon-phase skill, the generator wrote a call to **`https://api.moon.ph/v1/moon` — an endpoint that does not exist** (verified unreachable). The skill was staged, approved, and fails on *every* run with `Error fetching moon phase data`.

The old prompt pushed it that way — *"Use requests for HTTP calls"* — with nothing warning against guessing a URL.

This matters well beyond one skill: **"CODEC writes its own skills" is a headline feature**, and a skill that calls a hallucinated endpoint is broken 100% of the time while looking completely plausible in review. Nothing in the pipeline catches it, because the code is syntactically fine and passes the safety gate.

## New rules

- **Prefer the stdlib** — most asks (dates, conversions, moon phases, formatting, sums) are pure computation and need no network
- **Never invent an API URL** — don't guess a hostname or path
- `requests` only for data that genuinely can't be computed locally *and* whose endpoint is certain

## Verified by regenerating the same request

Before → `requests.get("https://api.moon.ph/v1/moon")` → always errors.

After → computes Julian Day + synodic month with `datetime` + `math`, **zero network**:

```
The current moon phase is First Quarter with approximately 43% illumination.
```

Cross-checked against an independent calculation: moon age 6.8 days of the 29.53-day cycle = First Quarter ✓

Manifest regenerated.
