### PR TITLE
fix(tests): stop staging fake skills into the operator's real review queue

### DIFF
--- a/tests/test_skill_routes.py
+++ b/tests/test_skill_routes.py
@@ -10,6 +10,7 @@ import inspect
 import sys
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -54,6 +55,22 @@ def test_replacement_handlers_present():
 
 
 # ── Live TestClient checks (verify the FastAPI app behavior) ──────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_reviews(tmp_path, monkeypatch):
+    """Stage reviews into a tmp dir, never the user's real ~/.codec.
+
+    routes/skills.py deliberately exposes _reviews_dir() as a FUNCTION "so tests
+    can monkeypatch it to a tmp dir for isolation" — but nothing did, so every
+    run of this file wrote a live `test_review.py` into the operator's Skills
+    review queue. Six had piled up before anyone noticed; three of them landed
+    in a single afternoon of test runs.
+    """
+    d = tmp_path / "skill_reviews"
+    d.mkdir()
+    monkeypatch.setattr(skills_routes, "_reviews_dir", lambda: str(d))
+    return d
 
 
 def _make_client() -> TestClient:


### PR DESCRIPTION
Mickael noticed "weird looking skill creation requests" piling up in the Skills tab. They weren't weird — they were **ours**.

`test_skill_routes` posts to `/api/skill/review` through a TestClient, and the handler writes to `~/.codec/skill_reviews` — the **real** one. Every suite run left a live `test_review.py` awaiting human approval. Six had accumulated; **three landed in one afternoon** of test runs while preparing the demo.

The irony: `routes/skills.py` anticipated this exactly —

```python
def _reviews_dir() -> str:
    """...A function (not a constant) so tests can monkeypatch it to a tmp dir
    for isolation."""
```

Nothing ever did. An autouse fixture now points it at `tmp_path`.

**Verified:** real review count 6 before the suite, 6 after — previously +1 per run. The 6 stale artifacts were cleared through the app's own reject endpoint (not by deleting files behind its back); only the genuine `moon_phase.py` remains.