### PR TITLE
design(chat): drop the last emoji — crew picker labels become plain text

### DIFF
--- a/codec_chat.html
+++ b/codec_chat.html
@@ -369,19 +369,19 @@ input[type=file]{display:none}
 <option value="">model…</option>
 </select>
 <select id="crewSelect">
-<option value="deep_research">🔍 Deep Research</option>
-<option value="daily_briefing">📰 Daily Briefing</option>
-<option value="trip_planner">✈️ Trip Planner</option>
-<option value="competitor_analysis">📊 Competitor Analysis</option>
-<option value="email_handler">📧 Email Handler</option>
-<option value="social_media">📱 Social Media</option>
-<option value="code_review">💻 Code Review</option>
-<option value="data_analysis">📈 Data Analysis</option>
-<option value="content_writer">✍️ Content Writer</option>
-<option value="meeting_summarizer">📋 Meeting Summarizer</option>
-<option value="invoice_generator">🧾 Invoice Generator</option>
-<option value="project_manager">📌 Project Manager</option>
-<option value="custom">⚙️ Custom Agent</option>
+<option value="deep_research">Deep Research</option>
+<option value="daily_briefing">Daily Briefing</option>
+<option value="trip_planner">Trip Planner</option>
+<option value="competitor_analysis">Competitor Analysis</option>
+<option value="email_handler">Email Handler</option>
+<option value="social_media">Social Media</option>
+<option value="code_review">Code Review</option>
+<option value="data_analysis">Data Analysis</option>
+<option value="content_writer">Content Writer</option>
+<option value="meeting_summarizer">Meeting Summarizer</option>
+<option value="invoice_generator">Invoice Generator</option>
+<option value="project_manager">Project Manager</option>
+<option value="custom">Custom Agent</option>
 </select>
 <button id="scheduleBtn" class="mode-btn" onclick="showSchedulePanel()" title="Schedule crew" style="display:none">
   <svg class="ico ico-sm" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>


### PR DESCRIPTION
The live `/chat` page was **still serving 13 emoji** — one per crew `<option>` in the Agents picker (magnifier, newspaper, aeroplane, chart, envelope, phone, laptop, graph, clipboard, pin, receipt, gear). I'd set these aside earlier as pre-existing; the live check after deploying the theme work caught them.

An `<option>` **cannot contain an SVG**, so the brand rule's other allowance applies: plain text. The crew names already say what each one is — the glyph carried no information.

```
- <option value="deep_research">🔍 Deep Research</option>
+ <option value="deep_research">Deep Research</option>
```

**Left deliberately:** `U+2715` MULTIPLICATION X (the close control) and `U+2192` RIGHTWARDS ARROW (in prose). Both are typography, not smartphone emoji, and the rule targets the latter.

This takes CODEC to **zero emoji across all five surfaces** — the dashboard's went in the token pass, cortex's theme glyphs became line-SVG with the auto-theme work, and these were the last.

**2737 passed, 78 skipped**; page JS `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)