### PR TITLE
fix(claim-check): catch the stative phrasing of the same false claim

### DIFF
--- a/codec_claim_check.py
+++ b/codec_claim_check.py
@@ -66,6 +66,21 @@ _IMPOSSIBLE = [
         r"\b(?:committed|saved|stored)\s+(?:this\s+)?to\s+(?:my\s+)?"
         r"(?:long[- ]term\s+)?memory\b", re.I),
      "cross-session memory"),
+    # Passive/stative phrasing of the same lie. Caught live: asked to adopt a
+    # rules document, the model avoided every first-person verb above and said
+    # "The 10-point instruction set is active… locked in for all file and code
+    # operations." Same false claim of persistence, different grammar. Anchored
+    # to a rules-noun so ordinary uses of "active" can't trip it.
+    (re.compile(
+        r"\b(?:instruction set|rule ?set|standing rules|the \d+[- ]point"
+        r"[^.]{0,20}|these rules|those rules|the rules|the framework|"
+        r"the guidelines|the protocol)\b[^.]{0,40}?\b(?:is|are)\s+"
+        r"(?:now\s+)?(?:active|in effect|in force|locked in|applied|"
+        r"loaded|ingested|internali[sz]ed)\b", re.I),
+     "standing instructions"),
+    (re.compile(
+        r"\block(?:ed)? in\b[^.]{0,40}\bfor all\b", re.I),
+     "standing instructions"),
 ]
 
 # ── 2. Real capabilities that require a real action ───────────────────────────

--- a/tests/test_claim_check.py
+++ b/tests/test_claim_check.py
@@ -113,3 +113,41 @@ def test_empty_reply_is_safe():
 
 def test_note_is_empty_when_nothing_to_correct():
     assert cc.correction_note([]) == ""
+
+
+# ── stative phrasing (caught live, 2026-07-21, after the first version shipped) ─
+def test_stative_phrasing_is_caught():
+    """The model dodged every first-person verb and made the same false claim:
+    "The 10-point instruction set is active... locked in for all file and code
+    operations." A guard that only catches one phrasing is theater."""
+    real = ("Understood. The 10-point instruction set is active.\n\n"
+            "I have parsed the constraints, specifically the Verification Lever "
+            "(Point 5) rules, which override default behavior. The rules "
+            "(Points 4, 8, 9) are locked in for all file and code operations.")
+    claims = cc.find_unbacked_claims(real, actions_taken=set())
+    assert claims, "the live paraphrase must be caught"
+    assert all(c.kind == "impossible" for c in claims)
+
+
+@pytest.mark.parametrize("reply", [
+    "The instruction set is active.",
+    "These rules are now in effect.",
+    "The framework is in force.",
+    "The rules are locked in for all operations.",
+    "Standing rules are applied.",
+])
+def test_stative_variants(reply):
+    assert cc.find_unbacked_claims(reply, actions_taken=set()), reply
+
+
+@pytest.mark.parametrize("reply", [
+    # "active"/"in effect"/"locked in" with no rules-noun — must stay silent
+    "Your account is active.",
+    "The service is now in effect.",
+    "The deploy is locked in for Friday.",
+    "I have parsed the CSV file.",
+    "These rules are worth writing down.",
+    "The instruction set you pasted has 10 points.",
+])
+def test_stative_false_positive_guard(reply):
+    assert cc.find_unbacked_claims(reply, actions_taken=set()) == [], reply


### PR DESCRIPTION
Found by replaying the original incident **against the guard I'd just shipped**.

The model dodged every first-person verb the patterns looked for and made the identical false claim in different grammar:

> *"The 10-point instruction set **is active**."*
> *"…are **locked in** for all file and code operations."*

Same lie about persistence. **Zero matches.** A guard that catches one phrasing and misses the common paraphrase is theater.

## Fix

Adds *rules-noun + state-of-being-in-force* patterns. Anchored to an explicit rules-noun so ordinary language can't trip them.

| Must catch | Must stay silent |
|---|---|
| "The instruction set is active" | "Your account is active" |
| "These rules are now in effect" | "The service is now in effect" |
| "The rules are locked in for all operations" | "The deploy is locked in for Friday" |
| "The framework is in force" | "I have parsed the CSV file" |

12 new tests, half of them false-positive guards. 40 claim-check tests pass.
