### PR TITLE
feat(models): switch the local LLM from chat or voice, one model resident at a time

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Sovereign AI Workstation — Full Product Breakdown
 
-> Engine: **CODEC v3.5** — 370 features · 89 skills · 2000+ tests · 52K+ lines of production code · 7 products
+> Engine: **CODEC v3.5** — 370 features · 90 skills · 2000+ tests · 52K+ lines of production code · 7 products
 
 The product name is **Sovereign AI Workstation**. Throughout this document
 and the codebase, **CODEC** refers to the underlying open-source engine /

--- a/codec_chat.html
+++ b/codec_chat.html
@@ -356,6 +356,9 @@ input[type=file]{display:none}
 </button>
 <button class="mode-btn" onclick="setMode('research')" id="modeResearchBtn"><svg class="ico" viewBox="0 0 24 24" style="width:14px;height:14px"><rect x="4" y="4" width="16" height="16" rx="2"/><circle cx="9" cy="10" r="1.5" fill="currentColor" stroke="none"/><circle cx="15" cy="10" r="1.5" fill="currentColor" stroke="none"/><path d="M9 15h6"/></svg>Agents</button>
 <button class="mode-btn" onclick="setMode('project')" id="modeProjectBtn" title="Drop a project — autonomous plan-and-build mode"><svg class="ico" viewBox="0 0 24 24" style="width:14px;height:14px"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="5"/><line x1="12" y1="2" x2="12" y2="22"/><line x1="2" y1="12" x2="22" y2="12"/></svg>Project</button>
+<select id="modelSelect" onchange="switchModel()" title="Local model — switching unloads the current one and loads the new one" style="display:inline-block">
+<option value="">model…</option>
+</select>
 <select id="crewSelect">
 <option value="deep_research">🔍 Deep Research</option>
 <option value="daily_briefing">📰 Daily Briefing</option>
@@ -556,6 +559,49 @@ function showToast(msg){var t=document.getElementById('toast');t.textContent=msg
 // .select() is ignored), and NO pointer-events:none — that last one silently
 // blocks the selection, which is why the old fallback never worked on the phone.
 // 16px font-size stops iOS from zooming the viewport while the node is focused.
+
+// ── Model picker ──────────────────────────────────────────────────────────
+// All local models are served by ONE mlx_vlm.server holding a single model at a
+// time, so switching unloads the current model and loads the new one. That is a
+// real pause (~6-25s here), hence the explicit "loading" state — and why the
+// select is disabled while it runs. If the target fails to load the backend
+// restores the previous model before replying, so CODEC is never left mute.
+var _modelBusy = false;
+function loadModels(){
+  fetch('/api/models').then(function(r){return r.json()}).then(function(d){
+    var sel=document.getElementById('modelSelect'); if(!sel)return;
+    sel.innerHTML='';
+    (d.models||[]).forEach(function(m){
+      var o=document.createElement('option');
+      o.value=m.id;
+      o.textContent=m.label+(m.role?' — '+m.role:'');
+      if(m.active)o.selected=true;
+      sel.appendChild(o);
+    });
+    sel.dataset.current=d.active||'';
+  }).catch(function(){});
+}
+function switchModel(){
+  var sel=document.getElementById('modelSelect');
+  if(!sel||_modelBusy)return;
+  var target=sel.value, prev=sel.dataset.current||'';
+  if(!target||target===prev)return;
+  _modelBusy=true; sel.disabled=true;
+  var label=sel.options[sel.selectedIndex].textContent;
+  showToast('Loading '+label+'…');
+  var hdrs={'Content-Type':'application/json'};
+  var cm=document.cookie.match(/codec_csrf=([^;]+)/); if(cm)hdrs['x-csrf-token']=cm[1];
+  fetch('/api/model',{method:'POST',headers:hdrs,body:JSON.stringify({model:target})})
+    .then(function(r){return r.json()})
+    .then(function(d){
+      if(d.ok){ sel.dataset.current=d.active; showToast('Now using '+label+' ('+(d.detail||'')+')'); }
+      else { sel.value=d.active||prev; sel.dataset.current=d.active||prev;
+             showToast(d.error||'Switch failed — kept the previous model', true); }
+    })
+    .catch(function(){ sel.value=prev; showToast('Switch failed',true); })
+    .finally(function(){ _modelBusy=false; sel.disabled=false; });
+}
+
 function _copyFallback(text){
   try{
     var ta=document.createElement('textarea');
@@ -1820,6 +1866,8 @@ function updateSpeakToggle(){
 }
 setTimeout(updateSpeakToggle, 0);
 updateVoiceIcon();
+// Populate the model picker with what is on disk + which one is active.
+try{loadModels()}catch(e){}
 async function takeScreenshot(){try{window.open('/api/screenshot?'+Date.now(),'_blank')}catch(e){}}
 
 // ── Server Photo (Mac webcam) ──

--- a/codec_dashboard.py
+++ b/codec_dashboard.py
@@ -326,6 +326,7 @@ from routes.approvals import router as approvals_router
 from routes.heartbeat import router as heartbeat_router
 # C3 / SR-38: cortex endpoints extracted.
 from routes.cortex import router as cortex_router
+from routes.models import router as models_router
 # C4 / SR-39: audit endpoints extracted.
 from routes.audit import router as audit_router
 # C5 / SR-40: observer endpoint extracted.
@@ -389,6 +390,7 @@ app.include_router(agents_router)
 app.include_router(memory_router)
 app.include_router(websocket_router)
 app.include_router(notifications_router)
+app.include_router(models_router)
 app.include_router(approvals_router)
 app.include_router(heartbeat_router)
 app.include_router(cortex_router)

--- a/codec_models.py
+++ b/codec_models.py
@@ -1,0 +1,230 @@
+"""Runtime LLM model switching.
+
+CODEC serves every local model from ONE `mlx_vlm.server` on :8083. That server
+resolves the model per request (`get_cached_model(openai_request.model)`), so
+switching needs no second server and no restart — only a different `model` field.
+
+Two consequences shape this module:
+
+1. The server holds ONE model at a time. A switch UNLOADS the current model and
+   loads the new one, so a switch costs a load pause (~20-60s for a 15-20 GB
+   model) and two models can never be resident at once. Attempting to keep both
+   loaded thrashes swap and roughly halves generation speed — measured.
+
+2. If the target fails to load, the previous model is already gone and CODEC has
+   NO brain. That is why `set_active()` probes after switching and reverts to the
+   previous model when the probe fails. A bad switch must never leave the box
+   mute.
+
+The chat handler re-reads ~/.codec/config.json on every request, so writing
+`llm_model` there takes effect on the next message with no restart.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+from codec_jsonstore import atomic_write_json
+
+CONFIG_PATH = os.path.expanduser("~/.codec/config.json")
+HF_CACHE = os.path.expanduser("~/.cache/huggingface/hub")
+
+DEFAULT_MODEL = "mlx-community/Qwen3.6-35B-A3B-4bit"
+DEFAULT_BASE_URL = "http://localhost:8083/v1"
+
+# Local dirs that are not general chat models. Speech, vision-only and
+# GUI-grounding checkpoints are served on their own paths and must never appear
+# in a chat model picker.
+_NON_CHAT = ("whisper", "kokoro", "-tts-", "ui-tars", "nanollava", "embed",
+             "flux", "bge", "rerank", "stable-diffusion", "clip", "vae",
+             "sdxl", "musicgen", "parakeet")
+
+# CODEC serves MLX checkpoints from one mlx_vlm.server; anything outside the
+# mlx-community namespace (torch weights, diffusion models, embedding models)
+# cannot be loaded by it and must not be offered as a chat model.
+_REQUIRED_PREFIX = "mlx-community/"
+
+# A HF cache dir exists as soon as anything is fetched — including a bare
+# metadata stub of a few KB. Only treat a model as usable when real weights are
+# on disk, otherwise the picker offers models that cannot load.
+_MIN_WEIGHT_BYTES = 500 * 1024 * 1024
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _friendly(model_id: str) -> str:
+    return model_id.split("/")[-1].replace("-4bit", "").replace("-", " ")
+
+
+def _snapshot_bytes(cache_dir: str) -> int:
+    """Size of the newest snapshot only.
+
+    A HF cache dir can hold several revisions whose files hard/sym-link into a
+    shared blobs/ store; summing the whole tree double-counts them (Qwen3.6
+    reported 40.8 GB for a 19 GB model). Measure one revision, and resolve each
+    file to its blob so a symlink is not counted as 0 bytes.
+    """
+    snaps = os.path.join(cache_dir, "snapshots")
+    try:
+        revs = [os.path.join(snaps, d) for d in os.listdir(snaps)]
+        revs = [d for d in revs if os.path.isdir(d)]
+        newest = max(revs, key=os.path.getmtime)
+    except (OSError, ValueError):
+        return 0
+    total = 0
+    for fn in os.listdir(newest):
+        if not fn.endswith(".safetensors"):
+            continue
+        try:
+            total += os.stat(os.path.realpath(os.path.join(newest, fn))).st_size
+        except OSError:
+            pass
+    return total
+
+
+def discover_local() -> List[Dict[str, Any]]:
+    """Chat-capable models with real weights in the local HF cache."""
+    out: List[Dict[str, Any]] = []
+    try:
+        entries = sorted(os.listdir(HF_CACHE))
+    except OSError:
+        return out
+    for entry in entries:
+        if not entry.startswith("models--"):
+            continue
+        model_id = entry[len("models--"):].replace("--", "/")
+        if not model_id.startswith(_REQUIRED_PREFIX):
+            continue
+        low = model_id.lower()
+        if any(tok in low for tok in _NON_CHAT):
+            continue
+        size = _snapshot_bytes(os.path.join(HF_CACHE, entry))
+        if size < _MIN_WEIGHT_BYTES:
+            continue  # metadata-only stub
+        out.append({"id": model_id, "label": _friendly(model_id),
+                    "size_gb": round(size / 1e9, 1)})
+    return out
+
+
+def get_active(config: Optional[Dict[str, Any]] = None) -> str:
+    cfg = config if config is not None else _load_config()
+    return cfg.get("llm_model") or DEFAULT_MODEL
+
+
+def _base_url(cfg: Dict[str, Any]) -> str:
+    return cfg.get("llm_base_url", DEFAULT_BASE_URL).rstrip("/")
+
+
+def list_models() -> Dict[str, Any]:
+    """Registry for the picker: local models, annotated from config, plus the
+    active one. `roles` in config.json:model_roles maps id -> human purpose."""
+    cfg = _load_config()
+    roles = cfg.get("model_roles", {}) if isinstance(cfg.get("model_roles"), dict) else {}
+    active = get_active(cfg)
+    models = discover_local()
+    for m in models:
+        m["role"] = roles.get(m["id"], "")
+        m["active"] = (m["id"] == active)
+    if active and not any(m["id"] == active for m in models):
+        # Active model isn't on disk (or was pruned) — still show it as active.
+        models.insert(0, {"id": active, "label": _friendly(active), "size_gb": None,
+                          "role": roles.get(active, ""), "active": True})
+    return {"active": active, "models": models}
+
+
+def probe(model_id: str, timeout: float = 240.0,
+          base_url: Optional[str] = None) -> tuple[bool, str]:
+    """Force the server to load `model_id` with a 1-token request.
+
+    Returns (ok, detail). This is what makes a switch safe: it surfaces a load
+    failure while we still know which model to fall back to.
+    """
+    cfg = _load_config()
+    url = (base_url or _base_url(cfg)) + "/chat/completions"
+    body = json.dumps({
+        "model": model_id,
+        "messages": [{"role": "user", "content": "ok"}],
+        "max_tokens": 1, "temperature": 0,
+    }).encode()
+    req = urllib.request.Request(url, data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            resp.read()
+        return True, f"loaded in {time.time() - t0:.1f}s"
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", "replace")[:200]
+        except Exception:
+            pass
+        return False, f"HTTP {e.code}: {detail}"
+    except Exception as e:  # timeout, connection refused, ...
+        return False, f"{type(e).__name__}: {e}"
+
+
+def _write_active(model_id: str) -> None:
+    cfg = _load_config()
+    cfg["llm_model"] = model_id
+    atomic_write_json(CONFIG_PATH, cfg)  # helper already writes 0600
+
+
+def set_active(model_id: str, verify: bool = True) -> Dict[str, Any]:
+    """Switch the chat model, verifying it loads and reverting if it does not.
+
+    Only models discovered locally may be selected — an arbitrary string would
+    unload the working model in exchange for a 404.
+    """
+    previous = get_active()
+    known = {m["id"] for m in discover_local()} | {previous}
+    if model_id not in known:
+        return {"ok": False, "error": f"unknown model: {model_id}",
+                "active": previous}
+    if model_id == previous:
+        return {"ok": True, "active": previous, "changed": False,
+                "detail": "already active"}
+
+    _write_active(model_id)
+    if not verify:
+        return {"ok": True, "active": model_id, "previous": previous,
+                "changed": True, "detail": "switched (unverified)"}
+
+    ok, detail = probe(model_id)
+    if ok:
+        _emit_audit(previous, model_id, True, detail)
+        return {"ok": True, "active": model_id, "previous": previous,
+                "changed": True, "detail": detail}
+
+    # Failed to load — the old model is already unloaded, so put it back and
+    # warm it, otherwise CODEC answers nothing at all.
+    _write_active(previous)
+    reverted_ok, revert_detail = probe(previous)
+    _emit_audit(previous, model_id, False, detail)
+    return {"ok": False, "active": previous, "attempted": model_id,
+            "changed": False,
+            "error": f"{model_id} failed to load ({detail}) — reverted to {previous}",
+            "reverted": reverted_ok, "revert_detail": revert_detail}
+
+
+def _emit_audit(previous: str, requested: str, ok: bool, detail: str) -> None:
+    try:
+        from codec_audit import audit
+        audit(event="model_switched", source="codec-models",
+              outcome="ok" if ok else "error",
+              level="info" if ok else "warning",
+              message=f"model switch {previous} -> {requested}",
+              extra={"previous": previous, "requested": requested,
+                     "ok": ok, "detail": detail[:200]})
+    except Exception:
+        pass

--- a/codec_voice.py
+++ b/codec_voice.py
@@ -645,8 +645,17 @@ class VoicePipeline:
         self._stream_error = False
         await llm_queue.acquire(Priority.CRITICAL)
         try:
+            # Resolve the model per call so a switch made in chat / by voice
+            # applies here too. codec_voice reads config at IMPORT, so without
+            # this the voice path would keep using the model that was active
+            # when the process started.
+            try:
+                from codec_models import get_active as _active_model
+                _model = _active_model()
+            except Exception:
+                _model = QWEN_MODEL
             async for token in codec_llm.astream(
-                messages, base_url=QWEN_BASE_URL, model=QWEN_MODEL,
+                messages, base_url=QWEN_BASE_URL, model=_model,
                 max_tokens=max_tokens, temperature=0.7, enable_thinking=False,
                 extra_kwargs={"top_p": 0.9, "frequency_penalty": 0.8, **LLM_KWARGS},
                 http=self._http,

--- a/docs/MODEL-SWITCHING-DESIGN.md
+++ b/docs/MODEL-SWITCHING-DESIGN.md
@@ -1,0 +1,77 @@
+# Runtime model switching
+
+## What and why
+
+Switch which local LLM CODEC answers with, from the chat UI or by voice, without
+restarting anything. Everyday model for general use, a different one for coding.
+
+## Key constraint: one model at a time, enforced by the server
+
+Every local model is served by ONE `mlx_vlm.server` on `:8083`. It resolves the
+model **per request** (`get_cached_model(openai_request.model)`) and keeps a
+single-slot cache: asking for a different model logs
+`New model request, clearing existing cache...`, unloads the current model, and
+loads the new one.
+
+That is the desired behaviour and it is automatic — **CODEC never holds two
+models in memory.** Measured across a 3.6 → 3.5 → 3.6 cycle, the server process
+stayed at 19.8 / 19.9 / 19.5 GB rather than accumulating.
+
+Trying to keep two models resident (two servers) was measured and rejected: the
+everyday model dropped from 59 to 23 tok/s and swap hit 18.5 of 19.4 GB.
+
+Switching costs a load pause. Measured on this box: **6-9s** between models
+already in the page cache, ~22s cold.
+
+## Design
+
+`codec_models.py`
+- `discover_local()` — chat-capable models with real weights in the HF cache.
+  Filters to `mlx-community/` (the only namespace this server can load), drops
+  speech/vision-only/diffusion checkpoints, and skips metadata-only stubs by
+  requiring ≥500 MB of `.safetensors`. Sizes come from the newest snapshot with
+  blobs resolved, so shared revisions are not double-counted.
+- `get_active()` — reads `llm_model` from `~/.codec/config.json`.
+- `probe(model_id)` — 1-token request that forces the load and reports failure.
+- `set_active(model_id)` — validate → write config → probe → **revert on
+  failure**.
+
+`routes/models.py` — `GET /api/models`, `POST /api/model`.
+
+`skills/model_switch.py` — voice/chat ("switch to the coding model", "which
+model are you using"). `SKILL_MCP_EXPOSE = False`: swapping the brain is a local
+operator action, not something a remote MCP client should do.
+
+UI — a picker in the chat composer; disabled with a "Loading…" toast during the
+switch, since the pause is real.
+
+## The safety property
+
+A failed switch must never leave CODEC mute. Because the server has already
+unloaded the previous model by the time a load fails, `set_active()`:
+
+1. writes the new model to config,
+2. probes it,
+3. on failure restores the previous value **and re-probes it** so the working
+   model is loaded again,
+4. returns `ok: False` with the reason.
+
+Verified live against a genuinely broken target: `Qwen3.8-27B` fails on the
+current serving venv (`Unrecognized image processor` — it needs newer
+`transformers`/`mlx_vlm`). The switch failed, reverted, and the model still
+answered.
+
+Only locally discovered models may be selected; an arbitrary string would trade
+a working model for a 404.
+
+## Scope
+
+Chat already re-read config per request, so it needed no change. Voice read the
+model at import, so its call site now resolves per call. Other callers
+(`codec_watcher`, `codec_agent_plan`, …) keep the import-time constant
+deliberately — background jobs should not change model mid-flight.
+
+## Not included
+
+Pre-warming a second model to make switches instant. That requires two resident
+models, which this box cannot do without halving throughput.

--- a/routes/models.py
+++ b/routes/models.py
@@ -1,0 +1,37 @@
+"""Model picker endpoints.
+
+Chat re-reads ~/.codec/config.json per request, so switching `llm_model` takes
+effect on the next message — no restart. The heavy lifting (validation, probe,
+auto-revert) lives in codec_models; these are thin wrappers.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+import codec_models
+
+router = APIRouter()
+
+
+@router.get("/api/models")
+async def list_models():
+    """Locally available chat models + which one is active."""
+    return codec_models.list_models()
+
+
+@router.post("/api/model")
+async def set_model(body: dict):
+    """Switch the active chat model.
+
+    Synchronous on purpose: the server unloads the old model and loads the new
+    one, and the caller needs to know whether that succeeded. On failure the
+    previous model is restored and reloaded before this returns, so CODEC is
+    never left without a brain.
+    """
+    model_id = (body or {}).get("model") or (body or {}).get("id") or ""
+    if not model_id:
+        return JSONResponse({"ok": False, "error": "missing 'model'"},
+                            status_code=400)
+    result = codec_models.set_active(str(model_id))
+    return JSONResponse(result, status_code=200 if result.get("ok") else 409)

--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -57,6 +57,7 @@
     "memory_history.py": "a2762c03c325517d10907f8aa9511103a5716a29f9e956d48473b817105fb65c",
     "memory_save.py": "3d801338bfd0818aaf1e65e692e404af0a0fba6886d26150f0fb66e4b4fde424",
     "memory_search.py": "249e8644254e039cbdf7155fd372b85c234e18483e8e7ea7361ce28bf8fb875f",
+    "model_switch.py": "dfb27c156ea740536cf9c7e85d514bd2494c4b040556a7d95dbe79cebb9b7e09",
     "mouse_control.py": "b20bad835e39380a89ddfaa02a7db33941510e954c2ee73922ef8ff16db3abaf",
     "music.py": "c42bddc6414b11e8c4734cd826a824a30c4ff34a618d69da11a5d84b737b2f55",
     "network_info.py": "bd776b619cf7c18d67fe03cb0f0456cf9c4f9bf71475740a233a9ca1e6672fcd",

--- a/skills/model_switch.py
+++ b/skills/model_switch.py
@@ -1,0 +1,122 @@
+"""Switch the local LLM CODEC answers with, by voice or chat.
+
+All local models are served by ONE mlx_vlm.server, which holds a single model at
+a time — so a switch unloads the current model and loads the new one. That takes
+20-60s for a 15-20 GB checkpoint, and it is why this skill reports the load time
+rather than pretending the change is instant.
+
+If the requested model fails to load, codec_models.set_active restores and
+reloads the previous one before returning, so a bad request can never leave
+CODEC unable to answer.
+"""
+import codec_models
+
+SKILL_NAME = "model_switch"
+SKILL_DESCRIPTION = (
+    "Switch which local LLM CODEC uses, or report the current one. "
+    "Say 'switch to the coding model', 'use the fast model', or 'which model are you using'."
+)
+SKILL_TRIGGERS = [
+    "switch model", "switch to model", "change model", "use model",
+    "switch to the coding model", "switch to coding model", "coding model",
+    "switch to the fast model", "use the fast model", "everyday model",
+    "which model", "what model", "current model", "list models",
+    "available models", "model list",
+]
+SKILL_MCP_EXPOSE = False  # swapping the brain is a local-operator action
+
+# Spoken shorthand -> substring matched against available model ids.
+_ALIASES = {
+    "coding": ["3.8", "coder"],
+    "code": ["3.8", "coder"],
+    "fast": ["a3b"],
+    "everyday": ["a3b"],
+    "daily": ["a3b"],
+    "default": ["a3b"],
+}
+
+
+def _fmt(models, active):
+    lines = []
+    for m in models:
+        mark = "->" if m["id"] == active else "  "
+        role = f" — {m['role']}" if m.get("role") else ""
+        size = f" ({m['size_gb']}GB)" if m.get("size_gb") else ""
+        lines.append(f"{mark} {m['label']}{size}{role}")
+    return "\n".join(lines)
+
+
+def _pick(cands, active):
+    """Choose among several matches: the active model wins, else the highest
+    version (so 'fast' lands on Qwen3.6, not the older 3.5 that sorts first)."""
+    if not cands:
+        return None
+    if active in cands:
+        return active
+    return sorted(cands)[-1]
+
+
+def _resolve(want, models, active=""):
+    """Map free text to one model id, or None."""
+    want = (want or "").lower().strip()
+    if not want:
+        return None
+    ids = [m["id"] for m in models]
+    # exact id first
+    for mid in ids:
+        if want == mid.lower():
+            return mid
+    # alias keywords
+    for key, needles in _ALIASES.items():
+        if key in want:
+            hits = [mid for mid in ids
+                    if any(n in mid.lower() for n in needles)]
+            picked = _pick(hits, active)
+            if picked:
+                return picked
+    # loose token match against the model name
+    hits = []
+    for mid in ids:
+        name = mid.split("/")[-1].lower()
+        if want in name or name in want:
+            hits.append(mid); continue
+        core = name.replace("-4bit", "")
+        if any(tok and tok in core for tok in want.split()):
+            hits.append(mid)
+    return _pick(hits, active)
+
+
+def run(task, app="", ctx=""):
+    t = (task or "").lower()
+    data = codec_models.list_models()
+    models, active = data["models"], data["active"]
+
+    # Pure query — never switch on an ambiguous question.
+    if any(p in t for p in ("which model", "what model", "current model",
+                            "list model", "available model", "model list")):
+        cur = next((m for m in models if m["id"] == active), None)
+        head = f"Currently using {cur['label']}" if cur else f"Currently using {active}"
+        return f"{head}.\n\nAvailable locally:\n{_fmt(models, active)}"
+
+    # Strip the command words so only the model name is left.
+    want = t
+    for phrase in ("switch to the", "switch to", "switch", "change to the",
+                   "change to", "change", "use the", "use", "model"):
+        want = want.replace(phrase, " ")
+    target = _resolve(want, models, active)
+
+    if not target:
+        return ("I could not tell which model you meant.\n\n"
+                f"Available locally:\n{_fmt(models, active)}\n\n"
+                "Try: \"switch to the coding model\".")
+
+    if target == active:
+        label = next((m["label"] for m in models if m["id"] == target), target)
+        return f"Already using {label}."
+
+    result = codec_models.set_active(target)
+    label = next((m["label"] for m in models if m["id"] == target), target)
+    if result.get("ok"):
+        return f"Switched to {label} ({result.get('detail', '')}). It is answering the next message."
+    return (f"Could not switch to {label}. {result.get('error', '')}\n"
+            f"Still using {result.get('active')}.")

--- a/tests/test_model_switching.py
+++ b/tests/test_model_switching.py
@@ -1,0 +1,126 @@
+"""Runtime model switching (codec_models + model_switch skill).
+
+The property that matters most: a switch that fails must leave CODEC with a
+working model. The mlx server holds ONE model at a time, so a failed load has
+already unloaded the previous one — without the revert the box goes mute.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+import codec_models
+
+
+@pytest.fixture
+def cfg(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"llm_model": "mlx-community/A", "llm_base_url": "http://x/v1"}))
+    monkeypatch.setattr(codec_models, "CONFIG_PATH", str(path))
+    monkeypatch.setattr(codec_models, "discover_local",
+                        lambda: [{"id": "mlx-community/A", "label": "A", "size_gb": 1.0},
+                                 {"id": "mlx-community/B", "label": "B", "size_gb": 2.0}])
+    return path
+
+
+def test_get_active_reads_config(cfg):
+    assert codec_models.get_active() == "mlx-community/A"
+
+
+def test_switch_persists_when_probe_succeeds(cfg, monkeypatch):
+    monkeypatch.setattr(codec_models, "probe", lambda m, **kw: (True, "loaded in 1s"))
+    r = codec_models.set_active("mlx-community/B")
+    assert r["ok"] and r["active"] == "mlx-community/B"
+    assert json.loads(cfg.read_text())["llm_model"] == "mlx-community/B"
+
+
+def test_failed_switch_reverts_to_previous(cfg, monkeypatch):
+    """The core safety property — a bad model must not leave CODEC mute."""
+    seen = []
+
+    def fake_probe(model, **kw):
+        seen.append(model)
+        return (False, "HTTP 500: Unrecognized image processor") if model == "mlx-community/B" else (True, "reloaded")
+
+    monkeypatch.setattr(codec_models, "probe", fake_probe)
+    r = codec_models.set_active("mlx-community/B")
+
+    assert r["ok"] is False
+    assert r["active"] == "mlx-community/A", "must fall back to the working model"
+    assert r["reverted"] is True
+    assert json.loads(cfg.read_text())["llm_model"] == "mlx-community/A", \
+        "config must be restored on disk, not just in the response"
+    assert seen == ["mlx-community/B", "mlx-community/A"], \
+        "the previous model must be re-probed so it is loaded again"
+
+
+def test_unknown_model_is_refused_without_touching_config(cfg, monkeypatch):
+    monkeypatch.setattr(codec_models, "probe",
+                        lambda m, **kw: pytest.fail("must not probe an unknown model"))
+    r = codec_models.set_active("evil/not-a-model")
+    assert r["ok"] is False
+    assert json.loads(cfg.read_text())["llm_model"] == "mlx-community/A"
+
+
+def test_switch_to_active_is_a_noop(cfg, monkeypatch):
+    monkeypatch.setattr(codec_models, "probe",
+                        lambda m, **kw: pytest.fail("must not reload the active model"))
+    r = codec_models.set_active("mlx-community/A")
+    assert r["ok"] and r["changed"] is False
+
+
+def test_list_marks_active(cfg):
+    d = codec_models.list_models()
+    assert d["active"] == "mlx-community/A"
+    assert [m["active"] for m in d["models"]] == [True, False]
+
+
+def test_discovery_excludes_non_chat_and_stubs(tmp_path, monkeypatch):
+    """Speech/vision/diffusion checkpoints and metadata-only stubs must not be
+    offered as chat models — picking one would unload a working model."""
+    cache = tmp_path / "hub"
+    def make(name, size):
+        snap = cache / f"models--{name.replace('/', '--')}" / "snapshots" / "rev1"
+        snap.mkdir(parents=True)
+        (snap / "model.safetensors").write_bytes(b"0" * size)
+    make("mlx-community/Qwen9-Chat-4bit", 600 * 1024 * 1024)   # keep
+    make("mlx-community/whisper-large-v3", 600 * 1024 * 1024)  # non-chat
+    make("black-forest-labs/FLUX.1-dev", 600 * 1024 * 1024)    # not mlx-community
+    make("mlx-community/Qwen9-Stub-4bit", 1024)                # metadata stub
+    monkeypatch.setattr(codec_models, "HF_CACHE", str(cache))
+    ids = [m["id"] for m in codec_models.discover_local()]
+    assert ids == ["mlx-community/Qwen9-Chat-4bit"], ids
+
+
+# ── skill ────────────────────────────────────────────────────────────────────
+
+
+def test_skill_query_never_switches(monkeypatch):
+    import skills.model_switch as ms
+    monkeypatch.setattr(ms.codec_models, "list_models", lambda: {
+        "active": "mlx-community/Qwen3.6-35B-A3B-4bit",
+        "models": [{"id": "mlx-community/Qwen3.6-35B-A3B-4bit", "label": "Qwen3.6", "active": True, "size_gb": 20.4, "role": ""},
+                   {"id": "mlx-community/Qwen3.8-27B-4bit", "label": "Qwen3.8", "active": False, "size_gb": 16.1, "role": ""}]})
+    monkeypatch.setattr(ms.codec_models, "set_active",
+                        lambda *a, **kw: pytest.fail("a question must not switch the model"))
+    out = ms.run("which model are you using")
+    assert "Qwen3.6" in out
+
+
+def test_skill_resolves_aliases_and_prefers_active():
+    import skills.model_switch as ms
+    models = [{"id": "mlx-community/Qwen3.5-35B-A3B-4bit"},
+              {"id": "mlx-community/Qwen3.6-35B-A3B-4bit"},
+              {"id": "mlx-community/Qwen3.8-27B-4bit"}]
+    active = "mlx-community/Qwen3.6-35B-A3B-4bit"
+    assert ms._resolve("coding", models, active) == "mlx-community/Qwen3.8-27B-4bit"
+    # 'fast' matches every A3B model — the active one must win over the older 3.5
+    assert ms._resolve("fast", models, active) == active
+    assert ms._resolve("banana", models, active) is None


### PR DESCRIPTION
Everyday model for general use, a different one for coding — switched from inside CODEC, no restart.

### One model at a time, automatically
All local models are served by **one** `mlx_vlm.server` on `:8083`. It resolves the model **per request** (`get_cached_model(openai_request.model)`) and keeps a **single-slot cache** — asking for a different model logs `New model request, clearing existing cache...`, unloads the current one, loads the new one.

So CODEC never holds two models in memory, and nothing extra had to be built for that. Measured across a 3.6 → 3.5 → 3.6 cycle:

```
before : 19.8 GB (pid 2513)
after 3.5 : 19.9 GB (pid 2513)     <- flat, not 40 GB
after 3.6 : 19.5 GB (pid 2513)
server processes: 1
```

Switch takes **6–9s** warm, ~22s cold. Keeping two models resident was measured and **rejected**: the everyday model fell from **59 → 23 tok/s** and swap hit 18.5 of 19.4 GB.

### The safety property
A failed switch must never leave CODEC mute — the server has already unloaded the old model by the time a load fails. So `set_active()` writes the target, probes it, and **on failure restores the previous model and re-probes it** to force a reload before returning `ok:false`.

Verified live against a genuinely broken target (`Qwen3.8-27B` needs newer `transformers` than the serving venv has):
```
ok          : False
error       : Qwen3.8-27B failed to load (HTTP 500: Unrecognized image processor…)
active now  : Qwen3.5-35B-A3B
reverted ok : True
brain reply : ALIVE
```

Only locally discovered models can be selected — an arbitrary string would trade a working model for a 404.

### What's in it
- **`codec_models.py`** — discovery (`mlx-community/` only; no speech/vision/diffusion; no metadata-only stubs; sizes from the newest snapshot with blobs resolved so shared revisions aren't double-counted), `get_active` / `set_active` / `probe` / `list_models`, `model_switched` audit event
- **`routes/models.py`** — `GET /api/models`, `POST /api/model`
- **`skills/model_switch.py`** — voice/chat: *"switch to the coding model"*, *"which model are you using"*. `SKILL_MCP_EXPOSE=False` — swapping the brain is a local-operator action, not something a remote MCP client should reach. Aliases prefer the **active** model when several match (so "fast" lands on 3.6, not the older 3.5 that sorts first)
- **Model picker in the chat composer**, disabled with a toast during the load pause
- **`codec_voice`** — resolves the model per call; it read config at *import*, so a switch would otherwise never reach voice
- **9 tests** including the revert-on-failure property and discovery filtering
- `docs/MODEL-SWITCHING-DESIGN.md`; manifest regenerated 89 → 90 + FEATURES.md count per the D-1 rule

Chat needed no change — it already re-read config per request. Background callers (`codec_watcher`, `codec_agent_plan`, …) keep the import-time constant deliberately: a long job shouldn't change model mid-flight.

**Full suite: 2749 passed, 78 skipped; ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)