### PR TITLE
fix(chat): copy button never copied anything — inline onclick died on apostrophes

### DIFF
--- a/codec_chat.html
+++ b/codec_chat.html
@@ -549,17 +549,35 @@ var webSearchEnabled=false;
 var thinkingEnabled=true;
 
 function showToast(msg){var t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');setTimeout(function(){t.classList.remove('show')},1800)}
+// execCommand fallback for when navigator.clipboard is unavailable — it is
+// undefined on any non-secure origin, so plain-http LAN access (http://<ip>:8090)
+// lands here even though the Cloudflare HTTPS host does not.
+// iOS Safari needs all three of: contentEditable, a Range selection (plain
+// .select() is ignored), and NO pointer-events:none — that last one silently
+// blocks the selection, which is why the old fallback never worked on the phone.
+// 16px font-size stops iOS from zooming the viewport while the node is focused.
 function _copyFallback(text){
   try{
     var ta=document.createElement('textarea');
     ta.value=text;
-    ta.setAttribute('readonly','');
+    ta.contentEditable='true';
+    ta.readOnly=false;
     ta.style.position='fixed';
     ta.style.top='0';ta.style.left='0';
-    ta.style.opacity='0';ta.style.pointerEvents='none';
+    ta.style.width='1px';ta.style.height='1px';
+    ta.style.padding='0';ta.style.border='none';ta.style.outline='none';
+    ta.style.boxShadow='none';ta.style.background='transparent';
+    ta.style.fontSize='16px';
+    ta.style.opacity='0';
     document.body.appendChild(ta);
-    ta.focus();ta.select();ta.setSelectionRange(0,ta.value.length);
+    var sel=window.getSelection();
+    var range=document.createRange();
+    range.selectNodeContents(ta);
+    sel.removeAllRanges();sel.addRange(range);
+    ta.setSelectionRange(0,ta.value.length);
+    ta.focus();
     var ok=document.execCommand('copy');
+    sel.removeAllRanges();
     document.body.removeChild(ta);
     return ok;
   }catch(e){return false}
@@ -952,15 +970,29 @@ function addMessage(role,content,animate){
   div.className='msg '+role;
   if(animate===false)div.style.animation='none';
   var time=new Date().toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'});
-  var enc=encodeURIComponent(content);
-  var copyBtn='<button class="msg-act msg-copy" onclick="copyMsgText(decodeURIComponent(\''+enc+'\'),this)" title="Copy"><svg class="ico ico-sm" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>';
-  var editBtn=role==='user'?'<button class="msg-act msg-edit" onclick="editMessage(decodeURIComponent(\''+enc+'\'),this)" title="Edit &amp; re-send"><svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>':'';
+  // Message text is NEVER embedded in an inline onclick. encodeURIComponent does
+  // NOT escape apostrophes — "'" is an unreserved mark, so it survives untouched
+  // and "don't" still terminated the JS string literal, killing the handler with a
+  // SyntaxError. The click then silently did nothing, on every message containing
+  // an apostrophe (i.e. most of them), on desktop AND phone — the PWA's Chat link
+  // serves this same file. Buttons are emitted bare and bound below via closures,
+  // which needs no escaping and makes message content non-executable by design.
+  // Same contract as bindCopyButtons() in codec_dashboard.html.
+  var copyBtn='<button class="msg-act msg-copy" data-act="copy" title="Copy"><svg class="ico ico-sm" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>';
+  var editBtn=role==='user'?'<button class="msg-act msg-edit" data-act="edit" title="Edit &amp; re-send"><svg class="ico ico-sm" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>':'';
   var regenBtn=role==='assistant'?'<button class="msg-act msg-regen" onclick="regenerateResponse(this)" title="Regenerate"><svg class="ico ico-sm" viewBox="0 0 24 24"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg></button>':'';
   // ── Speak button per assistant message — manual TTS playback regardless of global toggle
-  var speakBtn=role==='assistant'?'<button class="msg-act msg-speak" onclick="speakMessage(decodeURIComponent(\''+enc+'\'),this)" title="Speak"><svg class="ico ico-sm" viewBox="0 0 24 24"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg></button>':'';
+  var speakBtn=role==='assistant'?'<button class="msg-act msg-speak" data-act="speak" title="Speak"><svg class="ico ico-sm" viewBox="0 0 24 24"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg></button>':'';
   // One inline action row beneath the bubble: timestamp + regenerate / edit / copy / speak (role-gated)
   var actions=regenBtn+editBtn+copyBtn+speakBtn;
   div.innerHTML='<div class="msg-bubble">'+formatMsg(content)+'</div><div class="msg-meta"><span class="msg-time">'+time+'</span>'+actions+'</div>';
+  // Bind the action buttons to the raw text via a closure — see the note above.
+  (function(host,txt){
+    var b;
+    if((b=host.querySelector('[data-act="copy"]')))b.addEventListener('click',function(){copyMsgText(txt,b)});
+    if((b=host.querySelector('[data-act="edit"]')))b.addEventListener('click',function(){editMessage(txt,b)});
+    if((b=host.querySelector('[data-act="speak"]')))b.addEventListener('click',function(){speakMessage(txt,b)});
+  })(div,String(content));
   document.getElementById('messages').appendChild(div);
   scrollBottom();
   // ── Auto-speak via Kokoro when global "Voice Replies" toggle is ON

--- a/codec_dashboard.html
+++ b/codec_dashboard.html
@@ -892,21 +892,38 @@ function showToast(msg) {
 // modern API is unavailable (HTTP non-localhost) or the promise rejects
 // (permissions, focus loss, etc.). Always surfaces a toast — success or
 // failure — so the click is never silent.
+// iOS Safari needs contentEditable + a Range selection (plain .select() is
+// ignored), and must NOT have pointer-events:none — that silently blocks the
+// selection, so the fallback returned false on every phone. 16px font-size stops
+// iOS zooming the viewport while the node is focused. Mirrors codec_chat.html.
 function _copyFallback(text) {
   try {
     var ta = document.createElement('textarea');
     ta.value = text;
-    ta.setAttribute('readonly', '');
+    ta.contentEditable = 'true';
+    ta.readOnly = false;
     ta.style.position = 'fixed';
     ta.style.top = '0';
     ta.style.left = '0';
+    ta.style.width = '1px';
+    ta.style.height = '1px';
+    ta.style.padding = '0';
+    ta.style.border = 'none';
+    ta.style.outline = 'none';
+    ta.style.boxShadow = 'none';
+    ta.style.background = 'transparent';
+    ta.style.fontSize = '16px';
     ta.style.opacity = '0';
-    ta.style.pointerEvents = 'none';
     document.body.appendChild(ta);
-    ta.focus();
-    ta.select();
+    var sel = window.getSelection();
+    var range = document.createRange();
+    range.selectNodeContents(ta);
+    sel.removeAllRanges();
+    sel.addRange(range);
     ta.setSelectionRange(0, ta.value.length);
+    ta.focus();
     var ok = document.execCommand('copy');
+    sel.removeAllRanges();
     document.body.removeChild(ta);
     return ok;
   } catch (e) {

--- a/tests/test_copy_button_binding.py
+++ b/tests/test_copy_button_binding.py
@@ -1,0 +1,76 @@
+"""Copy / edit / speak buttons must never carry message text in an inline onclick.
+
+Regression guard for a bug that survived one "fix" and kept being reported.
+
+`encodeURIComponent()` does NOT escape an apostrophe — "'" is an unreserved mark
+(A-Z a-z 0-9 - _ . ! ~ * ' ( )), so it passes through untouched. Embedding the
+result in a single-quoted JS string inside an HTML attribute therefore still
+breaks on the first apostrophe:
+
+    onclick="copyMsgText(decodeURIComponent('I don't know'),this)"
+
+That is a SyntaxError, so the handler never runs and the click silently does
+nothing. Most sentences contain an apostrophe, which is why it presented as
+"the copy button never works" on desktop AND phone — the PWA's Chat link serves
+codec_chat.html too.
+
+The contract: buttons are emitted bare and bound with addEventListener over a
+closure. No escaping, and message content can never become executable.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# Files that render user/assistant message text with action buttons.
+HTML_FILES = ["codec_chat.html", "codec_dashboard.html", "codec_vibe.html", "codec_voice.html"]
+
+# The broken shape: an inline handler that decodes data back into a JS string.
+_INLINE_DATA_HANDLER = re.compile(r"""on\w+\s*=\s*["'][^"']*decodeURIComponent\s*\(""")
+
+
+@pytest.mark.parametrize("name", HTML_FILES)
+def test_no_message_text_embedded_in_inline_handler(name):
+    """No inline on*= handler may reconstruct message text via decodeURIComponent."""
+    path = REPO / name
+    if not path.exists():
+        pytest.skip(f"{name} not present")
+    hits = _INLINE_DATA_HANDLER.findall(path.read_text(encoding="utf-8"))
+    assert not hits, (
+        f"{name}: message text embedded in an inline handler ({len(hits)} site(s)). "
+        "encodeURIComponent does not escape apostrophes, so this breaks on \"don't\". "
+        "Emit a bare button and bind it with addEventListener over a closure."
+    )
+
+
+def test_chat_binds_actions_by_closure():
+    """codec_chat.html binds copy/edit/speak via data-act + addEventListener."""
+    src = (REPO / "codec_chat.html").read_text(encoding="utf-8")
+    for act in ("copy", "edit", "speak"):
+        assert f'data-act="{act}"' in src, f"missing bare button for data-act={act}"
+        assert re.search(
+            rf"""querySelector\(\s*['"]\[data-act="{act}"\]['"]\s*\)""", src
+        ), f"data-act={act} button is never bound by closure"
+    assert "addEventListener('click'" in src
+
+
+@pytest.mark.parametrize("name", ["codec_chat.html", "codec_dashboard.html"])
+def test_copy_fallback_is_ios_capable(name):
+    """The execCommand fallback must be usable on iOS Safari.
+
+    navigator.clipboard is undefined on any non-secure origin, so plain-http LAN
+    access falls back here. iOS needs contentEditable + a Range selection, and
+    pointer-events:none silently blocks the selection.
+    """
+    src = (REPO / name).read_text(encoding="utf-8")
+    start = src.index("function _copyFallback")
+    body = src[start : start + 1400]
+    assert "contentEditable" in body, f"{name}: iOS needs contentEditable on the copy node"
+    assert "createRange" in body, f"{name}: iOS ignores .select(); a Range selection is required"
+    assert not re.search(r"pointerEvents\s*=\s*['\"]none['\"]", body), (
+        f"{name}: pointer-events:none blocks the iOS selection and breaks the fallback"
+    )


### PR DESCRIPTION
Reported many times, on **phone and desktop**, for both user and assistant messages. Here's why it kept surviving "fixes".

### Root cause
`encodeURIComponent()` **does not escape an apostrophe** — `'` is an unreserved mark (`A-Z a-z 0-9 - _ . ! ~ * ' ( )`), so it passes through untouched:

```
encodeURIComponent("I don't know")  ->  I%20don't%20know
```

That was embedded in a single-quoted JS string inside an HTML attribute, which the apostrophe terminates:

```html
onclick="copyMsgText(decodeURIComponent('I don't know'),this)"
→ SyntaxError: missing ) after argument list
```

The handler never parsed, so **the click silently did nothing**. Most sentences contain an apostrophe — hence "never works."

### Why it looked device-independent
The PWA's **Chat** nav link serves `/chat` → the same `codec_chat.html`. Phone and desktop were hitting one identical defect. `codec_dashboard.html` had already been converted to `bindCopyButtons()`; `codec_chat.html` never was — and its **copy, edit and speak** buttons all shared the broken pattern.

### Fix
Emit bare buttons carrying only `data-act`, then bind with `addEventListener` over a closure on the raw text. No escaping anywhere, and message content can no longer become executable — the old form was also an injection surface.

### Second, independent defect (mobile)
The `execCommand` fallback — reached whenever `navigator.clipboard` is unavailable, which is **any non-secure origin**, so plain-http LAN access lands there — set `pointer-events:none` (silently blocks the iOS selection) and used `.select()` (iOS ignores it). Hardened in **both** files: `contentEditable` + Range selection, no `pointer-events:none`, 16px font-size to stop viewport zoom.

### Verification
jsdom harness driving the real markup:

```
PASS  "I don't know"
PASS  "Here's a 'quoted' word and a \"double\" one"
PASS  "Ligne avec apostrophe: l'été, c'est fini"
PASS  "multi\nline\ntext with don't"
PASS  "</script><img src=x onerror=alert(1)>  don't"
PASS  "plain text no punctuation"
6/6 clicked -> exact text delivered

old implementation, same input -> SyntaxError (click did nothing)
```

- Inline JS of both files syntax-checked with `node --check`
- `tests/test_copy_button_binding.py` (7 tests) locks the contract — **confirmed to fail against the original markup**, so it's a real guard, not a rubber stamp
- Full suite: **2737 passed, 78 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)