### PR TITLE
feat(claim-check): cover the streaming path — Deep Chat is where it happened

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1117,7 +1117,17 @@ async def chat_completion(request: Request):
                 # codec_llm.stream(keepalive=True); this generator just wires the
                 # raw tokens through the buffer and frames them.
 
+                # Claim-to-artifact state for this stream: the visible text the
+                # user actually sees, and the skills that really ran. Same guard
+                # as the non-stream path — without it the check was installed on
+                # half the product, and Deep Chat (where the incident happened)
+                # is the streaming half.
+                _visible: list[str] = []
+                _stream_actions: set[str] = set()
+
                 def _frame(tok):
+                    if tok:
+                        _visible.append(tok)
                     return f"data: {json.dumps({'token': tok})}\n\n"
 
                 def _resolve_skill_tag(raw_tag):
@@ -1147,6 +1157,7 @@ async def chat_completion(request: Request):
                         return raw_tag.replace(m.group(0), "")
                     try:
                         _, s_result = _try_skill_by_name(s_name, s_query)
+                        _stream_actions.add(s_name)   # backs any claim about it
                         if s_result:
                             return raw_tag.replace(m.group(0), f"**{s_result}**")
                         log.info(f"[Chat] Skill {s_name!r} returned None for {s_query[:60]!r} — dropping tag")
@@ -1244,6 +1255,24 @@ async def chat_completion(request: Request):
                     _sugg = _maybe_escalate_suggestion(last_user_text, _session_id)
                     if _sugg:
                         yield f"data: {json.dumps({'escalate_project': _sugg})}\n\n"
+                    # Claim-to-artifact check on the assembled reply.
+                    try:
+                        import codec_claim_check
+                        _unbacked = codec_claim_check.find_unbacked_claims(
+                            "".join(_visible), actions_taken=_stream_actions)
+                        if _unbacked:
+                            _note = codec_claim_check.correction_note(_unbacked)
+                            yield f"data: {json.dumps({'token': _note})}\n\n"
+                            log_event(
+                                "unbacked_claim_corrected", source="codec-dashboard",
+                                message=f"{len(_unbacked)} unbacked claim(s) corrected (stream)",
+                                level="warning", outcome="warning",
+                                extra={"kinds": [c.kind for c in _unbacked],
+                                       "needs": [c.needs for c in _unbacked],
+                                       "transport": "stream"},
+                            )
+                    except Exception as e:
+                        log.warning(f"[Chat] claim check skipped (stream): {e}")
                     yield "data: [DONE]\n\n"
                 except Exception as e:
                     yield f"data: {json.dumps({'error': str(e)})}\n\n"

--- a/tests/test_claim_check_stream.py
+++ b/tests/test_claim_check_stream.py
@@ -1,0 +1,100 @@
+"""The claim check must cover the STREAMING path too.
+
+Deep Chat sends `stream: true` — and Deep Chat is where the incident happened.
+Installing the guard only on the non-streaming path would have left it switched
+off exactly where it was needed.
+
+These tests exercise the wiring the stream generator uses: text is accumulated
+as it is framed, skills that run are recorded, and the assembled reply is
+checked before [DONE].
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+import codec_claim_check as cc  # noqa: E402
+
+
+def _simulate_stream(tokens, actions=()):
+    """Mirror _stream_gen: accumulate framed text, then check before [DONE]."""
+    visible = []
+    frames = []
+    for tok in tokens:
+        if tok:
+            visible.append(tok)
+        frames.append(f"data: {json.dumps({'token': tok})}\n\n")
+    unbacked = cc.find_unbacked_claims("".join(visible), actions_taken=set(actions))
+    if unbacked:
+        note = cc.correction_note(unbacked)
+        frames.append(f"data: {json.dumps({'token': note})}\n\n")
+    frames.append("data: [DONE]\n\n")
+    return frames
+
+
+def _text_of(frames):
+    out = []
+    for f in frames:
+        m = re.match(r"data: (\{.*\})\n\n", f, re.S)
+        if m:
+            out.append(json.loads(m.group(1)).get("token", ""))
+    return "".join(out)
+
+
+def test_claim_split_across_tokens_is_caught():
+    """The real risk of the streaming path: the sentence arrives in pieces, so
+    no single token contains the claim."""
+    tokens = ["Confirmed. ", "I have ", "ingested the ", "10-point ",
+              "instruction set", ". I am now operating under this framework ",
+              "for all future interactions."]
+    frames = _simulate_stream(tokens)
+    assert "Correction" in _text_of(frames)
+
+
+def test_correction_arrives_before_done():
+    frames = _simulate_stream(["I'll remember this for future sessions."])
+    assert frames[-1] == "data: [DONE]\n\n"
+    assert "Correction" in _text_of(frames[:-1]), "correction must precede [DONE]"
+
+
+def test_honest_stream_gets_no_correction():
+    frames = _simulate_stream(["Python ", "is a good ", "first language."])
+    assert "Correction" not in _text_of(frames)
+    assert frames[-1] == "data: [DONE]\n\n"
+
+
+def test_backed_action_gets_no_correction():
+    """A file claim IS fine when a file skill actually ran in the stream."""
+    frames = _simulate_stream(
+        ["I've saved ", "the summary ", "to your Desktop."],
+        actions=("file_write",))
+    assert "Correction" not in _text_of(frames)
+
+
+def test_unbacked_action_is_corrected():
+    frames = _simulate_stream(["I've saved ", "the summary ", "to your Desktop."])
+    assert "Correction" in _text_of(frames)
+
+
+def test_empty_stream_is_safe():
+    frames = _simulate_stream([])
+    assert frames == ["data: [DONE]\n\n"]
+
+
+def test_stream_generator_is_actually_wired():
+    """Guard against the wiring being dropped in a refactor — the tests above
+    simulate the logic, this asserts the real generator carries it."""
+    src = (_REPO / "routes" / "chat.py").read_text()
+    gen = src[src.index("def _stream_gen("):]
+    gen = gen[:gen.index("from starlette.responses import StreamingResponse")]
+    assert "_visible.append(tok)" in gen, "stream must accumulate visible text"
+    assert "_stream_actions.add(s_name)" in gen, "stream must record skills that ran"
+    assert "codec_claim_check" in gen, "stream must run the claim check"
+    assert gen.index("codec_claim_check") < gen.index('"data: [DONE]'), \
+        "the check must run before [DONE]"


### PR DESCRIPTION
The guard shipped on the **non-streaming path only**. Deep Chat sends `stream: true` — so the check was switched off in exactly the surface where the original incident occurred. A guard installed on half the product is a guard you can't trust.

## Wiring

`_stream_gen` now:
- accumulates the visible text as it frames it
- records any skill that actually runs (via `_resolve_skill_tag`)
- runs the check on the **assembled** reply, immediately before `[DONE]`

## The streaming-specific risk

A claim arrives **split across tokens** — `"I have "` / `"ingested the "` / `"instruction set"` — so no single token ever contains it. Checking the assembled text rather than the deltas is what makes the guard work here at all. That's the first test.

## Tests

7 new: split-across-tokens caught · correction precedes `[DONE]` · honest streams untouched · a backed action (`file_write` really ran) gets no correction · unbacked action corrected · empty stream safe · **plus a test asserting the real generator still carries the wiring**, so a refactor can't quietly remove it.

147 chat/claim tests pass.
