### PR TITLE
fix(ask_user): "no" declines a consent prompt instead of sticking forever

### DIFF
--- a/codec_ask_user.py
+++ b/codec_ask_user.py
@@ -77,6 +77,18 @@ _GENERIC_YES = frozenset({
     "fine", "alright", "go", "go ahead", "proceed", "do it",
 })
 
+# An explicit refusal is NOT ambiguous — it is the clearest possible answer, and
+# it can only ever block an action, never authorise one. Treating it as "not the
+# consent verb" meant a user who said "no" burned a rejection attempt instead of
+# declining, and because the rejection counter lives in memory, a question could
+# never be closed from a fresh process: it stayed `pending` forever. One had
+# been stuck since 2026-07-08.
+_EXPLICIT_NO = frozenset({
+    "n", "no", "nope", "nah", "cancel", "stop", "abort", "decline",
+    "don't", "dont", "do not", "never mind", "nevermind", "skip",
+    "no thanks", "no thank you",
+})
+
 # ── Lock + waiter registry ─────────────────────────────────────────────────────
 # Lock guards atomic file writes. Waiters dict maps pending_question_id →
 # threading.Event (caller signals via set() to unblock the agent thread).
@@ -149,7 +161,7 @@ def _prune_resolved(data: dict) -> None:
     cutoff = datetime.now(timezone.utc) - timedelta(hours=_RESOLVED_TTL_HOURS)
     kept = []
     for rec in data.get("pending_questions", []):
-        if rec.get("status") in ("answered", "timed_out"):
+        if rec.get("status") in ("answered", "timed_out", "declined"):
             ts = rec.get("answered_at") or rec.get("asked_at") or ""
             try:
                 when = datetime.fromisoformat(ts)
@@ -489,8 +501,9 @@ def ask(
             return _finalize_timeout(qid, reason="deadline")
         if rec.get("status") == "answered":
             return _finalize_answered(qid, rec)
-        if rec.get("status") == "timed_out":
-            # Some other path (admin clear, etc.) flipped it.
+        if rec.get("status") in ("timed_out", "declined"):
+            # Some other path (admin clear, explicit refusal) flipped it.
+            # "declined" is a deliberate NO — the caller must not proceed.
             return TIMEOUT_SENTINEL
         # Two-strike consent rejection check: if rejected_count >= max,
         # finalize as ambiguous_consent without waiting for the deadline.
@@ -615,6 +628,30 @@ def submit_answer(qid: str, answer: str, *, answered_via: str = "pwa") -> dict:
                 "answered_at": rec.get("answered_at")}
     if status == "timed_out":
         return {"ok": False, "error": "already_timed_out"}
+    if status == "declined":
+        return {"ok": False, "error": "already_declined",
+                "answered_at": rec.get("answered_at")}
+
+    # An explicit refusal closes the question immediately, in any mode. This is
+    # strictly safe: it can only withhold consent, never grant it. The caller
+    # sees the same TIMEOUT_SENTINEL it already treats as "do not proceed".
+    if answer and answer.strip().lower() in _EXPLICIT_NO:
+        with _FILE_LOCK, codec_jsonstore.file_lock(PENDING_QUESTIONS_PATH):
+            data = _load_pending_questions()
+            for r in data.get("pending_questions", []):
+                if r.get("id") == qid:
+                    r["status"] = "declined"
+                    r["answered_at"] = _now_iso()
+                    r["answered_via"] = answered_via
+                    r["answer"] = answer.strip()
+                    break
+            _save_pending_questions(data)
+        with _WAITERS_LOCK:
+            _REJECTION_COUNT.pop(qid, None)
+            ev = _WAITERS.get(qid)
+        if ev is not None:
+            ev.set()
+        return {"ok": True, "declined": True, "agent_unblocked": True}
 
     # §1.7 strict-consent acceptance check.
     if rec.get("consent_strict"):

--- a/tests/test_explicit_decline.py
+++ b/tests/test_explicit_decline.py
@@ -1,0 +1,102 @@
+"""An explicit "no" must decline a consent prompt — immediately and safely.
+
+Before this, strict-consent treated "no" as merely "not the consent verb": it
+burned a rejection attempt instead of declining. The rejection counter lives in
+memory, so from any fresh process the count reset to zero and the question could
+never reach the two-strike timeout — it stayed `pending` forever. One prompt had
+been stuck since 2026-07-08, and two more were created while reproducing the
+2026-07-21 chat-hang incident.
+
+The safety property that must never regress: a decline can only ever WITHHOLD
+consent. It must never be mistaken for approval.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+@pytest.fixture
+def au(tmp_path, monkeypatch):
+    """codec_ask_user pointed at a throwaway state file."""
+    import codec_ask_user as mod
+    pq = tmp_path / "pending_questions.json"
+    monkeypatch.setattr(mod, "PENDING_QUESTIONS_PATH", pq)
+    monkeypatch.setattr(mod, "NOTIFICATIONS_PATH", tmp_path / "notifications.json")
+    return mod
+
+
+def _seed(au, *, strict=True, verb="delete", status="pending"):
+    rec = {
+        "id": "q_test1234", "question": "CODEC wants to run 'file_ops'",
+        "options": None, "asked_at": "2026-07-21T10:00:00.000+00:00",
+        "deadline": "2026-07-21T10:10:00.000+00:00", "timeout_seconds": 600,
+        "status": status, "consent_strict": strict, "destructive_verb": verb,
+        "asked_from": "chat",
+    }
+    au.PENDING_QUESTIONS_PATH.write_text(
+        json.dumps({"schema": 1, "pending_questions": [rec]})
+    )
+    return rec
+
+
+def _status(au, qid="q_test1234"):
+    data = json.loads(au.PENDING_QUESTIONS_PATH.read_text())
+    return next(r["status"] for r in data["pending_questions"] if r["id"] == qid)
+
+
+@pytest.mark.parametrize("word", ["no", "No", "  NOPE  ", "cancel", "stop",
+                                  "abort", "decline", "don't", "skip"])
+def test_explicit_no_declines_immediately(au, word):
+    _seed(au)
+    out = au.submit_answer("q_test1234", word, answered_via="pwa")
+    assert out["ok"] is True and out["declined"] is True
+    assert _status(au) == "declined", "one refusal must close the question"
+
+
+def test_decline_is_not_consent(au):
+    """The safety property: declining must never read as approval."""
+    _seed(au)
+    au.submit_answer("q_test1234", "no", answered_via="pwa")
+    accepted, _ = au._is_consenting_answer(
+        "no", destructive_verb="delete", options=None)
+    assert accepted is False, "'no' must never be accepted as consent"
+
+
+def test_decline_is_idempotent(au):
+    _seed(au)
+    au.submit_answer("q_test1234", "no", answered_via="pwa")
+    second = au.submit_answer("q_test1234", "no", answered_via="pwa")
+    assert second["ok"] is False and second["error"] == "already_declined"
+
+
+def test_real_consent_verb_still_works(au):
+    """The gate must still open for the literal verb — this fix only adds a
+    way to say NO, it must not weaken the way to say YES."""
+    _seed(au, verb="delete")
+    out = au.submit_answer("q_test1234", "delete", answered_via="pwa")
+    assert out["ok"] is True and _status(au) == "answered"
+
+
+def test_generic_yes_still_rejected(au):
+    """A bare "yes" must still NOT satisfy a strict-consent gate."""
+    _seed(au, verb="delete")
+    out = au.submit_answer("q_test1234", "yes", answered_via="pwa")
+    assert out["ok"] is False and out["reason"] == "ambiguous_consent"
+    assert _status(au) == "pending"
+
+
+def test_declined_records_are_pruned(au):
+    """Declined records must age out, not accumulate forever."""
+    _seed(au, status="declined")
+    data = json.loads(au.PENDING_QUESTIONS_PATH.read_text())
+    data["pending_questions"][0]["answered_at"] = "2020-01-01T00:00:00+00:00"
+    au._prune_resolved(data)
+    assert data["pending_questions"] == [], "old declined records must be pruned"


### PR DESCRIPTION
Found while clearing orphaned approval prompts: **you cannot decline a consent prompt.**

Strict-consent treated `"no"` as merely *"not the consent verb"* — it burned a rejection attempt instead of declining. The rejection counter lives **in memory**, so from a fresh process the count resets to zero and the two-strike timeout is never reached. The question stays `pending` **forever**:

```
q_1c8bde72  2026-07-08T11:46:33  pending   ← stuck 13 days
q_dc5e64f8  2026-07-21T10:45:00  pending
→ submit_answer("no") → {"reason": "ambiguous_consent", "remaining_attempts": 1}
→ ...and 1 again. And 1 again. Forever.
```

## Fix

An explicit refusal is the *least* ambiguous answer there is, and it can only ever **withhold** consent — never grant it. It now closes the question immediately (`status="declined"`), wakes the waiter, and `ask()` returns the same `TIMEOUT_SENTINEL` callers already treat as "do not proceed".

Recognised: `no · nope · nah · cancel · stop · abort · decline · don't · skip · never mind` (+ variants).

## Safety is unchanged — pinned by tests

| Property | Result |
|---|---|
| `"no"` accepted as consent? | **never** ✅ |
| bare `"yes"` on a strict gate | still rejected ✅ |
| the literal verb (`"delete"`) | still opens the gate ✅ |
| second decline | idempotent (`already_declined`) ✅ |
| declined records | pruned on the same 24h TTL ✅ |

14 new tests; 104 existing ask_user/consent/step-3 tests pass.
