### PR TITLE
feat(chat): reply time + tokens, model-picker allowlist, fix dropped attachments in Agents/Project

### DIFF
--- a/codec_chat.html
+++ b/codec_chat.html
@@ -108,6 +108,7 @@ html,body{font-family:var(--font);background:var(--bg);color:var(--text);height:
 .msg-bubble{padding:10px 14px;border-radius:14px;line-height:1.6;font-size:15px;word-wrap:break-word;white-space:pre-wrap}
 .msg.user .msg-bubble{background:rgba(232,113,26,0.15);color:var(--text);border:1px solid rgba(232,113,26,0.25);border-bottom-right-radius:4px}
 .msg.assistant .msg-bubble{background:var(--surface-2);color:var(--text);border:1px solid var(--border);border-bottom-left-radius:4px}
+.msg-stats{font-size:10px;color:var(--text-dim);letter-spacing:.3px;margin-left:8px;opacity:.75;cursor:default}
 .msg-time{font-family:var(--mono);font-size:11px;color:var(--text-dim);margin-top:3px;padding:0 4px}
 .msg.user .msg-time{text-align:right}
 
@@ -560,6 +561,33 @@ function showToast(msg){var t=document.getElementById('toast');t.textContent=msg
 // blocks the selection, which is why the old fallback never worked on the phone.
 // 16px font-size stops iOS from zooming the viewport while the node is focused.
 
+
+// ── Reply stats ───────────────────────────────────────────────────────────
+// The backend emits one {stats:{…}} SSE frame after the stream finishes.
+// elapsed_s is wall time as the user experienced it (a cold model load is
+// included on purpose — that IS the wait). tok/s comes from the server's own
+// completion_tokens, so it is measured, not estimated.
+var _lastStats = null;
+function _fmtModel(id){ return String(id||'').split('/').pop().replace('-4bit',''); }
+function renderStats(msgEl, st){
+  try{
+    var meta = msgEl.querySelector('.msg-meta'); if(!meta) return;
+    var bits = [];
+    bits.push((st.elapsed_s != null ? st.elapsed_s : '?') + 's');
+    if(st.completion_tokens != null) bits.push(st.completion_tokens + ' tok');
+    if(st.tok_per_s != null) bits.push(st.tok_per_s + ' tok/s');
+    if(st.model) bits.push(_fmtModel(st.model));
+    var span = document.createElement('span');
+    span.className = 'msg-stats';
+    span.textContent = bits.join(' · ');
+    if(st.prompt_tokens != null && st.total_tokens != null){
+      span.title = st.prompt_tokens + ' prompt + ' + (st.completion_tokens||0) +
+                   ' completion = ' + st.total_tokens + ' tokens';
+    }
+    meta.appendChild(span);
+  }catch(e){}
+}
+
 // ── Model picker ──────────────────────────────────────────────────────────
 // All local models are served by ONE mlx_vlm.server holding a single model at a
 // time, so switching unloads the current model and loads the new one. That is a
@@ -789,7 +817,7 @@ function regenerateResponse(btn){
       for(var li=0;li<lines.length;li++){
         var line=lines[li].trim();if(!line.startsWith('data: '))continue;var payload=line.substring(6);
         if(payload==='[DONE]')break;
-        try{var j=JSON.parse(payload);if(j.skill){showToast('Skill: '+j.skill)}if(j.token){raw+=j.token;var ps=parseScaffold(raw);if(thinkingEnabled&&ps.think){var tp=makeToT(div,'Reveal train of thought',true);totSet(tp,ps.think)}if(ps.answer){if(!answerStarted){bubble.innerHTML='';answerStarted=true}bubble.innerHTML=formatMsg(ps.answer)}scrollBottom()}if(j.error){raw+='\nError: '+j.error}}catch(pe){}
+        try{var j=JSON.parse(payload);if(j.stats){_lastStats=j.stats}if(j.skill){showToast('Skill: '+j.skill)}if(j.token){raw+=j.token;var ps=parseScaffold(raw);if(thinkingEnabled&&ps.think){var tp=makeToT(div,'Reveal train of thought',true);totSet(tp,ps.think)}if(ps.answer){if(!answerStarted){bubble.innerHTML='';answerStarted=true}bubble.innerHTML=formatMsg(ps.answer)}scrollBottom()}if(j.error){raw+='\nError: '+j.error}}catch(pe){}
       }
     }
     var pf=parseScaffold(raw);
@@ -802,6 +830,7 @@ function regenerateResponse(btn){
     if(answer){
       div.remove();var md=addMessage('assistant',answer);
       if(thinkingEnabled&&pf.think&&pf.think.trim()&&md){var fp=makeToT(md,'Train of thought',false);totSet(fp,pf.think.trim())}
+      if(md&&_lastStats)renderStats(md,_lastStats);_lastStats=null;
       chatHist.push({role:'assistant',content:answer});saveMessages([{role:'assistant',content:answer}])
     }else{bubble.innerHTML='<em style="color:var(--text-dim)">No response</em>'}
     _currentAbort=null;isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false
@@ -1391,13 +1420,24 @@ async function sendMessage(){
   if(!text&&!pendingFiles.length)return;
   input.value='';input.style.height='auto';
 
+  // Attachments are read HERE, before the mode branches. They used to be built
+  // only in the chat path further down, which the project and research branches
+  // return past — so a PDF attached in Agents or Project mode was silently
+  // dropped: chips cleared, crew ran on the prompt alone, no error shown.
+  var fileContext='';var fileNames=[];
+  for(var i=0;i<pendingFiles.length;i++){var f=pendingFiles[i];fileNames.push(f.name);
+    if(f.type==='text'||f.type==='pdf'){fileContext+='\n\n[DOCUMENT: '+f.name+']\n'+f.content.substring(0,80000)+'\n[END DOCUMENT]'}
+    else if(f.type==='image'){fileContext+='\n\n[IMAGE ANALYSIS of '+f.name+']\n'+f.content.substring(0,80000)+'\n[END IMAGE]'}}
+
   // Project mode → POST /api/agents (Step 8 plan dispatch)
   // OR if there's an active agent in this thread, route the message to that agent
   // (status queries, mid-run instructions). User explicitly exits with × on chip.
   if(chatMode==='project'){
-    if(!text)return;
-    addMessage('user',text);
-    chatHist.push({role:'user',content:text});
+    if(!text&&!fileNames.length)return;
+    var projText=(text||'Please use the attached file(s).')+fileContext;
+    if(fileNames.length)clearChips();
+    addMessage('user',fileNames.length?(fileNames.join('\n')+'\n\n'+(text||'Please use the attached file(s).')):text);
+    chatHist.push({role:'user',content:projText});
     saveMessages([{role:'user',content:text}]);
     isProcessing=true;document.getElementById('sendBtn').disabled=true;
 
@@ -1450,7 +1490,7 @@ async function sendMessage(){
     scrollBottom();
     try{
       var pr=await fetch('/api/agents',{method:'POST',headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({title:text.slice(0,80),description:text})});
+        body:JSON.stringify({title:(text||fileNames.join(', ')).slice(0,80),description:projText})});
       if(pr.status===401||pr.status===403){
         pendingDiv.querySelector('.msg-bubble').innerHTML='<span style="color:var(--danger,#f87171)">Session expired</span> — refreshing...';
         setTimeout(function(){window.location.href='/auth'},1500);
@@ -1477,10 +1517,11 @@ async function sendMessage(){
   }
 
   if(chatMode==='research'){
-    var researchText=text||'';
+    var researchText=(text||'')+fileContext;
     var crew=document.getElementById('crewSelect').value||'deep_research';
     var noTextCrews=['daily_briefing','email_handler'];
-    if(!researchText&&!noTextCrews.includes(crew))return;
+    if(!text&&!fileNames.length&&!noTextCrews.includes(crew))return;
+    if(fileNames.length)clearChips();
 
     var crewLabels={'deep_research':'Deep Research','daily_briefing':'Daily Briefing',
       'trip_planner':'Trip Planner','competitor_analysis':'Competitor Analysis','email_handler':'Email Handler',
@@ -1488,7 +1529,8 @@ async function sendMessage(){
       'content_writer':'Content Writer','meeting_summarizer':'Meeting Summarizer',
       'invoice_generator':'Invoice Generator','project_manager':'Project Manager',
       'custom':document.getElementById('agentName').value||'Custom Agent'};
-    var userMsg=(crewLabels[crew]||crew)+': '+(researchText||'(running)');
+    var userMsg=(crewLabels[crew]||crew)+': '+((text||'')||(fileNames.length?fileNames.join(', '):'(running)'));
+    if(fileNames.length&&text)userMsg+=' ['+fileNames.join(', ')+']';
     addMessage('user',userMsg);chatHist.push({role:'user',content:userMsg});saveMessages([{role:'user',content:userMsg}]);
 
     var statusEl=null;
@@ -1531,8 +1573,6 @@ async function sendMessage(){
     isProcessing=false;_showSend();document.getElementById('sendBtn').disabled=false;return
   }
 
-  var fileContext='';var fileNames=[];
-  for(var i=0;i<pendingFiles.length;i++){var f=pendingFiles[i];fileNames.push(f.name);if(f.type==='text'||f.type==='pdf'){fileContext+='\n\n[DOCUMENT: '+f.name+']\n'+f.content.substring(0,80000)+'\n[END DOCUMENT]'}else if(f.type==='image'){fileContext+='\n\n[IMAGE ANALYSIS of '+f.name+']\n'+f.content.substring(0,80000)+'\n[END IMAGE]'}}
   var displayText=text;
   if(fileNames.length){displayText=(fileNames.map(function(n){return n}).join('\n'))+'\n\n'+(text||'Please analyze the attached file(s).')}
   addMessage('user',displayText);

--- a/codec_llm.py
+++ b/codec_llm.py
@@ -45,6 +45,13 @@ _THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
 # (codec_session.qwen_stream) are unaffected.
 KEEPALIVE = object()
 
+# Yielded by stream(usage_sentinel=True) when the server reports token counts in
+# its final chunk. Carries data, so unlike the bare object() sentinels it is a
+# dict subclass — callers check isinstance(item, StreamUsage) BEFORE treating an
+# item as text, otherwise it would be rendered into the reply.
+class StreamUsage(dict):
+    """Token accounting for one streamed reply (prompt/completion/total)."""
+
 # Sentinels yielded by stream(error_sentinel=True) — 2026-07 chat-visibility
 # fix. stream() never raises by contract, so before these existed a mid-reply
 # connection drop / non-200 / read timeout was indistinguishable from a clean
@@ -242,6 +249,7 @@ def stream(
     keepalive: bool = False,
     error_sentinel: bool = False,
     inline_reasoning: bool = False,
+    usage_sentinel: bool = False,
 ) -> Iterator[Any]:
     """POST with `stream=True` and yield the RAW assistant content deltas in
     order. Centralizes the SSE plumbing: header/payload build (shared with
@@ -277,6 +285,11 @@ def stream(
         temperature=temperature, enable_thinking=enable_thinking,
         extra_kwargs=extra_kwargs, stream=True,
     )
+    if usage_sentinel:
+        # OpenAI-style: usage is omitted from streamed responses unless asked
+        # for. mlx_vlm.server honours this and emits a final choices-empty chunk
+        # carrying prompt/completion tokens.
+        payload["stream_options"] = {"include_usage": True}
     url = base_url.rstrip("/") + "/chat/completions"
     _empty = 0  # empty "thinking" chunks seen (drives keepalive)
     try:
@@ -300,7 +313,21 @@ def stream(
                 if data.strip() == "[DONE]":
                     break
                 try:
-                    choice = _json.loads(data).get("choices", [{}])[0]
+                    _obj = _json.loads(data)
+                except Exception as e:
+                    log.warning("LLM stream chunk parse failed: %s", e)
+                    continue
+                # The usage chunk carries an EMPTY choices list, so it must be
+                # handled before the choices[0] access below — that access used
+                # to raise IndexError and the counts were swallowed as a parse
+                # failure.
+                if _obj.get("usage"):
+                    if usage_sentinel:
+                        yield StreamUsage(_obj["usage"])
+                    if not _obj.get("choices"):
+                        continue
+                try:
+                    choice = _obj.get("choices", [{}])[0]
                     _d = choice.get("delta", {})
                     delta = _d.get("content", "")
                 except Exception as e:

--- a/codec_models.py
+++ b/codec_models.py
@@ -116,6 +116,21 @@ def discover_local() -> List[Dict[str, Any]]:
     return out
 
 
+def _visible_ids(cfg: Dict[str, Any]) -> Optional[set]:
+    """Optional operator allowlist: `models_visible` in config.json.
+
+    Discovery finds every loadable chat model on disk, which includes ones the
+    operator does not want offered (an older generation, a vision checkpoint kept
+    only because skills/screenshot_text.py hardcodes it). Listing it here hides
+    it from the picker WITHOUT deleting weights that other code paths still use.
+    Absent or empty -> show everything discovered.
+    """
+    raw = cfg.get("models_visible")
+    if isinstance(raw, list) and raw:
+        return {str(x) for x in raw}
+    return None
+
+
 def get_active(config: Optional[Dict[str, Any]] = None) -> str:
     cfg = config if config is not None else _load_config()
     return cfg.get("llm_model") or DEFAULT_MODEL
@@ -132,6 +147,11 @@ def list_models() -> Dict[str, Any]:
     roles = cfg.get("model_roles", {}) if isinstance(cfg.get("model_roles"), dict) else {}
     active = get_active(cfg)
     models = discover_local()
+    allow = _visible_ids(cfg)
+    if allow:
+        # The active model is always shown, even if it was removed from the
+        # allowlist — hiding what CODEC is currently running would be a lie.
+        models = [m for m in models if m["id"] in allow or m["id"] == active]
     for m in models:
         m["role"] = roles.get(m["id"], "")
         m["active"] = (m["id"] == active)
@@ -187,7 +207,12 @@ def set_active(model_id: str, verify: bool = True) -> Dict[str, Any]:
     unload the working model in exchange for a 404.
     """
     previous = get_active()
-    known = {m["id"] for m in discover_local()} | {previous}
+    cfg = _load_config()
+    allow = _visible_ids(cfg)
+    known = {m["id"] for m in discover_local()}
+    if allow:
+        known &= allow            # hidden models are not switchable either
+    known |= {previous}
     if model_id not in known:
         return {"ok": False, "error": f"unknown model: {model_id}",
                 "active": previous}

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -33,6 +33,7 @@ import json
 import logging
 import re
 import secrets
+import time
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -1187,10 +1188,19 @@ async def chat_completion(request: Request):
                     # (tail only) and re-checked every ~40 deltas.
                     _acc = ""
                     _since_check = 0
+                    # Reply stats: wall time + token counts, surfaced to the UI
+                    # so the operator can see how long a local model actually
+                    # took. usage arrives in the server's final chunk.
+                    _t0 = time.time()
+                    _usage = None
                     for item in codec_llm.stream(messages, **_common,
                                                  keepalive=True,
                                                  error_sentinel=True,
-                                                 inline_reasoning=show_thoughts):
+                                                 inline_reasoning=show_thoughts,
+                                                 usage_sentinel=True):
+                        if isinstance(item, codec_llm.StreamUsage):
+                            _usage = dict(item)
+                            continue
                         if item is codec_llm.KEEPALIVE:
                             yield ": keepalive\n\n"
                             continue
@@ -1218,6 +1228,22 @@ async def chat_completion(request: Request):
                     # Stream ended ([DONE] or close): flush, then blank-bubble net.
                     for s in buf.finish():
                         yield _frame(s)
+                    # Reply stats — elapsed is measured here (not from the usage
+                    # chunk) so it reflects what the user actually waited for,
+                    # including any model load. tok/s is derived from the
+                    # server's completion_tokens when it reported them.
+                    _elapsed = round(time.time() - _t0, 1)
+                    _stats = {"elapsed_s": _elapsed, "model": model}
+                    if _usage:
+                        _ct = _usage.get("completion_tokens") or 0
+                        _stats.update(
+                            prompt_tokens=_usage.get("prompt_tokens"),
+                            completion_tokens=_ct,
+                            total_tokens=_usage.get("total_tokens"),
+                        )
+                        if _ct and _elapsed > 0:
+                            _stats["tok_per_s"] = round(_ct / _elapsed, 1)
+                    yield f"data: {json.dumps({'stats': _stats})}\n\n"
                     if show_thoughts:
                         for t in buf.drain_think():
                             yield f"data: {json.dumps({'think': t})}\n\n"

--- a/tests/test_model_switching.py
+++ b/tests/test_model_switching.py
@@ -124,3 +124,51 @@ def test_skill_resolves_aliases_and_prefers_active():
     # 'fast' matches every A3B model — the active one must win over the older 3.5
     assert ms._resolve("fast", models, active) == active
     assert ms._resolve("banana", models, active) is None
+
+
+# ── operator allowlist (models_visible) ──────────────────────────────────────
+# Discovery finds every loadable model on disk, including ones the operator does
+# not want offered. Hiding must not require deleting weights — screenshot_text.py
+# hardcodes the VL checkpoint, so deleting it would break screenshot OCR.
+
+
+def _cfg_with(tmp_path, monkeypatch, **extra):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"llm_model": "mlx-community/A", **extra}))
+    monkeypatch.setattr(codec_models, "CONFIG_PATH", str(path))
+    monkeypatch.setattr(codec_models, "discover_local",
+                        lambda: [{"id": "mlx-community/A", "label": "A", "size_gb": 1.0},
+                                 {"id": "mlx-community/B", "label": "B", "size_gb": 2.0},
+                                 {"id": "mlx-community/HIDE", "label": "H", "size_gb": 3.0}])
+    return path
+
+
+def test_allowlist_hides_models_from_picker(tmp_path, monkeypatch):
+    _cfg_with(tmp_path, monkeypatch,
+              models_visible=["mlx-community/A", "mlx-community/B"])
+    ids = [m["id"] for m in codec_models.list_models()["models"]]
+    assert ids == ["mlx-community/A", "mlx-community/B"]
+
+
+def test_hidden_model_cannot_be_switched_to(tmp_path, monkeypatch):
+    cfg = _cfg_with(tmp_path, monkeypatch,
+                    models_visible=["mlx-community/A", "mlx-community/B"])
+    monkeypatch.setattr(codec_models, "probe",
+                        lambda m, **kw: pytest.fail("hidden model must not be probed"))
+    r = codec_models.set_active("mlx-community/HIDE")
+    assert r["ok"] is False
+    assert json.loads(cfg.read_text())["llm_model"] == "mlx-community/A"
+
+
+def test_active_model_is_shown_even_if_not_in_allowlist(tmp_path, monkeypatch):
+    """Hiding what CODEC is currently running would be a lie."""
+    _cfg_with(tmp_path, monkeypatch, models_visible=["mlx-community/B"])
+    d = codec_models.list_models()
+    ids = [m["id"] for m in d["models"]]
+    assert d["active"] == "mlx-community/A"
+    assert "mlx-community/A" in ids
+
+
+def test_no_allowlist_shows_everything(tmp_path, monkeypatch):
+    _cfg_with(tmp_path, monkeypatch)
+    assert len(codec_models.list_models()["models"]) == 3

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -1,0 +1,84 @@
+"""codec_llm.stream(usage_sentinel=True) surfaces token counts.
+
+The server reports usage in a FINAL chunk whose `choices` list is EMPTY. The
+parser used to do choices[0] unconditionally, so that chunk raised IndexError and
+the counts were swallowed as a parse failure — which is why reply stats were
+impossible before.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+import codec_llm
+
+
+class _FakeResp:
+    status_code = 200
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    def iter_lines(self):
+        for ln in self._lines:
+            yield ln.encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _run(monkeypatch, lines, **kw):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None, stream=None):
+        captured["payload"] = json
+        return _FakeResp(lines)
+
+    import requests
+    monkeypatch.setattr(requests, "post", fake_post)
+    out = list(codec_llm.stream([{"role": "user", "content": "hi"}],
+                                base_url="http://x/v1", model="m", **kw))
+    return out, captured
+
+
+def _chunk(content):
+    return "data: " + json.dumps(
+        {"choices": [{"delta": {"content": content}}]})
+
+
+USAGE_CHUNK = "data: " + json.dumps(
+    {"choices": [], "usage": {"prompt_tokens": 15, "completion_tokens": 42,
+                              "total_tokens": 57}})
+
+
+def test_usage_is_yielded_as_a_typed_sentinel(monkeypatch):
+    out, _ = _run(monkeypatch, [_chunk("hi"), USAGE_CHUNK, "data: [DONE]"],
+                  usage_sentinel=True)
+    usage = [x for x in out if isinstance(x, codec_llm.StreamUsage)]
+    assert len(usage) == 1
+    assert usage[0]["completion_tokens"] == 42
+    # and it must NOT have leaked into the text stream
+    assert "".join(x for x in out if isinstance(x, str)) == "hi"
+
+
+def test_include_usage_only_requested_when_asked(monkeypatch):
+    _, cap = _run(monkeypatch, [_chunk("hi"), "data: [DONE]"], usage_sentinel=True)
+    assert cap["payload"]["stream_options"] == {"include_usage": True}
+    _, cap2 = _run(monkeypatch, [_chunk("hi"), "data: [DONE]"])
+    assert "stream_options" not in cap2["payload"]
+
+
+def test_usage_chunk_does_not_break_the_default_path(monkeypatch):
+    """A server that volunteers usage must not corrupt callers that didn't ask."""
+    out, _ = _run(monkeypatch, [_chunk("a"), USAGE_CHUNK, _chunk("b"),
+                                "data: [DONE]"])
+    assert "".join(x for x in out if isinstance(x, str)) == "ab"
+    assert not [x for x in out if isinstance(x, codec_llm.StreamUsage)]


### PR DESCRIPTION
Three things, all operator-visible.

### 1. Reply stats under every message
`12.4s · 847 tok · 61.7 tok/s · Qwen3.8-27B`, with a tooltip breaking out prompt vs completion tokens.

Elapsed is measured around the whole stream, so **a cold model load is included on purpose** — that's what you actually waited for. tok/s comes from the server's own `completion_tokens`, so it's measured, not estimated.

This required a real fix in `codec_llm.stream`: the server reports usage in a **final chunk whose `choices` list is empty**, and the parser did `choices[0]` unconditionally — so that chunk raised `IndexError` and got swallowed as a parse failure. That's why token counts were unavailable before. Usage is now handled before that access and surfaced as a typed `StreamUsage` sentinel behind an opt-in `usage_sentinel` flag (default off → existing callers untouched).

### 2. Model picker allowlist
`models_visible` in `config.json` restricts what the picker offers. Now set to **Qwen3.6-35B (everyday)** and **Qwen3.8-27B (coding)**.

Qwen3.5 and Qwen2.5-VL are **hidden, not deleted** — `skills/screenshot_text.py` *hardcodes* the VL checkpoint and voice/telegram/imessage fall back to it, so deleting the weights would break screenshot OCR. Hidden models aren't switchable either. The **active** model is always shown even if it's not in the allowlist, because hiding what CODEC is currently running would be a lie.

### 3. Attachments were silently dropped in Agents and Project mode
Reported live. `pendingFiles` was only read in the chat path, which the project and research branches `return` past — so a PDF attached in **Agents** ran the crew on the prompt alone: chips cleared, no error, no indication. **Project** mode was worse — `if(!text)return` dropped an attachment-only message entirely.

File context is now built **above** the mode branches. Research threads it through `researchText` (already wired into `payload.topic`/`task`); project sends it as the plan `description` instead of the bare prompt. Verified across all three modes, with and without accompanying text:

```
chat      PDF INCLUDED      chat     (file only) PDF INCLUDED
research  PDF INCLUDED      research (file only) PDF INCLUDED
project   PDF INCLUDED      project  (file only) PDF INCLUDED
```

### Verification
- **2735 passed, 78 skipped**; ruff clean; page JS `node --check` clean
- 3 new tests for the usage sentinel (including that usage never leaks into the text stream, and that a volunteering server can't corrupt callers who didn't ask) + 4 for the allowlist
- `test_self_improve_plugin` excluded from the run: network-flaky under parallel load, passes in isolation, and uses `codec_llm.call` not `stream` — untouched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)