### PR TITLE
feat(models): restart the model server on a switch instead of swapping in-place

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -563,6 +563,8 @@ These zones break running infrastructure if changed without coordination. NEVER 
 - `~/.codec/memory.db` schema — migrations require backup + rollback plan
 - `codec_audit.py` audit envelope schema — affects 30 days of logs
 - `_HTTP_BLOCKED` list in `codec_config.py` — security boundary
+- `scripts/start_model_server.sh` + `~/.codec/config.json:llm_model` — the launcher for PM2 `qwen3.6` reads the ACTIVE model from config at startup, so a model switch works by writing config and restarting the process (`codec_models.restart_server`). Two invariants: preload by the **hub id** the clients send, never a snapshot path (mlx_vlm caches by exact identifier, so a mismatch double-loads the whole checkpoint); and do NOT re-add `max_memory_restart` — PM2 measures RSS and MLX memory is GPU-backed, so the process reads ~60 MB of RSS while holding 20 GB. `footprint -p <pid>` is the only honest measure.
+- `~/.codec/config.json:model_pm2_process` — which PM2 process a model switch restarts (default `qwen3.6`). Pointing it at the wrong service means switches restart something else and never reclaim memory.
 - PM2 process names (real list: `open-codec`, `codec-dashboard`, `codec-autopilot`, `codec-heartbeat`, `codec-dictate`, `codec-hotkey`, `codec-imessage`, `codec-mcp-http`, `codec-overlay`, `codec-telegram`, `codec-watchdog`, plus support: `kokoro-82m`, `qwen3.6`, `whisper-stt`, `cloudflared`, `ava-license`, `ava-proxy`) — break supervision if renamed
 - Port assignments in `setup_codec.py` and `~/.codec/config.json` — break multi-machine LAN setup
 - Cloudflare tunnel hostnames (configured in `~/.cloudflared/config.yml` as `codec.<your-domain>`) — break PWA access from phone

--- a/codec_models.py
+++ b/codec_models.py
@@ -1,30 +1,54 @@
 """Runtime LLM model switching.
 
 CODEC serves every local model from ONE `mlx_vlm.server` on :8083. That server
-resolves the model per request (`get_cached_model(openai_request.model)`), so
-switching needs no second server and no restart — only a different `model` field.
+resolves the model per request (`get_cached_model(openai_request.model)`), so a
+switch needs no second server — only a different `model` field.
 
-Two consequences shape this module:
+**A switch restarts the PM2 process rather than swapping in-place.** In-place
+swapping works, but the server does not give the freed memory back: repeated
+switching grew it to 52 GB (measured) against a 19 GB model. A recording is
+exactly the wrong moment to discover that, and a fresh process is the only
+reliable way to reclaim it. Two things make the leak easy to miss:
 
-1. The server holds ONE model at a time. A switch UNLOADS the current model and
-   loads the new one, so a switch costs a load pause (~20-60s for a 15-20 GB
-   model) and two models can never be resident at once. Attempting to keep both
-   loaded thrashes swap and roughly halves generation speed — measured.
+- PM2's `max_memory_restart` guard cannot see it. PM2 measures RSS, and MLX
+  allocates GPU-backed memory that never appears there — the server reads ~60 MB
+  of RSS while holding 20 GB. `footprint -p <pid>` (`phys_footprint`) is the only
+  honest measure.
+- A restart is nearly free. `scripts/start_model_server.sh` preloads the active
+  model during FastAPI's lifespan, and uvicorn does not bind the port until
+  lifespan finishes — so "port accepts a connection" already means "model
+  loaded". That is what `restart_server()` waits for.
+
+Three further consequences shape this module:
+
+1. The server holds ONE model at a time. A switch costs a load pause (~20-60s
+   for a 15-20 GB model) and two models can never be resident at once.
+   Attempting to keep both loaded thrashes swap and roughly halves generation
+   speed — measured.
 
 2. If the target fails to load, the previous model is already gone and CODEC has
    NO brain. That is why `set_active()` probes after switching and reverts to the
    previous model when the probe fails. A bad switch must never leave the box
    mute.
 
+3. The restart is best-effort, never load-bearing. Where PM2 is absent (tests,
+   a hand-started server, CI) `restart_server()` reports failure and the switch
+   proceeds in-place exactly as before — `probe()` forces the load either way.
+   Losing the memory reclaim is a worse outcome than losing the switch.
+
 The chat handler re-reads ~/.codec/config.json on every request, so writing
-`llm_model` there takes effect on the next message with no restart.
+`llm_model` there takes effect on the next message.
 """
 from __future__ import annotations
 
 import json
 import os
+import shutil
+import socket
+import subprocess
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Dict, List, Optional
 
@@ -35,6 +59,19 @@ HF_CACHE = os.path.expanduser("~/.cache/huggingface/hub")
 
 DEFAULT_MODEL = "mlx-community/Qwen3.6-35B-A3B-4bit"
 DEFAULT_BASE_URL = "http://localhost:8083/v1"
+
+# PM2 process that serves the models. Overridable via config.json so a second
+# machine with a different service name does not need a code change.
+DEFAULT_PM2_PROCESS = "qwen3.6"
+
+# How long to wait for the restarted server to accept connections. Generous on
+# purpose: the port does not open until the model finishes preloading, and a
+# 20 GB checkpoint on a cold page cache is the slow case.
+_RESTART_READY_TIMEOUT = 300.0
+
+# How long to wait for PM2 to report a NEW pid. Only covers process teardown and
+# respawn, not the model load, so it is short.
+_RESTART_RESPAWN_TIMEOUT = 30.0
 
 # Local dirs that are not general chat models. Speech, vision-only and
 # GUI-grounding checkpoints are served on their own paths and must never appear
@@ -194,6 +231,100 @@ def probe(model_id: str, timeout: float = 240.0,
         return False, f"{type(e).__name__}: {e}"
 
 
+def _pm2_process_name(cfg: Optional[Dict[str, Any]] = None) -> str:
+    c = cfg if cfg is not None else _load_config()
+    return str(c.get("model_pm2_process") or DEFAULT_PM2_PROCESS)
+
+
+def _host_port(cfg: Dict[str, Any]) -> tuple[str, int]:
+    parsed = urllib.parse.urlparse(_base_url(cfg))
+    return parsed.hostname or "localhost", parsed.port or 8083
+
+
+def _is_listening(host: str, port: int, timeout: float = 1.5) -> bool:
+    """Bare TCP connect — the readiness signal, not an HTTP call.
+
+    Same reasoning as the #308 heartbeat fix: a socket that accepts a connection
+    proves the process is up without asking it to do any work. Here it proves
+    more, because uvicorn binds only after FastAPI's lifespan (and therefore the
+    model preload) has finished.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _pm2_pid(name: str) -> Optional[int]:
+    """Current pid of a PM2 process, or None if pm2 or the process is absent."""
+    pm2 = shutil.which("pm2")
+    if not pm2:
+        return None
+    try:
+        out = subprocess.run([pm2, "jlist"], capture_output=True, text=True,
+                             timeout=20).stdout
+        for proc in json.loads(out):
+            if proc.get("name") == name:
+                env = proc.get("pm2_env") or {}
+                if env.get("status") != "online":
+                    return None
+                return proc.get("pid") or None
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+    return None
+
+
+def restart_server(process: Optional[str] = None,
+                   ready_timeout: float = _RESTART_READY_TIMEOUT) -> tuple[bool, str]:
+    """Restart the model server via PM2 and wait until it serves again.
+
+    Returns (ok, detail). Never raises: a failure here downgrades the switch to
+    the old in-place behaviour rather than aborting it.
+
+    Waiting is two-stage because the port is a liar for the first moment after
+    `pm2 restart` — the OLD process still holds it, so an immediate connect
+    succeeds and we would return before the new process exists. So: wait for PM2
+    to report a different pid, THEN wait for that pid to bind the port.
+    """
+    cfg = _load_config()
+    name = process or _pm2_process_name(cfg)
+    host, port = _host_port(cfg)
+
+    pm2 = shutil.which("pm2")
+    if not pm2:
+        return False, "pm2 not on PATH — switching in place"
+
+    before = _pm2_pid(name)
+    t0 = time.time()
+    # NOTE: `pm2 start <name>` fails (pm2 reads the name as a filename);
+    # `restart` is the verb that accepts a process name.
+    try:
+        r = subprocess.run([pm2, "restart", name, "--update-env"],
+                           capture_output=True, text=True, timeout=60)
+    except subprocess.SubprocessError as e:
+        return False, f"pm2 restart {name} failed: {type(e).__name__}: {e}"
+    if r.returncode != 0:
+        err = (r.stderr or r.stdout or "").strip().replace("\n", " ")[:200]
+        return False, f"pm2 restart {name} exited {r.returncode}: {err}"
+
+    deadline = time.time() + _RESTART_RESPAWN_TIMEOUT
+    while time.time() < deadline:
+        now = _pm2_pid(name)
+        if now is not None and now != before:
+            break
+        time.sleep(0.5)
+    else:
+        return False, f"{name} did not respawn within {_RESTART_RESPAWN_TIMEOUT:.0f}s"
+
+    deadline = time.time() + ready_timeout
+    while time.time() < deadline:
+        if _is_listening(host, port):
+            return True, f"{name} restarted, serving in {time.time() - t0:.1f}s"
+        time.sleep(1.0)
+    return False, f"{name} restarted but {host}:{port} never opened within {ready_timeout:.0f}s"
+
+
 def _write_active(model_id: str) -> None:
     cfg = _load_config()
     cfg["llm_model"] = model_id
@@ -222,34 +353,52 @@ def set_active(model_id: str, verify: bool = True) -> Dict[str, Any]:
 
     _write_active(model_id)
     if not verify:
+        # No restart either: an unverified switch is the caller asking not to
+        # wait, and a restart is the longest part of the wait.
         return {"ok": True, "active": model_id, "previous": previous,
                 "changed": True, "detail": "switched (unverified)"}
 
+    # Config is written first so the restarted server preloads the NEW model.
+    restarted, restart_detail = restart_server()
+
     ok, detail = probe(model_id)
     if ok:
-        _emit_audit(previous, model_id, True, detail)
+        _emit_audit(previous, model_id, True, detail, restarted, restart_detail)
         return {"ok": True, "active": model_id, "previous": previous,
-                "changed": True, "detail": detail}
+                "changed": True, "detail": detail,
+                "restarted": restarted, "restart_detail": restart_detail}
 
     # Failed to load — the old model is already unloaded, so put it back and
-    # warm it, otherwise CODEC answers nothing at all.
+    # warm it, otherwise CODEC answers nothing at all. Restart again on the way
+    # back: the process that just failed to load a model is the last one we want
+    # to keep serving from.
     _write_active(previous)
+    restart_server()
     reverted_ok, revert_detail = probe(previous)
-    _emit_audit(previous, model_id, False, detail)
+    _emit_audit(previous, model_id, False, detail, restarted, restart_detail)
     return {"ok": False, "active": previous, "attempted": model_id,
             "changed": False,
             "error": f"{model_id} failed to load ({detail}) — reverted to {previous}",
-            "reverted": reverted_ok, "revert_detail": revert_detail}
+            "reverted": reverted_ok, "revert_detail": revert_detail,
+            "restarted": restarted, "restart_detail": restart_detail}
 
 
-def _emit_audit(previous: str, requested: str, ok: bool, detail: str) -> None:
+def _emit_audit(previous: str, requested: str, ok: bool, detail: str,
+                restarted: Optional[bool] = None,
+                restart_detail: str = "") -> None:
     try:
         from codec_audit import audit
+        extra = {"previous": previous, "requested": requested,
+                 "ok": ok, "detail": detail[:200]}
+        if restarted is not None:
+            # Recorded so a switch that quietly fell back to in-place — and
+            # therefore did NOT reclaim memory — is visible after the fact.
+            extra["restarted"] = restarted
+            extra["restart_detail"] = restart_detail[:200]
         audit(event="model_switched", source="codec-models",
               outcome="ok" if ok else "error",
               level="info" if ok else "warning",
               message=f"model switch {previous} -> {requested}",
-              extra={"previous": previous, "requested": requested,
-                     "ok": ok, "detail": detail[:200]})
+              extra=extra)
     except Exception:
         pass

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -76,17 +76,26 @@ module.exports = {
       autorestart: true,
     },
 
-    // ── LLM + Vision Server (Qwen 3.6 via mlx_vlm) ──
+    // ── LLM + Vision Server (via mlx_vlm) ──
     // Single unified server on :8083 — the Qwen 3.6 35B model handles both
     // text reasoning and vision, so one mlx_vlm.server replaces the old
     // split mlx_lm(:8081) + VL(:8082) layout. config.json's llm_base_url
     // and vision_base_url both point here.
+    //
+    // WHICH model it serves comes from ~/.codec/config.json:llm_model, read by
+    // the launcher at startup — NOT from this file. That is what lets a model
+    // switch restart this process instead of swapping in-place, which is how
+    // the server's memory gets reclaimed (see codec_models.restart_server).
+    //
+    // No max_memory_restart: PM2 measures RSS, and MLX allocates GPU-backed
+    // memory that never lands in RSS. This process reads ~60 MB of RSS while
+    // holding 20 GB, so the old "8G" guard could never fire — it read as
+    // protection that did not exist. `footprint -p <pid>` is the real measure.
     {
       name: "qwen3.6",
-      script: "bash",
-      args: "-c 'python3 -m mlx_vlm.server --model mlx-community/Qwen3.6-35B-A3B-4bit --port 8083'",
+      script: "scripts/start_model_server.sh",
+      interpreter: "bash",
       cwd: __dirname,
-      max_memory_restart: "8G",
       restart_delay: 10000,
       max_restarts: 5,
       autorestart: true,

--- a/scripts/start_model_server.sh
+++ b/scripts/start_model_server.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# CODEC model server launcher (PM2 process `qwen3.6`).
+#
+# Reads the ACTIVE model from ~/.codec/config.json instead of hardcoding one, so
+# `codec_models.set_active()` can switch models by writing the config and
+# restarting this process. A restart is how CODEC reclaims memory: swapping
+# models in-place leaks, and repeated in-place switching grew the server to
+# 52 GB against a 19 GB model.
+#
+# Preloads by the SAME identifier the clients send (the hub id, e.g.
+# mlx-community/Qwen3.6-35B-A3B-4bit). mlx_vlm caches by exact identifier, so
+# preloading a snapshot path while chat requests the hub id makes the first
+# request evict the preloaded copy and load the same 19 GB again — the previous
+# launcher did exactly that, and it is where the 39 GB footprint peak came from.
+#
+# uvicorn binds the port only after FastAPI's lifespan finishes, and the preload
+# happens in lifespan. So "the port accepts a connection" already means "the
+# model is loaded" — that is the readiness signal restart_server() waits on.
+set -euo pipefail
+
+CONFIG="${CODEC_CONFIG:-$HOME/.codec/config.json}"
+VENV="${CODEC_MODEL_VENV:-$HOME/codec-qwen38-venv}"
+DEFAULT_MODEL="mlx-community/Qwen3.6-35B-A3B-4bit"
+DEFAULT_PORT=8083
+HOST="${CODEC_MODEL_HOST:-0.0.0.0}"
+
+# Model and port both come from config.json so there is ONE source of truth.
+# Any failure here (missing file, bad JSON, no key) falls through to the
+# defaults rather than refusing to start — a mute CODEC is the worse outcome.
+read -r MODEL PORT <<<"$(
+  CONFIG="$CONFIG" DEFAULT_MODEL="$DEFAULT_MODEL" DEFAULT_PORT="$DEFAULT_PORT" \
+  python3 - <<'PY' 2>/dev/null || echo "$DEFAULT_MODEL $DEFAULT_PORT"
+import json, os
+from urllib.parse import urlparse
+cfg = {}
+try:
+    with open(os.environ["CONFIG"]) as f:
+        cfg = json.load(f)
+except Exception:
+    pass
+model = cfg.get("llm_model") or os.environ["DEFAULT_MODEL"]
+try:
+    port = urlparse(cfg.get("llm_base_url", "")).port or int(os.environ["DEFAULT_PORT"])
+except Exception:
+    port = int(os.environ["DEFAULT_PORT"])
+print(model, port)
+PY
+)"
+
+[ -n "${MODEL:-}" ] || MODEL="$DEFAULT_MODEL"
+[ -n "${PORT:-}" ] || PORT="$DEFAULT_PORT"
+
+if [ -f "$VENV/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  source "$VENV/bin/activate"
+else
+  echo "start_model_server: venv not found at $VENV — using system python3" >&2
+fi
+
+echo "start_model_server: model=$MODEL port=$PORT host=$HOST" >&2
+exec python -m mlx_vlm.server --model "$MODEL" --port "$PORT" --host "$HOST"

--- a/tests/test_model_switching.py
+++ b/tests/test_model_switching.py
@@ -19,6 +19,18 @@ if str(REPO) not in sys.path:
 import codec_models
 
 
+@pytest.fixture(autouse=True)
+def no_real_pm2(monkeypatch):
+    """Never let the suite restart the operator's actual model server.
+
+    `restart_server()` shells out to a real `pm2`, which exists on any machine
+    that runs CODEC — so an unmocked test would take the brain offline mid-run.
+    Hiding pm2 makes restart_server return its clean "switching in place"
+    failure. Tests that exercise the restart override this themselves.
+    """
+    monkeypatch.setattr(codec_models.shutil, "which", lambda _name: None)
+
+
 @pytest.fixture
 def cfg(tmp_path, monkeypatch):
     path = tmp_path / "config.json"
@@ -172,3 +184,142 @@ def test_active_model_is_shown_even_if_not_in_allowlist(tmp_path, monkeypatch):
 def test_no_allowlist_shows_everything(tmp_path, monkeypatch):
     _cfg_with(tmp_path, monkeypatch)
     assert len(codec_models.list_models()["models"]) == 3
+
+
+# ── Restart-on-switch (memory reclaim) ────────────────────────────────────────
+# A switch restarts the PM2 model process rather than swapping in-place, because
+# in-place swapping does not give the memory back (52 GB measured against a
+# 19 GB model). The restart must never be load-bearing: where PM2 is missing the
+# switch still has to happen, just without the reclaim.
+
+def test_switch_restarts_the_server_after_writing_config(cfg, monkeypatch):
+    """Order matters: the launcher reads llm_model at startup, so the config
+    must already name the NEW model when the process comes back."""
+    events = []
+
+    def fake_restart(*a, **kw):
+        events.append(("restart", json.loads(cfg.read_text())["llm_model"]))
+        return True, "restarted"
+
+    monkeypatch.setattr(codec_models, "restart_server", fake_restart)
+    monkeypatch.setattr(codec_models, "probe",
+                        lambda m, **kw: (events.append(("probe", m)), (True, "loaded"))[1])
+
+    r = codec_models.set_active("mlx-community/B")
+
+    assert r["ok"] and r["restarted"] is True
+    assert events == [("restart", "mlx-community/B"), ("probe", "mlx-community/B")], \
+        "config must be written before the restart, and probed after it"
+
+
+def test_switch_survives_a_failed_restart(cfg, monkeypatch):
+    """No pm2 (tests, CI, a hand-started server) must degrade to the old
+    in-place swap, not fail the switch."""
+    monkeypatch.setattr(codec_models, "restart_server",
+                        lambda *a, **kw: (False, "pm2 not on PATH — switching in place"))
+    monkeypatch.setattr(codec_models, "probe", lambda m, **kw: (True, "loaded in 30s"))
+
+    r = codec_models.set_active("mlx-community/B")
+
+    assert r["ok"] and r["active"] == "mlx-community/B"
+    assert r["restarted"] is False
+    assert "pm2" in r["restart_detail"]
+    assert json.loads(cfg.read_text())["llm_model"] == "mlx-community/B"
+
+
+def test_failed_switch_restarts_again_before_reverting(cfg, monkeypatch):
+    """The process that just failed to load a model is not the one to keep
+    serving from — the revert restarts too, with the old model back in config."""
+    seen = []
+    monkeypatch.setattr(codec_models, "restart_server",
+                        lambda *a, **kw: (seen.append(("restart", json.loads(cfg.read_text())["llm_model"])),
+                                          (True, "restarted"))[1])
+    monkeypatch.setattr(
+        codec_models, "probe",
+        lambda m, **kw: (seen.append(("probe", m)),
+                         (False, "HTTP 500") if m == "mlx-community/B" else (True, "reloaded"))[1])
+
+    r = codec_models.set_active("mlx-community/B")
+
+    assert r["ok"] is False and r["active"] == "mlx-community/A"
+    assert seen == [("restart", "mlx-community/B"), ("probe", "mlx-community/B"),
+                    ("restart", "mlx-community/A"), ("probe", "mlx-community/A")]
+    assert json.loads(cfg.read_text())["llm_model"] == "mlx-community/A"
+
+
+def test_unverified_switch_does_not_restart(cfg, monkeypatch):
+    """verify=False is the caller asking not to wait, and the restart is the
+    longest part of the wait."""
+    monkeypatch.setattr(codec_models, "restart_server",
+                        lambda *a, **kw: pytest.fail("must not restart when unverified"))
+    monkeypatch.setattr(codec_models, "probe",
+                        lambda m, **kw: pytest.fail("must not probe when unverified"))
+    r = codec_models.set_active("mlx-community/B", verify=False)
+    assert r["ok"] and json.loads(cfg.read_text())["llm_model"] == "mlx-community/B"
+
+
+def test_restart_server_without_pm2_is_a_clean_failure(cfg, monkeypatch):
+    monkeypatch.setattr(codec_models.shutil, "which", lambda _: None)
+    ok, detail = codec_models.restart_server()
+    assert ok is False and "pm2" in detail
+
+
+def test_restart_server_waits_for_a_new_pid_then_the_port(cfg, monkeypatch):
+    """The port lies for a moment after `pm2 restart` — the OLD process still
+    holds it. Returning on that first connect would report ready before the new
+    process exists."""
+    monkeypatch.setattr(codec_models.shutil, "which", lambda _: "/usr/bin/pm2")
+    monkeypatch.setattr(codec_models.subprocess, "run",
+                        lambda *a, **kw: __import__("types").SimpleNamespace(
+                            returncode=0, stdout="", stderr=""))
+    monkeypatch.setattr(codec_models.time, "sleep", lambda _s: None)
+
+    pids = iter([111, 111, 222, 222, 222])
+    monkeypatch.setattr(codec_models, "_pm2_pid", lambda name: next(pids, 222))
+    listens = iter([False, False, True])
+    monkeypatch.setattr(codec_models, "_is_listening",
+                        lambda h, p, **kw: next(listens, True))
+
+    ok, detail = codec_models.restart_server()
+    assert ok is True and "serving in" in detail
+
+
+def test_restart_server_reports_a_port_that_never_opens(cfg, monkeypatch):
+    monkeypatch.setattr(codec_models.shutil, "which", lambda _: "/usr/bin/pm2")
+    monkeypatch.setattr(codec_models.subprocess, "run",
+                        lambda *a, **kw: __import__("types").SimpleNamespace(
+                            returncode=0, stdout="", stderr=""))
+    monkeypatch.setattr(codec_models.time, "sleep", lambda _s: None)
+    pids = iter([111, 222])
+    monkeypatch.setattr(codec_models, "_pm2_pid", lambda name: next(pids, 222))
+    monkeypatch.setattr(codec_models, "_is_listening", lambda h, p, **kw: False)
+
+    ok, detail = codec_models.restart_server(ready_timeout=0.01)
+    assert ok is False and "never opened" in detail
+
+
+def test_restart_server_reports_a_nonzero_pm2_exit(cfg, monkeypatch):
+    monkeypatch.setattr(codec_models.shutil, "which", lambda _: "/usr/bin/pm2")
+    monkeypatch.setattr(codec_models.subprocess, "run",
+                        lambda *a, **kw: __import__("types").SimpleNamespace(
+                            returncode=1, stdout="", stderr="Process not found"))
+    ok, detail = codec_models.restart_server()
+    assert ok is False and "Process not found" in detail
+
+
+def test_restart_targets_the_configured_process_and_port(tmp_path, monkeypatch):
+    """A second machine renames the service in config.json, not in code."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"model_pm2_process": "qwen-other",
+                                "llm_base_url": "http://127.0.0.1:9999/v1"}))
+    monkeypatch.setattr(codec_models, "CONFIG_PATH", str(path))
+    assert codec_models._pm2_process_name() == "qwen-other"
+    assert codec_models._host_port(codec_models._load_config()) == ("127.0.0.1", 9999)
+
+
+def test_restart_process_name_defaults(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    path.write_text("{}")
+    monkeypatch.setattr(codec_models, "CONFIG_PATH", str(path))
+    assert codec_models._pm2_process_name() == codec_models.DEFAULT_PM2_PROCESS
+    assert codec_models._host_port({}) == ("localhost", 8083)


### PR DESCRIPTION
## Why

Repeated in-place model switching grew the mlx_vlm server to **52 GB** against a 19 GB model. A switch now writes the config, restarts the PM2 process, then probes. A fresh process is the only reliable way to reclaim it, and a recording is the wrong moment to discover that.

## Three things that made the leak easy to miss

**1. The `max_memory_restart: "8G"` guard could never fire.** PM2 measures RSS; MLX allocates GPU-backed memory that never lands there. Measured on the live server:

```
RSS:              60 MB
phys_footprint:   20 GB
phys_footprint_peak: 39 GB
```

Removed rather than left in place reading as protection that does not exist. `footprint -p <pid>` is the honest measure.

**2. Every start double-loaded the model.** The launcher preloaded a snapshot *path* while chat and `probe()` send the hub *id*. mlx_vlm caches by exact identifier, so the first request after every start evicted the preloaded copy and loaded the same 19 GB again — that is where the 39 GB peak came from. `scripts/start_model_server.sh` preloads the hub id now, and reads *which* model from `~/.codec/config.json` so a restart brings back the model just selected.

**3. The committed ecosystem entry had drifted from the live process.** It ran `python3 -m mlx_vlm.server` at repo cwd — the old interpreter, not `~/codec-qwen38-venv`. Re-creating the service from the repo produced a server that could not load. Both now point at the same launcher.

## How the wait works

Readiness is a bare TCP connect — the #308 trick — and it proves more here than it did there: uvicorn binds the port only after FastAPI's lifespan finishes, and the preload happens *in* lifespan. An open port already means a loaded model.

Two-stage, because the port lies for a moment after `pm2 restart`: the **old** process still holds it, so an immediate connect succeeds and we would report ready before the new process exists. It waits for PM2 to report a different pid first, then for that pid to bind.

## Safety

The restart is best-effort, never load-bearing. Where pm2 is absent (tests, CI, a hand-started server), `restart_server()` returns a clean failure and the switch proceeds in-place exactly as before — losing the reclaim beats losing the switch. The `model_switched` audit records which path ran, so a switch that silently fell back is visible after the fact.

A failed switch restarts again on the way back: the process that just failed to load a model is not the one to keep serving from.

## Tests

11 new — write-then-restart-then-probe ordering, degradation without pm2, the double restart on revert, no restart when `verify=False`, the two-stage pid/port wait, config-driven process name and port.

An autouse fixture hides pm2 from the whole suite. Without it these tests shell out to a real `pm2` and restart the operator's live model server mid-run.

`2768 passed, 78 skipped` locally; ruff clean.

## Deploy note

The live `qwen3.6` still runs the old out-of-repo `start.sh` from a worktree cwd. Picking this up needs `pm2 delete qwen3.6` + re-add from `ecosystem.config.js` — brain offline for one model load. Not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)