### PR TITLE
docs: finish the v3.5 Pilot unhook — correct repo pointers, drop stale claims + client domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.5.0 (2026-07-22)
 ### Changed
-- **CODEC Pilot parked.** The browser-automation pillar is withdrawn from the product: the Pilot tab is removed from the dashboard and its product card from the Cortex map. Pilot needs a far deeper build than the rest of CODEC to be trustworthy — Google blocks account sign-in from any CDP-controlled browser (not a setting we can change), and cookie walls plus bot challenges make a large share of real sites unusable. The code is parked, not deleted: the skill, route proxy, and PM2 runner were unhooked from the repo and preserved in git history (see `docs/PILOT-PARKED.md`), so it can return when it earns its place.
+- **CODEC Pilot parked.** The browser-automation pillar is withdrawn from the product: the Pilot tab is removed from the dashboard and its product card from the Cortex map. Pilot needs a far deeper build than the rest of CODEC to be trustworthy — Google blocks account sign-in from any CDP-controlled browser (not a setting we can change), and cookie walls plus bot challenges make a large share of real sites unusable. The code is parked, not deleted: the skill, route proxy, vendored copy, and PM2 entry were unhooked from this repo, and the engine lives on in the separate `AVADSA25/codec-pilot` repo (see `docs/PILOT-PARKED.md`), so it can return when it earns its place.
 - **CODEC Project folded into CODEC Overview.** Project mode is a capability of the dashboard rather than a product in its own right. No functionality changes — plan → approve → autonomous run all work exactly as before.
 - **9 products → 7.** Core · Dictate · Instant · Chat · Vibe · Voice · Overview.
 
@@ -33,7 +33,7 @@
 ## v3.1.0 (2026-05-25)
 ### Security
 - **Pilot security-hardening wave (PP-1…PP-12)** — full adversarial audit remediation of the browser-automation pillar. AST safety gate at skill-approval time (`skill_review.py` refuses to activate dangerous compiled skills), untrusted-input fencing on the LLM selector-rescue prompt (`replay.py` `build_rescue_prompt` / `wrap_untrusted` so page text can't redirect element selection), irreversible-click blocking on replay unless `PILOT_ALLOW_DESTRUCTIVE=1`, path/glob-traversal neutralization in `slugify()` lookups, and a forensic audit trail (`audit()`) on every skill write/approve/reject/block.
-- **`pilot.lucyvpa.com` tunnel removed** from the Cloudflare ingress after an RCE finding — Pilot is local-only again pending re-hardening.
+- **Pilot tunnel removed** from the Cloudflare ingress after an RCE finding — Pilot is local-only again pending re-hardening.
 
 ### Added
 - **Conversational continuity in Project mode** — a Project-mode chat thread now binds to the agent it drafts (`_activeAgentId`). Follow-up messages route to that running agent (status queries, mid-run instructions) instead of spawning a duplicate project. Pulsing "Talking to …" chip with one-click exit; auto-clears on terminal status.
@@ -73,7 +73,7 @@
   - Recent Runs with inline ▶ Replay and 💾 Compile buttons per row
   - Pending Skills panel with source preview, ✓ Approve / ✕ Reject gate
   - HITL pause/resume controls on selected run detail
-- **Cloudflare tunnel exposure** — `pilot.lucyvpa.com` mapped to `localhost:8094` for off-LAN dashboard access
+- **Cloudflare tunnel exposure** — a Pilot hostname mapped to `localhost:8094` for off-LAN dashboard access
 - **PM2 service `pilot-runner`** added to `ecosystem.config.js` (autorestart, 2GB memory cap, isolated log files)
 - **Approved skills auto-expose as MCP tools** — generated `pilot_{slug}.py` files carry `SKILL_NAME`/`SKILL_DESCRIPTION`/`SKILL_TAGS` metadata, registered by CODEC's SkillRegistry, callable from voice / Chat / Scheduler / Claude Code / Cursor / VS Code
 

--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -79,7 +79,7 @@
 
 ## Cut from the demo
 - **Compare across models** (ex-beat 21) — removed 2026-07-21: needs a licensed machine (AVA cloud) to show 3+ columns; on an unlicensed Mac it shows one and makes no comparison.
-- **CODEC Pilot** (ex-beat 13) — parked 2026-07-22, unhooked from production in v3.5. Google blocks account sign-in from any CDP-controlled browser, and cookie walls / bot challenges make a large share of real sites unusable. It needs a far deeper build to be trustworthy; the code is preserved in git history (see `docs/PILOT-PARKED.md`), not deleted.
+- **CODEC Pilot** (ex-beat 13) — parked 2026-07-22, unhooked from production in v3.5. Google blocks account sign-in from any CDP-controlled browser, and cookie walls / bot challenges make a large share of real sites unusable. It needs a far deeper build to be trustworthy; the engine is preserved in the separate `codec-pilot` repo (see `docs/PILOT-PARKED.md`), not deleted.
 - **Live webcam vision** (ex-beat 8) — removed 2026-07-16. The capture was soft (the Anker C200's lens, not code) and it landed as a gadget rather than a capability. Nothing else depends on it.
 
 ## Decide before filming

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,19 +11,22 @@ those are concrete engine components rather than separate products.
 
 **v2.3 adds Phase 1 (audit + plugin substrate), Phase 2 (continuous
 observation + automation), Phase 3 (drop-a-project autonomous agents),
-Phase 3.5 (UX polish + proactive overlay), and CODEC Pilot (the 8th product
-— browser automation you can teach)** — sections 10–14 below.
+Phase 3.5 (UX polish + proactive overlay), and CODEC Pilot (then an 8th
+product — browser automation you can teach; **parked in v3.5**)** — sections
+10–14 below.
 
 Phase 3 ships `codec-agent-runner`, the autonomous-agent daemon that makes
 CODEC a "real AI employee" at the substrate level — drop a project, agent
 plans + builds + sends updates back proactively, with permission gates
 and resume-after-restart guarantees throughout.
 
-CODEC Pilot ships the 8th product slot: a dedicated headless Chromium driven
-by Qwen, record-by-doing teach mode, deterministic XPath → CSS → LLM-rescue
-replay, and an approval gate that protects the SkillRegistry from
-prompt-injection-spawned skills. With Project promoted to product #9 in this
-release, CODEC is now a **9-product system**.
+CODEC Pilot shipped the 8th product slot in v2.3: a dedicated headless Chromium
+driven by Qwen, record-by-doing teach mode, deterministic XPath → CSS →
+LLM-rescue replay, and an approval gate that protects the SkillRegistry from
+prompt-injection-spawned skills. Project was promoted to product #9 in the same
+release, making CODEC a 9-product system at the time. **As of v3.5 that is no
+longer the shape:** Pilot is parked (§14) and Project folded into CODEC
+Overview, so CODEC ships as a **7-product system**.
 
 ---
 
@@ -496,7 +499,7 @@ notification dispatch.
 > challenges make a large share of real sites unusable. The code is preserved in the `codec-pilot` repo.
 > The inventory below is kept for reference and is **not** counted in CODEC's feature total.
 
-The 8th product — a complete browser-automation pillar with a dedicated headless Chromium, ReAct-style agent loop driven by Qwen, deterministic record-replay with selector fallback, a skill approval gate, and human-in-the-loop takeover. Lives in `~/codec/pilot/` (11 modules), runs as `pilot-runner` on PM2 port 8094.
+Formerly the 8th product — a complete browser-automation pillar with a dedicated headless Chromium, ReAct-style agent loop driven by Qwen, deterministic record-replay with selector fallback, a skill approval gate, and human-in-the-loop takeover. The engine now lives in the separate `AVADSA25/codec-pilot` repo (11 modules); its `pilot-runner` PM2 service and `:8094` port were retired from this stack in v3.5.
 
 ### Browser substrate (5 features)
 
@@ -573,8 +576,8 @@ The 8th product — a complete browser-automation pillar with a dedicated headle
 ### Live view + infrastructure (3 features bundled)
 
 - **MJPEG live stream** at `/screenshot/stream` — ~3 fps multipart feed, ~350 KB/s; falls back to 2-second polling on disconnect
-- **30 HTTP endpoints** on `pilot-runner` (FastAPI, port 8094) with CORS enabled for `codec.lucyvpa.com` cross-origin calls
-- **Cloudflare tunnel** at `pilot.lucyvpa.com` for off-LAN dashboard access; PM2 service `pilot-runner` with autorestart + isolated log files
+- **30 HTTP endpoints** on `pilot-runner` (FastAPI, port 8094) with CORS enabled for the dashboard origin — *retired in v3.5*
+- **Cloudflare tunnel** for off-LAN dashboard access — removed in v3.1 after an RCE finding; the `pilot-runner` PM2 service was retired in v3.5
 
 ---
 
@@ -615,7 +618,7 @@ The 8th product — a complete browser-automation pillar with a dedicated headle
 **The 9th product + adversarial-hardening release.** CODEC Project promoted to a live product, Pilot security-hardened end-to-end, calmer 2026 palette across the dashboard.
 
 - **9 products. One system.** Cortex neural map expanded from 28 → 38 nodes (+31 edges); CODEC Pilot and CODEC Project added as live product cards.
-- **Pilot security-hardening wave (PP-1…PP-12)** — full adversarial-audit remediation: AST safety gate at skill-approval time (refuses to activate dangerous compiled skills), untrusted-input fencing on the LLM selector-rescue prompt (page text can't redirect element selection), irreversible-click blocking on replay unless `PILOT_ALLOW_DESTRUCTIVE=1`, path/glob-traversal neutralization in `slugify()` lookups, forensic audit trail on every skill write/approve/reject/block. The `pilot.lucyvpa.com` Cloudflare tunnel was removed after the RCE finding — Pilot is local-only.
+- **Pilot security-hardening wave (PP-1…PP-12)** — full adversarial-audit remediation: AST safety gate at skill-approval time (refuses to activate dangerous compiled skills), untrusted-input fencing on the LLM selector-rescue prompt (page text can't redirect element selection), irreversible-click blocking on replay unless `PILOT_ALLOW_DESTRUCTIVE=1`, path/glob-traversal neutralization in `slugify()` lookups, forensic audit trail on every skill write/approve/reject/block. The Pilot Cloudflare tunnel was removed after the RCE finding — Pilot is local-only.
 - **Conversational continuity in Project mode** — a Project-mode chat thread now binds to the agent it drafts; follow-ups route to the running agent instead of spawning duplicates. Pulsing *"Talking to …"* chip with one-click exit.
 - **Voice in / voice out** — Kokoro TTS now actually speaks assistant replies when *"Voice Replies"* is on (the toggle was previously inert); per-message Speak button; Pilot tab gets its own 🎤 dictate + 🔊 speak controls.
 - **Live preview panel** — slide-out shows the most-recently-modified files in a running agent's project folder (5s poll), so you can watch output appear without leaving the chat.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://github.com/AVADSA25/codec/actions/workflows/ci.yml"><img src="https://github.com/AVADSA25/codec/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
   <a href="https://github.com/AVADSA25/codec/discussions"><img src="https://img.shields.io/badge/community-Discussions-7057ff?style=flat-square&logo=github" alt="GitHub Discussions"/></a>
   <a href="FEATURES.md"><img src="https://img.shields.io/badge/features-370-blue?style=flat-square" alt="370 Features"/></a>
-  <img src="https://img.shields.io/badge/skills-76-orange?style=flat-square" alt="76 Skills"/>
+  <img src="https://img.shields.io/badge/skills-89-orange?style=flat-square" alt="89 Skills"/>
   <img src="https://img.shields.io/badge/tests-2000+-green?style=flat-square" alt="2,000+ Tests"/>
   <img src="https://img.shields.io/badge/lines-52K+-purple?style=flat-square" alt="52K+ Lines"/>
   <img src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square" alt="MIT License"/>
@@ -703,7 +703,7 @@ setup_codec.py        — Setup wizard (9 steps)
 ecosystem.config.js   — PM2 process management (16 services)
 ```
 
-**CODEC Pilot** is parked (v3.5) and no longer part of the product. Its code, skill, route proxy, and PM2 service were unhooked from this repo in v3.5 and preserved in git history (see [docs/PILOT-PARKED.md](docs/PILOT-PARKED.md)).
+**CODEC Pilot** is parked (v3.5) and no longer part of the product. Its skill, route proxy, vendored copy, and PM2 entry were unhooked from this repo in v3.5; the engine itself lives on in the separate `AVADSA25/codec-pilot` repo (see [docs/PILOT-PARKED.md](docs/PILOT-PARKED.md)).
 
 ---
 
@@ -743,7 +743,7 @@ python3 setup_codec.py
 
 > **Project mode** (drop-a-project autonomy) is live and ships as part of **CODEC Overview**.
 >
-> **CODEC Pilot** (browser automation) is **parked as of v3.5.** Google blocks account sign-in from any CDP-controlled browser, and cookie walls plus bot challenges make a large share of real sites unusable — it needs a considerably deeper build before it can be trusted as a product. The code is preserved in git history (see [docs/PILOT-PARKED.md](docs/PILOT-PARKED.md)) rather than deleted.
+> **CODEC Pilot** (browser automation) is **parked as of v3.5.** Google blocks account sign-in from any CDP-controlled browser, and cookie walls plus bot challenges make a large share of real sites unusable — it needs a considerably deeper build before it can be trusted as a product. The engine is preserved in the separate `AVADSA25/codec-pilot` repo (see [docs/PILOT-PARKED.md](docs/PILOT-PARKED.md)) rather than deleted.
 
 **Phase 3.5 (in progress)** — UX + polish on top of the autonomous-agent substrate:
 

--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -359,7 +359,7 @@ from routes.vision import router as vision_router
 from routes.vibe_exec import router as vibe_exec_router
 from routes.web_search import router as web_search_router
 from routes.cdp import router as cdp_router
-# G-series (SR-57..58): cross-source memory search + Pilot proxy.
+# G-series (SR-57..58): cross-source memory search.
 from routes.memory_search import router as memory_search_router
 from routes.mcp import router as mcp_router
 # H1 / SR-59: chat handler (POST /api/chat) + its helper cluster. The helpers
@@ -817,7 +817,6 @@ async def tasks_page():
             return HTMLResponse(f.read(), headers=_NO_CACHE)
     return HTMLResponse("<h1>Tasks page not found</h1>", status_code=500)
 
-# G2 pilot_proxy → moved to routes/*.py
 # C3 / SR-38: cortex endpoints moved to routes/cortex.py.
 
 


### PR DESCRIPTION
Follow-up to #302, clearing the last Pilot references. Three things.

### 1. A correction to #302
#302 rewrote "the code lives in the `codec-pilot` repo" into "preserved in git history", on the belief the repo didn't exist. **It does** — `AVADSA25/codec-pilot` holds the pilot-runner engine (checked out at `~/codec`, last commit *"docs: mark CODEC Pilot as development-parked"*). I removed a true statement. Restored an accurate one in README (×2), CHANGELOG, and DEMO_SCRIPT:

> the skill, route proxy, vendored copy, and PM2 entry were unhooked from **this** repo; the engine lives on in `AVADSA25/codec-pilot`.

### 2. Stale breadcrumbs
`codec_dashboard.py` still carried `# G2 pilot_proxy → moved to routes/*.py` and a "+ Pilot proxy" header note. `pilot_proxy` was **deleted**, not moved. Both dropped. (Comments only — no runtime effect.)

### 3. Stale public claims + client domains in FEATURES.md
- Intro still asserted a live **"9-product system"** and called Pilot "the 8th product" in present tense → now framed as v2.3 history with the v3.5 shape (**7 products**) stated plainly.
- §14 described Pilot as running on `pilot-runner` `:8094` *in this stack* → retired in v3.5.
- **The repo is public and must not name a client domain.** The dead Pilot infra lines named `codec.lucyvpa.com` / `pilot.lucyvpa.com`. Genericized there and in the two historical CHANGELOG entries.
- README skills badge read **76** (the MCP-exposed subset) while FEATURES.md says **89** built-in → badge now 89. In-text "76 skills" in MCP-server context is correct and left alone.

**Deliberately NOT touched:** `lucyvpa` references that are *live infrastructure* — `codec_ava_client` proxy URL, the dashboard CORS origin, `codec_mcp_http` host, the license alias, PRIVACY.md. Those still resolve and belong to roadmap R5 (brand separation), not a docs PR.

Security blocklists naming the `pilot` skill (`codec_consent`, `codec_voice`, `codec_mcp`, `codec_bridges`, `codec_agent_runner`, `codec_license`) are also left in place on purpose: blocking a now-absent skill costs nothing and keeps it blocked if Pilot ever returns.

### Verification
- **2730 passed, 78 skipped**; `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)