### PR TITLE
fix(chat): a long paste must not auto-fire a skill (chat hung with no reply)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -385,6 +385,12 @@ def _enrich_messages(messages: list, config: dict, force_search: bool = False) -
 
 
 
+# Longest message that may auto-fire a skill. Above this it's a paste (a doc, a
+# spec, an article) and belongs to the LLM, not the dispatcher. Generous: the
+# longest real command in the demo — a prompt_feeder list with 3 prompts — is
+# ~150 chars.
+MAX_SKILL_HIJACK_CHARS = 2000
+
 CHAT_SKILL_ALLOWLIST = {
     # Core utilities
     "calculator", "weather", "web_search", "bitcoin_price",
@@ -503,6 +509,15 @@ def _try_skill(user_text: str):
     LLM answered from memory (and fabricated)."""
     try:
         from codec_dispatch import check_skill, run_skill
+        # A long paste is a document, not a command. Pasting a spec, an article,
+        # or a set of instructions would otherwise hijack the turn: a 6.3k-char
+        # paste of standing rules mentioning "write ... to <path>" matched
+        # file_ops, which is destructive, so the consent gate called ask_user and
+        # BLOCKED the request thread for its full 600s timeout. The user saw the
+        # chat simply never answer, and nothing was ever saved.
+        # Real skill commands are short imperatives, well under this cap.
+        if len(user_text) > MAX_SKILL_HIJACK_CHARS:
+            return None, None
         skill = check_skill(user_text)
         matched = bool(skill and skill.get("name") in CHAT_SKILL_ALLOWLIST)
         if not matched and _is_conversational(user_text):

--- a/tests/test_chat_hijack_length.py
+++ b/tests/test_chat_hijack_length.py
@@ -1,0 +1,79 @@
+"""Long pastes must not auto-fire a skill.
+
+Reproduces the 2026-07-21 "CODEC just stopped replying" incident.
+
+A 6,305-char paste of standing rules — prose, containing the phrase "write it
+with CODEC file_write to <path>" — matched the `file_ops` trigger. file_ops is
+allowlisted for chat, so the match bypassed the conversational filter; file_ops
+is destructive, so the consent gate called codec_ask_user.ask(), which BLOCKS
+the request thread until answered. Nobody answered a panel they never saw, so
+the HTTP request hung until the 600s timeout. The user saw the chat simply never
+respond, and nothing was saved.
+
+Evidence at the time: pending_questions.json held
+  2026-07-21T10:08:17 status=timed_out "CODEC wants to run the 'file_ops' skill"
+
+A paste is a document, not a command.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from routes import chat as rc  # noqa: E402
+
+
+def test_cap_is_generous_enough_for_real_commands():
+    """Real skill commands are short imperatives — the cap must not clip them."""
+    real_commands = [
+        "what was I doing 20 minutes ago?",
+        "feed these prompts into Google Flow: 1. a drone shot over Marbella at "
+        "golden hour 2. the same shot at night 3. a close up of the marina",
+        "create a new skill that tells me the current moon phase",
+        "what's the weather in Marbella",
+    ]
+    for c in real_commands:
+        assert len(c) < rc.MAX_SKILL_HIJACK_CHARS, f"cap would clip a real command: {c[:40]}"
+
+
+def test_long_paste_does_not_hijack(monkeypatch):
+    """The incident: a long paste must fall through to the LLM untouched."""
+    fired = []
+    monkeypatch.setattr(
+        "codec_dispatch.check_skill",
+        lambda t: fired.append(t) or {"name": "file_ops"},
+    )
+
+    paste = (
+        "Point 6 — Obsidian capture via CODEC:\n"
+        "When a conversation has accumulated decisions worth keeping, offer once "
+        "to save a summary. Only on my explicit yes, write it with CODEC "
+        "file_write to [VAULT_PATH]/ChatLogs/YYYY-MM-DD-topic.md and confirm the "
+        "written path back to me.\n"
+    ) * 20                                   # ~6k chars, like the real paste
+    assert len(paste) > rc.MAX_SKILL_HIJACK_CHARS
+
+    name, result = rc._try_skill(paste)
+    assert name is None and result is None, "a long paste must not fire a skill"
+    assert not fired, "check_skill must not even be consulted for a long paste"
+
+
+def test_short_command_still_reaches_dispatch(monkeypatch):
+    """The cap must not disable the feature for normal-length messages."""
+    seen = []
+
+    def fake_check(t):
+        seen.append(t)
+        return {"name": "weather"}
+
+    monkeypatch.setattr("codec_dispatch.check_skill", fake_check)
+    monkeypatch.setattr("codec_dispatch.run_skill", lambda s, t, app="": "Sunny, 28C")
+    monkeypatch.setattr("codec_consent.chat_consent_ok", lambda n, t: True)
+
+    name, result = rc._try_skill("what's the weather in Marbella")
+    assert seen, "short messages must still reach check_skill"
+    assert name == "weather" and "Sunny" in result


### PR DESCRIPTION
Root cause of **"CODEC just stopped replying for no reason."**

## The chain

1. A **6,305-char paste** of standing rules — prose, containing *"write it with CODEC `file_write` to `<path>`"*
2. `check_skill` matched **`file_ops`**
3. `file_ops` is in `CHAT_SKILL_ALLOWLIST`, so `matched=True` **bypassed the conversational filter** (right for short commands, wrong for a document)
4. `file_ops` is **destructive** → the consent gate called `codec_ask_user.ask()`
5. `ask()` **blocks the request thread** until answered — default **600s**
6. The approval panel went to Notifications, which was sitting unread
7. Request hung → **no reply, nothing saved**

## Evidence

`pending_questions.json` at the time of the incident:

```
2026-07-21T10:08:17  status=timed_out  from=chat
  "CODEC wants to run the 'file_ops' skill — a destructive / hi…"
```

(10:08 UTC = 12:08 local, exactly the message that got no answer.)

Reproduced by replaying the exact message through `/api/chat`: **HTTP 000 after 200s**, while a short control message answered in **3.3s**.

## Fix

A paste is a document, not a command. Skills no longer auto-fire above `MAX_SKILL_HIJACK_CHARS` (**2000**) — generous, since the longest real command in the demo (a 3-item prompt_feeder list) is ~150 chars.

This kills the whole class of bug, not just `file_ops`: the same paste also matched `terminal`, `google_tasks` and `imessage_send`.

## Tests

New `tests/test_chat_hijack_length.py` — 3 cases: the cap doesn't clip real commands · a long paste doesn't fire (and `check_skill` isn't even consulted) · short commands still dispatch normally.

180 chat/consent/allowlist tests pass, no regressions.
