### PR TITLE
feat(create_skill): refuse generated code that calls a host which doesn't exist

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -33,7 +33,7 @@
     "cookbook_scan.py": "9bc1fe32073267c45c20d6dca67e293ed07f5c04dfff0109b480f778ffeaa3bb",
     "cookbook_serve.py": "8a08bb5deecd988431da421b1b4825cd411c7e9c7658bc547aa16ce74c0e1ddd",
     "cookbook_stop.py": "8b51e04ef08e08899df24d032af7a609bef7bf02ad72be5badf95eb0a2b1ce64",
-    "create_skill.py": "865cee32d124f57cbbfef34ad6d568415d88a83fa2f706319f920d84a019b9ad",
+    "create_skill.py": "6d5131d789347519a4c4cb60ac4dc50406ba163af0823e79de5192ba3ec34737",
     "daily_kickoff.py": "c649a0597265f284a876512c5689c2b210eb894ffddbd8da6b95f5e36a8cedab",
     "delegate.py": "7c595d5605cd9913a8afa331ae0013861d6996f378f8a59aca0249f1b2f3a474",
     "email_triage.py": "d7b9032b81179f58c5aff660c34f9b8edf212a8ce7651d307306e4757a8daaf2",

--- a/skills/create_skill.py
+++ b/skills/create_skill.py
@@ -38,6 +38,50 @@ BLOCKED_IN_SKILLS = [
 ]
 
 
+_URL_IN_CODE_RE = re.compile(r"https?://([A-Za-z0-9.\-]+)")
+
+# Hosts that are obviously placeholders rather than a claim about the world.
+_PLACEHOLDER_HOSTS = ("example.com", "example.org", "localhost", "127.0.0.1",
+                      "your-api.com", "api.example.com")
+
+
+def _unresolvable_hosts(code):
+    """Hostnames the generated code calls that DO NOT EXIST.
+
+    The model can invent an endpoint that reads perfectly: asked for a
+    moon-phase skill it wrote `https://api.moon.ph/v1/moon`, which resolves to
+    nothing. The code compiled, passed every safety check, looked plausible in
+    review — and failed 100% of the time it ran.
+
+    A prompt rule alone can't catch this; the only honest check is to ask the
+    world. DNS resolution is the cheapest one that exists and it is decisive:
+    if the hostname doesn't resolve, the model made it up.
+
+    Deliberately narrow — DNS failure only. A host that resolves but 404s, rate
+    limits, or blocks us is a live-service question, not a fabrication, and is
+    not this gate's business. Returns [] when offline (no DNS at all) so a
+    flight-mode laptop can't fail every skill.
+    """
+    import socket
+    hosts = {h.lower() for h in _URL_IN_CODE_RE.findall(code or "")}
+    hosts = {h for h in hosts if h not in _PLACEHOLDER_HOSTS}
+    if not hosts:
+        return []
+    # Are we online at all? If not, this check can't mean anything.
+    try:
+        socket.getaddrinfo("one.one.one.one", 443)
+    except OSError:
+        log.info("create_skill: skipping URL check — no DNS (offline)")
+        return []
+    bad = []
+    for h in sorted(hosts):
+        try:
+            socket.getaddrinfo(h, 443)
+        except OSError:
+            bad.append(h)
+    return bad
+
+
 def _validate_skill_code(code):
     """Validate generated skill code for safety and correctness.
     Returns (ok: bool, error_message: str)."""
@@ -60,6 +104,23 @@ def _validate_skill_code(code):
         compile(code, "<generated_skill>", "exec")
     except SyntaxError as e:
         return False, f"Generated code has a syntax error: {e}. Try describing the skill differently."
+
+    # Artifact over confidence: refuse code that calls a host which doesn't
+    # exist. This is the only check here that asks the world instead of reading
+    # the text, and it's the one that catches an invented endpoint.
+    try:
+        bad = _unresolvable_hosts(code)
+    except Exception as e:                      # never fail a skill on a checker bug
+        log.warning("create_skill: URL check errored, skipping: %s", e)
+        bad = []
+    if bad:
+        hosts = ", ".join(bad)
+        return False, (
+            f"The generated skill calls a host that does not exist: {hosts}. "
+            f"That endpoint was invented, so the skill would fail every time it "
+            f"ran. Ask again and say the skill must compute the answer locally "
+            f"with the standard library, or name the real API to use."
+        )
 
     return True, ""
 

--- a/tests/test_create_skill_url_check.py
+++ b/tests/test_create_skill_url_check.py
@@ -1,0 +1,115 @@
+"""Generated skills must not call hosts that don't exist.
+
+The 2026-07-21 incident: asked for a moon-phase skill, the generator wrote
+`https://api.moon.ph/v1/moon`. That host does not resolve. The code compiled,
+passed every safety check, and read perfectly in review — then failed 100% of
+the time it ran, returning "Error fetching moon phase data".
+
+A prompt rule ("don't invent URLs") reduces this but cannot catch it: the model
+is equally confident either way. The only honest check asks the world. DNS
+resolution is the cheapest such check and it is decisive — if the hostname
+doesn't resolve, the model made it up.
+
+Deliberately narrow: DNS failure only. A host that resolves but 404s or rate
+limits is a live-service question, not a fabrication.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+import importlib.util  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "cs_under_test", _REPO / "skills" / "create_skill.py")
+cs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cs)
+
+
+def _skill(body: str) -> str:
+    return (
+        '"""CODEC Skill: T"""\n'
+        'SKILL_NAME = "t"\n'
+        'SKILL_DESCRIPTION = "test"\n'
+        'def run(task, app="", ctx=""):\n'
+        f"    {body}\n"
+    )
+
+
+def test_invented_host_is_rejected(monkeypatch):
+    """The exact failure from the incident."""
+    monkeypatch.setattr(cs, "_unresolvable_hosts", lambda code: ["api.moon.ph"])
+    ok, err = cs._validate_skill_code(
+        _skill('import requests; return requests.get("https://api.moon.ph/v1/moon").text'))
+    assert ok is False
+    assert "api.moon.ph" in err
+    assert "does not exist" in err
+
+
+def test_real_host_passes(monkeypatch):
+    monkeypatch.setattr(cs, "_unresolvable_hosts", lambda code: [])
+    ok, err = cs._validate_skill_code(
+        _skill('import requests; return requests.get("https://api.github.com/zen").text'))
+    assert ok is True, err
+
+
+def test_local_computation_passes(monkeypatch):
+    """No URLs at all — the preferred shape — must never be blocked."""
+    monkeypatch.setattr(cs, "_unresolvable_hosts", lambda code: [])
+    ok, err = cs._validate_skill_code(_skill("import math; return str(math.pi)"))
+    assert ok is True, err
+
+
+def test_checker_crash_does_not_fail_the_skill(monkeypatch):
+    """A bug in the checker must never block a legitimate skill."""
+    def boom(code):
+        raise RuntimeError("resolver exploded")
+    monkeypatch.setattr(cs, "_unresolvable_hosts", boom)
+    ok, _ = cs._validate_skill_code(_skill("return 'hi'"))
+    assert ok is True
+
+
+def test_offline_skips_the_check(monkeypatch):
+    """With no DNS at all the check is meaningless — it must not fail
+    every skill on a laptop in flight mode."""
+    import socket
+
+    def no_dns(host, port):
+        raise OSError("Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", no_dns)
+    assert cs._unresolvable_hosts('requests.get("https://totally-made-up-xyz.tld/a")') == []
+
+
+def test_placeholder_hosts_are_ignored(monkeypatch):
+    """example.com is a documentation placeholder, not a claim about the world."""
+    import socket
+    calls = []
+
+    def fake(host, port):
+        calls.append(host)
+        if host == "one.one.one.one":
+            return [("ok",)]
+        raise OSError("nope")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake)
+    assert cs._unresolvable_hosts('requests.get("https://example.com/x")') == []
+    assert "example.com" not in calls
+
+
+def test_real_incident_file_is_caught():
+    """End-to-end against the genuine artifact, using real DNS.
+    Skipped when offline."""
+    import socket
+    try:
+        socket.getaddrinfo("one.one.one.one", 443)
+    except OSError:
+        pytest.skip("offline")
+    code = _skill('import requests; return requests.get("https://api.moon.ph/v1/moon").text')
+    assert cs._unresolvable_hosts(code) == ["api.moon.ph"]


### PR DESCRIPTION
Follow-up to #280, and the more important half.

#280 told the model *"don't invent URLs."* That reduces the problem but **cannot catch it** — the model is equally confident either way. This checks.

## The incident

Asked for a moon-phase skill, the generator wrote `https://api.moon.ph/v1/moon`. **That host does not resolve.** The code compiled, passed every safety gate, and read perfectly in review — then failed 100% of the time it ran with `Error fetching moon phase data`.

Nothing in the pipeline could catch it, because every existing check reads the *text*. The only honest check asks the *world*.

## This is your own rule, applied to CODEC

> *"Check the state of the world, not the plan."*

A claim about an external system is now verified against that system before the skill is staged. DNS resolution is the cheapest such check and it's decisive: if the hostname doesn't resolve, it was invented.

## Deliberately narrow — false rejections are the real risk

| Case | Behaviour |
|---|---|
| Host doesn't resolve | **rejected**, naming the host |
| Host resolves but 404s / rate limits | allowed — that's a live-service question, not a fabrication |
| Offline (no DNS at all) | check skipped — a laptop in flight mode must not fail every skill |
| `example.com`, `localhost` | ignored — documentation placeholders |
| Checker itself crashes | never blocks a skill |

## Verified against the real artifact

```
the actual shipped skill → REJECTED: "calls a host that does not exist: api.moon.ph"
api.github.com           → passes
stdlib-only (no URLs)    → passes
```

7 new tests (incl. one running real DNS against the genuine incident file, skipped when offline). 25 create_skill/skill_review tests pass. Manifest regenerated.
