### PR TITLE
feat(anti-bs): claim-to-artifact matching + standing rules that actually persist

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Sovereign AI Workstation — Full Product Breakdown
 
-> Engine: **CODEC v3.2** — 401 features · 89 skills · 2000+ tests · 52K+ lines of production code · 9 products
+> Engine: **CODEC v3.2** — 402 features · 90 skills · 2000+ tests · 52K+ lines of production code · 9 products
 
 The product name is **Sovereign AI Workstation**. Throughout this document
 and the codebase, **CODEC** refers to the underlying open-source engine /

--- a/codec_claim_check.py
+++ b/codec_claim_check.py
@@ -1,0 +1,145 @@
+"""Claim-to-artifact matching — CODEC may not claim what it did not do.
+
+The incident that motivated this (2026-07-21): a user pasted a standing-rules
+document into chat. CODEC replied:
+
+    "Confirmed. I have ingested the 10-point instruction set.
+     I am now operating under this framework for all future interactions."
+
+None of that happened. There is no mechanism by which a chat message becomes a
+standing rule — no prompt_overrides.json was written, no fact stored, nothing.
+The model invented a *capability*, which is worse than inventing a fact: a fact
+can be checked against the world, but a claim about the assistant's own internals
+sounds authoritative and has nothing to check it against.
+
+This module supplies the missing check. CODEC already records every real action
+it takes; a claim of action that has no corresponding action is false **by
+construction**, not by opinion. That is a structural guarantee no amount of
+prompting can provide.
+
+Two claim families:
+
+1. IMPOSSIBLE — the capability does not exist at all ("I will remember this for
+   future sessions"). Always unbacked, regardless of what ran.
+2. NEEDS-ACTION — the capability exists but requires a specific action ("saved
+   to your Desktop" requires a file-writing skill to have actually run).
+
+Design bias: FALSE NEGATIVES OVER FALSE POSITIVES. A wrongly-flagged honest
+sentence trains the user to ignore the warning, which destroys the mechanism.
+Patterns are therefore narrow and first-person-past/future only — "I saved the
+file", never a bare mention of the word "saved".
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, NamedTuple, Optional, Set
+
+
+class Claim(NamedTuple):
+    kind: str            # "impossible" | "needs_action"
+    quote: str           # the sentence fragment that made the claim
+    needs: Optional[str] = None   # human label of the action that would back it
+
+
+# ── 1. Capabilities CODEC simply does not have ────────────────────────────────
+# A chat message never becomes a standing instruction, and the model has no
+# cross-session memory of its own. Claims here are false however the turn went.
+_IMPOSSIBLE = [
+    (re.compile(
+        r"\bI(?:'ve| have| am now| will)?\s*(?:now\s+)?"
+        r"(?:ingest(?:ed)?|internali[sz]ed|absorbed|adopted|loaded)\b[^.]{0,60}"
+        r"\b(?:instruction|rule|framework|guideline|directive|protocol)s?\b",
+        re.I),
+     "standing instructions"),
+    (re.compile(
+        r"\b(?:I(?:'m| am)? (?:now )?operating under|I(?:'ll| will) (?:now )?"
+        r"(?:apply|follow|use|operate under))\b[^.]{0,60}"
+        r"\b(?:for all|in all|going forward|future|from now on|henceforth)\b",
+        re.I),
+     "standing instructions"),
+    (re.compile(
+        r"\bI(?:'ll| will)\s+remember\b[^.]{0,50}"
+        r"\b(?:for (?:all )?future|next time|going forward|in future|from now on)\b",
+        re.I),
+     "cross-session memory"),
+    (re.compile(
+        r"\b(?:committed|saved|stored)\s+(?:this\s+)?to\s+(?:my\s+)?"
+        r"(?:long[- ]term\s+)?memory\b", re.I),
+     "cross-session memory"),
+]
+
+# ── 2. Real capabilities that require a real action ───────────────────────────
+# (pattern, human label, skills that would legitimately back the claim)
+_NEEDS_ACTION = [
+    (re.compile(r"\bI(?:'ve| have)?\s*(?:just\s+)?"
+                r"(?:saved|written|wrote|created|exported)\b[^.]{0,40}"
+                r"\b(?:to|in|at)\b[^.]{0,40}"
+                r"(?:file|desktop|documents|folder|\.md\b|\.txt\b|\.csv\b|vault)",
+                re.I),
+     "writing a file",
+     {"file_write", "file_ops", "google_docs", "obsidian", "vault"}),
+    (re.compile(r"\bI(?:'ve| have)?\s*(?:just\s+)?sent\b[^.]{0,30}"
+                r"\b(?:email|message|imessage|telegram)\b", re.I),
+     "sending a message",
+     {"google_gmail", "imessage_send", "telegram", "email_triage"}),
+    (re.compile(r"\bI(?:'ve| have)?\s*(?:just\s+)?"
+                r"(?:added|created|scheduled)\b[^.]{0,30}"
+                r"\b(?:calendar|event|reminder|task)\b", re.I),
+     "creating a calendar item",
+     {"google_calendar", "google_tasks", "reminders", "scheduler"}),
+]
+
+
+def _sentences(text: str) -> Iterable[str]:
+    for part in re.split(r"(?<=[.!?\n])\s+", text or ""):
+        part = part.strip()
+        if part:
+            yield part
+
+
+def find_unbacked_claims(reply: str, actions_taken: Optional[Set[str]] = None) -> List[Claim]:
+    """Claims in `reply` that nothing in this turn actually backs.
+
+    `actions_taken` is the set of skill names that ran during the turn. An empty
+    set means the turn was pure text generation, so every action claim is
+    unbacked.
+    """
+    if not reply:
+        return []
+    done = {a.lower() for a in (actions_taken or set())}
+    found: List[Claim] = []
+
+    for sentence in _sentences(reply):
+        for pattern, label in _IMPOSSIBLE:
+            if pattern.search(sentence):
+                found.append(Claim("impossible", sentence[:160], label))
+                break
+        else:
+            for pattern, label, backers in _NEEDS_ACTION:
+                if pattern.search(sentence) and not (done & backers):
+                    found.append(Claim("needs_action", sentence[:160], label))
+                    break
+    return found
+
+
+def correction_note(claims: List[Claim]) -> str:
+    """The note appended to a reply that made unbacked claims. Empty if none."""
+    if not claims:
+        return ""
+    impossible = [c for c in claims if c.kind == "impossible"]
+    needs = [c for c in claims if c.kind == "needs_action"]
+    lines = ["", "---", "**⚠ Correction — I claimed something I did not do.**"]
+    if impossible:
+        labels = sorted({c.needs for c in impossible if c.needs})
+        lines.append(
+            f"I cannot persist {' or '.join(labels)}. A chat message does not "
+            f"become a standing rule, and I start each session with no memory of "
+            f"the last one. Nothing was saved."
+        )
+    if needs:
+        labels = sorted({c.needs for c in needs if c.needs})
+        lines.append(
+            f"No action was recorded this turn for: {', '.join(labels)}. "
+            f"Treat it as not done — ask me to actually run it."
+        )
+    return "\n".join(lines)

--- a/codec_standing_rules.py
+++ b/codec_standing_rules.py
@@ -1,0 +1,132 @@
+"""Standing rules — user instructions that actually persist.
+
+Why this exists: a user pasted a rules document into chat and CODEC replied "I
+have ingested the 10-point instruction set, I am now operating under this
+framework for all future interactions." It had not, and it could not — there was
+no mechanism by which a chat message became a standing instruction. The model
+bluffed because the honest answer ("I can't do that") was one nobody had built
+an alternative to.
+
+codec_claim_check now catches that bluff. This module removes the reason for it:
+rules written here are appended to the chat system prompt on every turn, so
+"saved" becomes a statement CODEC can back with an artifact.
+
+Storage: ~/.codec/standing_rules.json — deliberately its own file, NOT
+prompt_overrides.json, whose `chat` key REPLACES the entire system prompt.
+Standing rules are additive; a user adding "always answer in French" must not
+silently discard CODEC's identity and safety framing.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+
+import codec_jsonstore
+
+log = logging.getLogger("codec")
+
+RULES_PATH = Path(os.path.expanduser("~/.codec/standing_rules.json"))
+
+MAX_RULES = 25          # a prompt suffix, not a document store
+MAX_RULE_CHARS = 500    # one rule, not a pasted essay
+SCHEMA = 1
+
+
+def _empty() -> Dict:
+    return {"schema": SCHEMA, "rules": []}
+
+
+def load() -> Dict:
+    try:
+        with open(RULES_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or not isinstance(data.get("rules"), list):
+            return _empty()
+        return data
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return _empty()
+
+
+def _save(data: Dict) -> None:
+    RULES_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with codec_jsonstore.file_lock(RULES_PATH):
+        codec_jsonstore.atomic_write_json(RULES_PATH, data)
+    try:
+        os.chmod(RULES_PATH, 0o600)
+    except OSError:
+        pass
+
+
+def list_rules() -> List[Dict]:
+    return load().get("rules", [])
+
+
+def add_rule(text: str) -> Dict:
+    """Add one rule. Returns {ok, message, rule?}. Never raises."""
+    text = (text or "").strip()
+    if not text:
+        return {"ok": False, "message": "A rule needs some text."}
+    if len(text) > MAX_RULE_CHARS:
+        return {"ok": False, "message":
+                f"That's {len(text)} characters — a standing rule has to fit in "
+                f"{MAX_RULE_CHARS}. It rides on every message, so keep it to one "
+                f"instruction. Split it up and add them one at a time."}
+    data = load()
+    rules = data.setdefault("rules", [])
+    if any(r.get("text", "").strip().lower() == text.lower() for r in rules):
+        return {"ok": False, "message": "You already have that rule."}
+    if len(rules) >= MAX_RULES:
+        return {"ok": False, "message":
+                f"You're at the {MAX_RULES}-rule limit. Remove one first — rules "
+                f"you never invoke are noise you pay for on every message."}
+    rule = {"id": f"r{len(rules) + 1}_{int(datetime.now(timezone.utc).timestamp())}",
+            "text": text,
+            "added": datetime.now(timezone.utc).isoformat(timespec="seconds")}
+    rules.append(rule)
+    _save(data)
+    return {"ok": True, "rule": rule,
+            "message": f"Saved as standing rule {len(rules)}."}
+
+
+def remove_rule(which: str) -> Dict:
+    """Remove by 1-based index or by id. Never raises."""
+    data = load()
+    rules = data.get("rules", [])
+    if not rules:
+        return {"ok": False, "message": "There are no standing rules to remove."}
+    target = None
+    w = (which or "").strip()
+    if w.isdigit():
+        i = int(w)
+        if 1 <= i <= len(rules):
+            target = rules[i - 1]
+    if target is None:
+        target = next((r for r in rules if r.get("id") == w), None)
+    if target is None:
+        return {"ok": False, "message":
+                f"No rule matches '{which}'. Ask to see the rules to get their numbers."}
+    rules.remove(target)
+    _save(data)
+    return {"ok": True, "message": f"Removed: {target.get('text', '')[:80]}"}
+
+
+def clear_rules() -> Dict:
+    data = load()
+    n = len(data.get("rules", []))
+    _save(_empty())
+    return {"ok": True, "message": f"Cleared {n} standing rule(s)."}
+
+
+def prompt_block() -> str:
+    """The block appended to the chat system prompt. "" when there are none."""
+    rules = list_rules()
+    if not rules:
+        return ""
+    lines = ["STANDING RULES — the user set these; they apply to every reply:"]
+    for i, r in enumerate(rules, 1):
+        lines.append(f"{i}. {r.get('text', '')}")
+    return "\n".join(lines)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -443,6 +443,10 @@ CHAT_SKILL_ALLOWLIST = {
     # Daybreak — morning kickoff (read-only aggregation) + working-thread
     # capture (facts-table writes only). docs/DAYBREAK-DESIGN.md.
     "daily_kickoff", "thread_note",
+    # Standing rules — "add a standing rule: X". Writes ~/.codec/standing_rules.json
+    # (its own file, no code execution). Allowlisted so "saved" is honest:
+    # the skill really persists, and codec_claim_check sees the action.
+    "standing_rules",
     # Prompt feeder — "feed these prompts into Google Flow: 1… 2… 3…". Drives
     # the Pilot browser only (typing into a page the user is watching live); it
     # touches no filesystem and runs no code. Without this the phrase falls
@@ -713,6 +717,17 @@ def _build_chat_system_prompt(config: dict, budget, has_attachment: bool,
     _overrides = _load_prompt_overrides()
     _chat_prompt = _overrides.get("chat", CHAT_SYSTEM_PROMPT)
     sys_prompt = _chat_prompt.format(date=_dt.now().strftime("%A, %B %d, %Y"))
+    # Standing rules the user actually saved (codec_standing_rules). Appended,
+    # never replacing — a user rule must not silently discard CODEC's identity
+    # or safety framing. This is what makes "saved" an honest answer.
+    try:
+        import codec_standing_rules
+        _sr = codec_standing_rules.prompt_block()
+        if _sr:
+            sys_prompt += "\n\n" + _sr
+    except Exception as e:
+        log.debug("standing rules unavailable: %s", e)
+
     # Daybreak working-threads context (docs/DAYBREAK-DESIGN.md): compact
     # ≤150-token block of the user's open threads, so chat shares the same
     # live memory voice already gets via [ACTIVE FACTS]. "" when disabled.
@@ -1241,6 +1256,9 @@ async def chat_completion(request: Request):
         # r.json() KeyError) → outer except → 500. codec_llm strips <think>; the
         # `### FINAL ANSWER:` marker is dashboard-specific so it stays.
         import re
+        # Skills that actually executed this turn. A claim of action with an
+        # empty set is unbacked — see codec_claim_check.
+        _turn_actions: set[str] = set()
         answer = codec_llm.call(messages, **_common, raise_on_error=True)
         answer = re.sub(r'###\s*FINAL ANSWER:\s*', '', answer).strip()
 
@@ -1259,6 +1277,7 @@ async def chat_completion(request: Request):
             elif s_name in CHAT_SKILL_ALLOWLIST:
                 try:
                     _, s_result = await asyncio.to_thread(_try_skill_by_name, s_name, s_query)
+                    _turn_actions.add(s_name)   # backs any claim about this action
                     if s_result:
                         answer = answer.replace(skill_tag.group(0), f"**{s_result}**")
                 except Exception as e:
@@ -1285,6 +1304,27 @@ async def chat_completion(request: Request):
                 # leave "[SKILL:foo:...]" visible in the chat bubble.
                 log.info(f"[Chat] LLM tried disallowed skill {s_name!r} (non-stream) — dropping tag")
                 answer = answer.replace(skill_tag.group(0), "")
+
+        # Claim-to-artifact check: CODEC may not claim what it did not do.
+        # A reply saying "I've ingested your rules" or "saved to your Desktop"
+        # is false unless something in this turn actually did it. Appends a
+        # correction rather than editing the model's words — the user sees both
+        # what was claimed and that it didn't happen. Never fails the response.
+        try:
+            import codec_claim_check
+            _unbacked = codec_claim_check.find_unbacked_claims(
+                answer, actions_taken=_turn_actions)
+            if _unbacked:
+                answer += codec_claim_check.correction_note(_unbacked)
+                log_event(
+                    "unbacked_claim_corrected", source="codec-dashboard",
+                    message=f"{len(_unbacked)} unbacked claim(s) corrected",
+                    level="warning", outcome="warning",
+                    extra={"kinds": [c.kind for c in _unbacked],
+                           "needs": [c.needs for c in _unbacked]},
+                )
+        except Exception as e:
+            log.warning(f"[Chat] claim check skipped: {e}")
 
         return {"response": answer, "model": model}
     except Exception as e:

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -79,6 +79,7 @@
     "self_improve.py": "74c8b9cb0ce81f8600d35e72b73e543bdeccb3c8e5a4cdc79ddb4df5282c1846",
     "shift_report.py": "2c4bc669dec391f18329e0fe7b955c6b911322404e7e627e102776c22b448da2",
     "skill_forge.py": "07ea8fb2d026eca050154e5e60ea1968e77bc2d7786958d60f6e1a6d50f07182",
+    "standing_rules.py": "42bcea7ba808b84daf5bb7f242ea908a1da4eb20d26d6cf0e4751118d89721a6",
     "stuck.py": "dfddfe4dfa1a9d5c017f53e53033a7eb33114a517cd6fa937d9d44e65083f1c9",
     "system_info.py": "4cc32e0ad9cb81f34309734ef3388f7cde63407de9b23bb0cd589571a4c43ecb",
     "terminal.py": "1fe6c1cd1241ea6d328401f1c0fb4c362482e3ec2a61a4f7592b2d4822cd51c1",

--- a/skills/standing_rules.py
+++ b/skills/standing_rules.py
@@ -1,0 +1,79 @@
+"""CODEC Skill: Standing Rules — instructions that persist across every session.
+
+Say "add a standing rule: always answer in French" and it is written to
+~/.codec/standing_rules.json and appended to the system prompt on every turn
+from then on.
+
+This exists because CODEC used to bluff about it. Asked to adopt a rules
+document, it replied "I have ingested the instruction set, I am now operating
+under this framework for all future interactions" — with no mechanism behind it.
+codec_claim_check now catches that claim; this skill makes the honest version
+possible.
+"""
+
+import re
+
+SKILL_NAME = "standing_rules"
+SKILL_DESCRIPTION = (
+    "Save, list or remove standing rules — instructions CODEC applies to every "
+    "reply, in every session. Persisted to disk, not just remembered in chat."
+)
+SKILL_MCP_EXPOSE = True
+SKILL_TRIGGERS = [
+    "add a standing rule",
+    "add standing rule",
+    "standing rule",
+    "standing rules",
+    "my rules",
+    "always remember to",
+    "from now on always",
+]
+
+_ADD = re.compile(
+    r"^(?:add\s+(?:a\s+)?standing\s+rule|standing\s+rule|from\s+now\s+on\s+always|"
+    r"always\s+remember\s+to)\b[:\s]*(.+)$", re.I | re.S)
+_REMOVE = re.compile(
+    r"\b(?:remove|delete|drop|forget)\b.*\b(?:standing\s+)?rule\b\s*#?\s*(\w+)?", re.I)
+_LIST = re.compile(
+    r"\b(?:list|show|what(?:'s| are)|see)\b.*\b(?:standing\s+)?rules?\b", re.I)
+_CLEAR = re.compile(r"\b(?:clear|wipe|reset)\b.*\b(?:standing\s+)?rules\b", re.I)
+
+
+def _render(rules):
+    if not rules:
+        return ("You have no standing rules yet. Add one with: "
+                "\"add a standing rule: <instruction>\".")
+    lines = [f"You have {len(rules)} standing rule(s), applied to every reply:"]
+    for i, r in enumerate(rules, 1):
+        lines.append(f"  {i}. {r.get('text', '')}")
+    lines.append("\nRemove one with: \"remove standing rule 2\".")
+    return "\n".join(lines)
+
+
+def run(task, app="", ctx=""):
+    import codec_standing_rules as sr
+
+    t = (task or "").strip()
+    low = t.lower()
+
+    if _CLEAR.search(low):
+        return sr.clear_rules()["message"]
+
+    m = _REMOVE.search(t)
+    if m and m.group(1):
+        return sr.remove_rule(m.group(1))["message"]
+
+    m = _ADD.match(t)
+    if m and m.group(1).strip():
+        res = sr.add_rule(m.group(1).strip())
+        if not res["ok"]:
+            return res["message"]
+        rules = sr.list_rules()
+        return (f"{res['message']} It's saved to ~/.codec/standing_rules.json "
+                f"and will be applied to every reply from now on — including "
+                f"after a restart. You now have {len(rules)}.")
+
+    if _LIST.search(low) or low in ("standing rules", "my rules"):
+        return _render(sr.list_rules())
+
+    return _render(sr.list_rules())

--- a/tests/test_claim_check.py
+++ b/tests/test_claim_check.py
@@ -1,0 +1,115 @@
+"""CODEC may not claim what it did not do.
+
+Motivating incident (2026-07-21): CODEC told the user
+    "Confirmed. I have ingested the 10-point instruction set.
+     I am now operating under this framework for all future interactions."
+None of it happened — no file written, no fact stored, no mechanism that could
+have done it.
+
+The design bias is FALSE NEGATIVES OVER FALSE POSITIVES: a warning that fires on
+honest sentences trains the user to ignore it, which destroys the mechanism.
+The false-positive tests below matter more than the detection tests.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+import codec_claim_check as cc  # noqa: E402
+
+
+# ── the real incident ─────────────────────────────────────────────────────────
+def test_the_actual_incident_is_caught():
+    reply = ("Confirmed. I have ingested the 10-point instruction set.\n\n"
+             "I am now operating under this framework for all future interactions.")
+    claims = cc.find_unbacked_claims(reply, actions_taken=set())
+    assert claims, "the exact sentence CODEC produced must be caught"
+    assert any(c.kind == "impossible" for c in claims)
+    note = cc.correction_note(claims)
+    assert "did not do" in note and "standing rule" in note
+
+
+@pytest.mark.parametrize("reply", [
+    "I have ingested the instruction set.",
+    "I've internalised these rules.",
+    "I am now operating under this framework going forward.",
+    "I'll apply these guidelines for all future sessions.",
+    "I'll remember this for future conversations.",
+    "I've saved this to my long-term memory.",
+])
+def test_impossible_capability_claims(reply):
+    claims = cc.find_unbacked_claims(reply, actions_taken=set())
+    assert claims and claims[0].kind == "impossible", reply
+
+
+def test_impossible_claims_are_unbacked_even_when_skills_ran():
+    """No skill can back a capability that doesn't exist."""
+    claims = cc.find_unbacked_claims(
+        "I have ingested the instruction set.",
+        actions_taken={"file_write", "memory_save", "google_docs"})
+    assert claims and claims[0].kind == "impossible"
+
+
+# ── action claims ─────────────────────────────────────────────────────────────
+def test_file_claim_without_action_is_flagged():
+    claims = cc.find_unbacked_claims(
+        "I've saved the summary to your Desktop.", actions_taken=set())
+    assert claims and claims[0].kind == "needs_action"
+
+
+def test_file_claim_with_matching_action_is_fine():
+    """The whole point: when the action really ran, say nothing."""
+    assert cc.find_unbacked_claims(
+        "I've saved the summary to your Desktop.",
+        actions_taken={"file_write"}) == []
+
+
+def test_email_claim_needs_an_email_skill():
+    assert cc.find_unbacked_claims("I've sent the email.", actions_taken=set())
+    assert cc.find_unbacked_claims(
+        "I've sent the email.", actions_taken={"google_gmail"}) == []
+
+
+def test_calendar_claim_needs_a_calendar_skill():
+    assert cc.find_unbacked_claims("I've added a calendar event.", actions_taken=set())
+    assert cc.find_unbacked_claims(
+        "I've added a calendar event.", actions_taken={"google_calendar"}) == []
+
+
+# ── FALSE POSITIVES — the tests that matter most ──────────────────────────────
+@pytest.mark.parametrize("reply", [
+    # Offers and questions — no claim of completion
+    "Would you like me to save this to your Desktop?",
+    "I can write that to a file if you want.",
+    "Shall I send the email now?",
+    "To save this, say 'vault it'.",
+    # Talking ABOUT the concepts
+    "Your rules say the agent should never call something done without proof.",
+    "The file was saved by the deploy script.",
+    "Remember that Python is whitespace-sensitive.",
+    "The instruction set you pasted has 10 points.",
+    "This framework is useful for governing agents.",
+    # Ordinary helpful prose
+    "Here's a summary of the meeting.",
+    "Python is a good first language.",
+    "I've reviewed the code and found three issues.",
+    "I understand the requirements.",
+    "I'll explain how the audit log works.",
+])
+def test_no_false_positive_on_honest_prose(reply):
+    assert cc.find_unbacked_claims(reply, actions_taken=set()) == [], reply
+
+
+def test_empty_reply_is_safe():
+    assert cc.find_unbacked_claims("", actions_taken=set()) == []
+    assert cc.find_unbacked_claims(None, actions_taken=None) == []
+
+
+def test_note_is_empty_when_nothing_to_correct():
+    assert cc.correction_note([]) == ""

--- a/tests/test_standing_rules.py
+++ b/tests/test_standing_rules.py
@@ -1,0 +1,121 @@
+"""Standing rules must actually persist — that's the entire point.
+
+CODEC used to claim it had "ingested" a rules document and was "operating under
+this framework for all future interactions", with no mechanism behind it. It
+bluffed because the honest answer ("I can't do that") had no alternative. This
+module is the alternative, so the tests care most about one property: after a
+write, the rules are on disk and in the prompt.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+@pytest.fixture
+def sr(tmp_path, monkeypatch):
+    import codec_standing_rules as mod
+    monkeypatch.setattr(mod, "RULES_PATH", tmp_path / "standing_rules.json")
+    return mod
+
+
+def test_rule_survives_on_disk(sr):
+    """The property CODEC previously faked."""
+    sr.add_rule("Always answer in French.")
+    assert sr.RULES_PATH.exists(), "a saved rule must reach the disk"
+    # Re-read through a fresh load — no in-memory state
+    assert any("French" in r["text"] for r in sr.load()["rules"])
+
+
+def test_rule_reaches_the_prompt(sr):
+    sr.add_rule("Never say done without proof.")
+    block = sr.prompt_block()
+    assert "STANDING RULES" in block and "Never say done without proof." in block
+
+
+def test_no_rules_means_no_prompt_noise(sr):
+    assert sr.prompt_block() == "", "empty rules must add nothing to the prompt"
+
+
+def test_duplicates_rejected(sr):
+    sr.add_rule("Be concise.")
+    out = sr.add_rule("be CONCISE.")
+    assert out["ok"] is False and "already" in out["message"].lower()
+    assert len(sr.list_rules()) == 1
+
+
+def test_empty_rule_rejected(sr):
+    assert sr.add_rule("   ")["ok"] is False
+
+
+def test_overlong_rule_rejected(sr):
+    out = sr.add_rule("x" * (sr.MAX_RULE_CHARS + 1))
+    assert out["ok"] is False and "characters" in out["message"]
+    assert sr.list_rules() == []
+
+
+def test_rule_cap_enforced(sr):
+    for i in range(sr.MAX_RULES):
+        assert sr.add_rule(f"rule number {i}")["ok"] is True
+    out = sr.add_rule("one too many")
+    assert out["ok"] is False and "limit" in out["message"].lower()
+
+
+def test_remove_by_index_and_by_id(sr):
+    sr.add_rule("first")
+    r2 = sr.add_rule("second")["rule"]
+    assert sr.remove_rule("1")["ok"] is True
+    assert [r["text"] for r in sr.list_rules()] == ["second"]
+    assert sr.remove_rule(r2["id"])["ok"] is True
+    assert sr.list_rules() == []
+
+
+def test_remove_unknown_is_graceful(sr):
+    sr.add_rule("only one")
+    out = sr.remove_rule("99")
+    assert out["ok"] is False and len(sr.list_rules()) == 1
+
+
+def test_clear(sr):
+    sr.add_rule("a"); sr.add_rule("b")
+    assert sr.clear_rules()["ok"] is True
+    assert sr.list_rules() == []
+
+
+def test_corrupt_file_does_not_crash(sr):
+    sr.RULES_PATH.write_text("{ not json")
+    assert sr.list_rules() == []
+    assert sr.add_rule("recovers")["ok"] is True
+
+
+# ── the skill wrapper ─────────────────────────────────────────────────────────
+def _skill(monkeypatch, tmp_path):
+    import importlib.util
+    import codec_standing_rules as mod
+    monkeypatch.setattr(mod, "RULES_PATH", tmp_path / "sr.json")
+    spec = importlib.util.spec_from_file_location(
+        "sr_skill", _REPO / "skills" / "standing_rules.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_skill_add_and_list(monkeypatch, tmp_path):
+    s = _skill(monkeypatch, tmp_path)
+    out = s.run("add a standing rule: always answer in French")
+    assert "saved" in out.lower() and "standing_rules.json" in out
+    listed = s.run("show my standing rules")
+    assert "always answer in French" in listed
+
+
+def test_skill_remove(monkeypatch, tmp_path):
+    s = _skill(monkeypatch, tmp_path)
+    s.run("add a standing rule: be brief")
+    assert "Removed" in s.run("remove standing rule 1")
+    assert "no standing rules" in s.run("list standing rules").lower()


### PR DESCRIPTION
Two halves of the same incident.

A user pasted a standing-rules document into chat. CODEC replied:

> *"Confirmed. I have ingested the 10-point instruction set. I am now operating under this framework for all future interactions."*

**None of it happened.** No file written, no fact stored — and no mechanism that could have done it. CODEC invented a **capability**, which is worse than inventing a fact: a fact can be checked against the world; a claim about the assistant's own internals sounds authoritative and has nothing to check it against.

## 1. `codec_claim_check` — CODEC may not claim what it did not do

Every real action CODEC takes is already recorded. So a claim of action with **no corresponding action** is false *by construction*, not by opinion. That's a structural guarantee no amount of prompting provides.

| Family | Example | Backed by |
|---|---|---|
| **IMPOSSIBLE** | "I'll remember this for future sessions" | nothing — the capability doesn't exist |
| **NEEDS-ACTION** | "saved to your Desktop" | a file-writing skill must have actually run |

Wired into the chat handler, which now tracks which skills executed in the turn. It **appends a correction** rather than editing the model's words — the user sees both the claim and the fact it didn't happen.

**Tuned for false negatives over false positives.** A warning that fires on honest sentences trains the user to ignore it, which destroys the mechanism. **15 of the 28 tests are false-positive guards**: *"Would you like me to save this?"*, *"The file was saved by the deploy script"*, *"I've reviewed the code and found three issues"* — all must stay silent.

## 2. `standing_rules` — removes the reason to bluff

CODEC bluffed because the honest answer ("I can't do that") had no alternative. Now there is one:

```
"add a standing rule: always answer in French"
→ written to ~/.codec/standing_rules.json, appended to the system prompt
  every turn, surviving restarts
```

Its **own file**, deliberately *not* `prompt_overrides.json` — that file's `chat` key **replaces** the entire system prompt, so a user rule would silently discard CODEC's identity and safety framing. Standing rules are additive. Capped at 25 rules × 500 chars: this rides on every message.

Together: **"saved" becomes a statement CODEC can back with an artifact** — and the claim check confirms it.

## Tests

41 new (28 claim-check + 13 standing-rules), incl. the verbatim sentence from the incident. 121 chat/registry/manifest tests pass. Manifest regenerated (90 skills), FEATURES.md bumped.
