### PR TITLE
fix(pwa): route every storage access through a shim that cannot throw

### DIFF
--- a/codec_audit.html
+++ b/codec_audit.html
@@ -314,10 +314,28 @@ body { display: flex; flex-direction: column; overflow: hidden; }
 </div>
 
 <script>
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
+<script>
 function openSidePanel(){document.getElementById('sidePanel').classList.add('open');document.getElementById('sidePanelOverlay').classList.add('open')}
 function closeSidePanel(){document.getElementById('sidePanel').classList.remove('open');document.getElementById('sidePanelOverlay').classList.remove('open')}
-var _voiceOn=localStorage.getItem('codec-voice')==='true';
-function toggleVoiceReply(){_voiceOn=!_voiceOn;localStorage.setItem('codec-voice',_voiceOn);updateVoiceIcon()}
+var _voiceOn=_lsGet('codec-voice')==='true';
+function toggleVoiceReply(){_voiceOn=!_voiceOn;_lsSet('codec-voice',_voiceOn);updateVoiceIcon()}
 function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#E8711A'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
 updateVoiceIcon();
 const CATEGORIES = [
@@ -348,17 +366,17 @@ function init() {
 
 // --- Theme ---
 function loadTheme() {
-  const saved = localStorage.getItem('codec-theme');
+  const saved = _lsGet('codec-theme');
   if (saved === 'light') document.documentElement.setAttribute('data-theme', 'light');
 }
 document.getElementById('themeToggle').onclick = function() {
   const isLight = document.documentElement.getAttribute('data-theme') === 'light';
   if (isLight) {
     document.documentElement.removeAttribute('data-theme');
-    localStorage.setItem('codec-theme', 'dark');
+    _lsSet('codec-theme', 'dark');
   } else {
     document.documentElement.setAttribute('data-theme', 'light');
-    localStorage.setItem('codec-theme', 'light');
+    _lsSet('codec-theme', 'light');
   }
 };
 

--- a/codec_auth.html
+++ b/codec_auth.html
@@ -195,9 +195,27 @@
     </div>
 
     <script>
-function toggleTheme(){var t=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',t);localStorage.setItem('codec-theme',t);updateThemeIcon(t)}
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
+<script>
+function toggleTheme(){var t=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',t);_lsSet('codec-theme',t);updateThemeIcon(t)}
 function updateThemeIcon(t){document.getElementById('themeIco').innerHTML=t==='light'?'<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>':'<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}
-(function(){var s=localStorage.getItem('codec-theme');if(s==='light'){document.documentElement.setAttribute('data-theme','light');updateThemeIcon('light')}})();
+(function(){var s=_lsGet('codec-theme');if(s==='light'){document.documentElement.setAttribute('data-theme','light');updateThemeIcon('light')}})();
 
 var isRemote = location.hostname !== 'localhost' && location.hostname !== '127.0.0.1';
 if (isRemote) {
@@ -425,7 +443,7 @@ function completeLogin() {
     if (location.protocol === 'https:') _ck += '; Secure';
     document.cookie = _ck;
     // Also store in sessionStorage as fallback (Android Chrome may not persist cookies)
-    try { sessionStorage.setItem('codec_session', _pendingToken); } catch(e) {}
+    try { _ssSet('codec_session', _pendingToken); } catch(e) {}
     // CSRF double-submit token (readable by JS, paired with x-csrf-token header)
     var _csrf = _pendingToken.substring(0, 16);
     document.cookie = 'codec_csrf=' + _csrf + '; path=/; max-age=' + _exp + '; SameSite=Lax';
@@ -447,7 +465,7 @@ function _e2eNegotiateAuth() {
     return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){
         return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){
             return fetch('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){
-                if(d.pub){sessionStorage.setItem('_e2eReady','1')}
+                if(d.pub){_ssSet('_e2eReady','1')}
             });
         });
     }).catch(function(e){console.warn('E2E key exchange skipped:',e)});

--- a/codec_chat.html
+++ b/codec_chat.html
@@ -466,13 +466,31 @@ input[type=file]{display:none}
 <div class="toast" id="toast"></div>
 
 <script>
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
+<script>
 function openSidePanel(){document.getElementById('sidePanel').classList.add('open');document.getElementById('sidePanelOverlay').classList.add('open')}
 function closeSidePanel(){document.getElementById('sidePanel').classList.remove('open');document.getElementById('sidePanelOverlay').classList.remove('open')}
 // Auth + CSRF: inject session token and CSRF header on all requests
 // On mobile (Android Chrome), cookies may not persist — fallback to sessionStorage
 (function(){
 var _f=window.fetch;
-function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||sessionStorage.getItem('codec_session')||''}
+function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||_ssGet('codec_session')||''}
 function _injectSession(url){var s=_getSession();if(!s)return url;var sep=url.indexOf('?')>=0?'&':'?';return url+sep+'s='+s}
 var _authRedirecting=false;
 window.fetch=function(u,o){
@@ -490,11 +508,11 @@ window.fetch=function(u,o){
 // E2E encryption layer — AES-256-GCM via ECDH key exchange
 var _e2eKey=null;
 (function(){var _f2=window.fetch;function _b64(buf){var bytes=new Uint8Array(buf),CHUNK=8192,str='';for(var i=0;i<bytes.length;i+=CHUNK){str+=String.fromCharCode.apply(null,bytes.subarray(i,i+CHUNK))}return btoa(str)}function _unb64(s){var b=atob(s),a=new Uint8Array(b.length);for(var i=0;i<b.length;i++)a[i]=b.charCodeAt(i);return a}
-window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;sessionStorage.setItem('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
+window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;_ssSet('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
 var _e2eRetrying=false;
 window.fetch=function(u,o){o=o||{};var _origBody=o.body;if(!_e2eKey)return _f2.call(this,u,o);var method=(o.method||'GET').toUpperCase();if(method!=='GET'&&o.body){var iv=crypto.getRandomValues(new Uint8Array(12));return crypto.subtle.encrypt({name:'AES-GCM',iv:iv},_e2eKey,new TextEncoder().encode(o.body)).then(function(ct){o.body=JSON.stringify({iv:_b64(iv),ct:_b64(ct)});o.headers=o.headers||{};if(o.headers instanceof Headers){o.headers.set('x-e2e','1');o.headers.set('Content-Type','application/json')}else{o.headers['x-e2e']='1';o.headers['Content-Type']='application/json'}return _f2.call(this,u,o)}.bind(this)).then(function(r){if(r.status===428&&!_e2eRetrying){_e2eRetrying=true;_e2eKey=null;return window._e2eNegotiate().then(function(){_e2eRetrying=false;o.body=_origBody;delete o.headers['x-e2e'];return window.fetch(u,o)}).catch(function(){_e2eRetrying=false;return r})}return _decResp(r)})}return _f2.call(this,u,o).then(_decResp)};
 function _decResp(r){if(!_e2eKey||r.headers.get('x-e2e')!=='1')return r;return r.clone().json().then(function(d){if(!d.iv||!d.ct)return r;var iv=_unb64(d.iv),ct=_unb64(d.ct);return crypto.subtle.decrypt({name:'AES-GCM',iv:iv},_e2eKey,ct).then(function(pt){var txt=new TextDecoder().decode(pt);return new Response(txt,{status:r.status,headers:r.headers})})}).catch(function(){return r})}
-if(sessionStorage.getItem('_e2eReady'))window._e2eNegotiate();
+if(_ssGet('_e2eReady'))window._e2eNegotiate();
 })();
 var SYS="You are *CODEC Deep Chat* \u2014 a J.A.R.V.I.S.-class AI running locally on a Mac Studio M1 Ultra (64GB unified RAM). Fully self-hosted via MLX. No cloud dependency.\n\n" +
 "### THE 7 CODEC PRODUCTS\n" +
@@ -537,7 +555,7 @@ function buildSystem(){return SYS+(thinkingEnabled?'':CONCISE_MODE);}
 
 // Working folder allocated to this chat (like a working directory). Sent with
 // every message so file operations can be scoped to it. Persists per-browser.
-var _workdir=localStorage.getItem('codec_workdir')||'';
+var _workdir=_lsGet('codec_workdir')||'';
 function _renderWorkdir(){
   var chip=document.getElementById('workdirChip');
   if(_workdir){document.getElementById('workdirPath').textContent=_workdir;chip.style.display='flex'}
@@ -545,13 +563,13 @@ function _renderWorkdir(){
 }
 function pickWorkingFolder(){
   fetch('/api/pick-folder',{method:'POST'}).then(function(r){return r.json()}).then(function(j){
-    if(j&&j.ok&&j.path){_workdir=j.path;localStorage.setItem('codec_workdir',_workdir);_renderWorkdir();
+    if(j&&j.ok&&j.path){_workdir=j.path;_lsSet('codec_workdir',_workdir);_renderWorkdir();
       showToast('Working folder: '+_workdir)}
     else if(j&&j.cancelled){/* user dismissed — no-op */}
     else{showToast((j&&j.error)||'Could not open folder picker')}
   }).catch(function(){showToast('Folder picker unavailable')});
 }
-function clearWorkingFolder(){_workdir='';localStorage.removeItem('codec_workdir');_renderWorkdir();}
+function clearWorkingFolder(){_workdir='';_lsDel('codec_workdir');_renderWorkdir();}
 _renderWorkdir();
 var chatHist=[],isProcessing=false,isRecording=false,recognition=null;
 var pendingFiles=[];
@@ -943,14 +961,14 @@ function parseScaffold(raw){
 
 function genId(){return Date.now().toString(36)+Math.random().toString(36).substr(2,5)}
 
-function startNewSession(){sessionId=genId();localStorage.setItem('codec-chat-session',sessionId);chatHist=[];pendingFiles=[];document.getElementById('fileChips').innerHTML='';document.getElementById('messages').innerHTML='<div class="empty-state" id="emptyState"><img src="https://i.imgur.com/jD1X5W8.png"><p>Deep Chat \u2014 250K context window<br>Drop files, images, or just talk.</p></div>'}
+function startNewSession(){sessionId=genId();_lsSet('codec-chat-session',sessionId);chatHist=[];pendingFiles=[];document.getElementById('fileChips').innerHTML='';document.getElementById('messages').innerHTML='<div class="empty-state" id="emptyState"><img src="https://i.imgur.com/jD1X5W8.png"><p>Deep Chat \u2014 250K context window<br>Drop files, images, or just talk.</p></div>'}
 
 // PR #39: persist sessionId across page reloads. If a previous session
 // exists, load it on boot so the user lands back on the same chat (with
 // any project plan cards rehydrated). Falls back to a fresh session if
 // the previous one's GET returns empty.
 (function bootSession(){
-  var saved=localStorage.getItem('codec-chat-session');
+  var saved=_lsGet('codec-chat-session');
   if(!saved){startNewSession();return}
   // Optimistically load \u2014 if the session is empty/missing, we'll start fresh
   fetch('/api/qchat/session/'+saved).then(function(r){
@@ -987,7 +1005,7 @@ async function saveMessages(msgs){
 // value is always stamped on data-theme, so every existing [data-theme="light"]
 // rule keeps working untouched. An explicit light/dark choice pins it and stops
 // following the OS until the user cycles back to system.
-function _themePref(){var v=null;try{v=localStorage.getItem('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
+function _themePref(){var v=null;try{v=_lsGet('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
 function _themeResolved(pref){
   if(pref==='light'||pref==='dark')return pref;
   try{return (window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches)?'light':'dark'}catch(e){return 'dark'}
@@ -999,7 +1017,7 @@ function applyTheme(){
 }
 function toggleTheme(){
   var order=['system','light','dark'],next=order[(order.indexOf(_themePref())+1)%3];
-  try{localStorage.setItem('codec-theme',next)}catch(e){}
+  try{_lsSet('codec-theme',next)}catch(e){}
   applyTheme();
   if(typeof showToast==='function')showToast(next==='system'?'Theme follows your system':'Theme: '+next);
 }
@@ -1048,7 +1066,7 @@ async function loadSidebarHistory(){
 }
 
 async function loadSession(sid){
-  closeSidebar();sessionId=sid;localStorage.setItem('codec-chat-session',sid);chatHist=[];pendingFiles=[];
+  closeSidebar();sessionId=sid;_lsSet('codec-chat-session',sid);chatHist=[];pendingFiles=[];
   document.getElementById('fileChips').innerHTML='';
   var es=document.getElementById('emptyState');if(es)es.remove();
   document.getElementById('messages').innerHTML='';
@@ -1940,8 +1958,8 @@ async function deleteSelectedAgent(){
 function lockSession(){fetch('/api/auth/logout',{method:'POST'}).then(function(){document.cookie='codec_session=;path=/;max-age=0;SameSite=Lax'+(location.protocol==='https:'?';Secure':'');window.location.href='/auth'})}
 
 // ── Header icons (matching dashboard) ──
-var voiceReplyEnabled=localStorage.getItem('codec-voice')==='true';
-function toggleVoiceReply(){voiceReplyEnabled=!voiceReplyEnabled;localStorage.setItem('codec-voice',voiceReplyEnabled);updateVoiceIcon();updateSpeakToggle()}
+var voiceReplyEnabled=_lsGet('codec-voice')==='true';
+function toggleVoiceReply(){voiceReplyEnabled=!voiceReplyEnabled;_lsSet('codec-voice',voiceReplyEnabled);updateVoiceIcon();updateSpeakToggle()}
 function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(voiceReplyEnabled){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#d97757'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
 function updateSpeakToggle(){
   var btn=document.getElementById('speakToggle');
@@ -2065,7 +2083,7 @@ function showSchedulePanel(){
   });
 })();
 // Apply UI preferences from dashboard settings
-(function(){try{var p=JSON.parse(localStorage.getItem('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn','chat_sidebar':'#sidebar,#sidebarOverlay,.sidebar-toggle','chat_agents':'#modeResearchBtn','chat_agent_builder':'#agentBuilder'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
+(function(){try{var p=JSON.parse(_lsGet('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn','chat_sidebar':'#sidebar,#sidebarOverlay,.sidebar-toggle','chat_agents':'#modeResearchBtn','chat_agent_builder':'#agentBuilder'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
 </script>
 <div class="webcam-pip" id="webcamPip">
   <img id="pipVideo" alt="Mac Webcam" onclick="expandPip()" style="cursor:pointer" />
@@ -2315,13 +2333,13 @@ async function viewAgentPlan(agentId,e){
 // terminal status (done / failed / aborted), or by user clicking ×
 // on the "Talking to …" chip above the composer.
 var _activeAgentId = null;
-try { _activeAgentId = localStorage.getItem('codec-active-agent') || null; } catch(e) {}
+try { _activeAgentId = _lsGet('codec-active-agent') || null; } catch(e) {}
 
 function setActiveAgent(id){
   _activeAgentId = id;
   try {
-    if (id) localStorage.setItem('codec-active-agent', id);
-    else    localStorage.removeItem('codec-active-agent');
+    if (id) _lsSet('codec-active-agent', id);
+    else    _lsDel('codec-active-agent');
   } catch(e) {}
   renderActiveAgentChip();
 }
@@ -2354,12 +2372,12 @@ function renderActiveAgentChip(){
 }
 
 // ── Live preview panel: shows recent files produced by the active agent ──────
-var _livePreviewOpen = (localStorage.getItem('codec-live-preview') === 'true');
+var _livePreviewOpen = (_lsGet('codec-live-preview') === 'true');
 var _livePreviewTimer = null;
 function toggleLivePreview(e){
   if (e) e.preventDefault();
   _livePreviewOpen = !_livePreviewOpen;
-  try { localStorage.setItem('codec-live-preview', _livePreviewOpen ? 'true' : 'false'); } catch(err){}
+  try { _lsSet('codec-live-preview', _livePreviewOpen ? 'true' : 'false'); } catch(err){}
   renderLivePreviewPanel();
 }
 function renderLivePreviewPanel(){

--- a/codec_cortex.html
+++ b/codec_cortex.html
@@ -264,6 +264,24 @@ svg text{font-family:'IBM Plex Sans',-apple-system,system-ui,sans-serif}
 <div class="legend" id="legend"></div>
 
 <script>
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
+<script>
 // Hide header/nav when embedded in dashboard iframe
 if(window.location.search.indexOf('embed=1')!==-1){
   document.addEventListener('DOMContentLoaded',function(){
@@ -276,8 +294,8 @@ if(window.location.search.indexOf('embed=1')!==-1){
 }
 function openSidePanel(){document.getElementById('sidePanel').classList.add('open');document.getElementById('sidePanelOverlay').classList.add('open')}
 function closeSidePanel(){document.getElementById('sidePanel').classList.remove('open');document.getElementById('sidePanelOverlay').classList.remove('open')}
-var _voiceOn=(function(){try{return localStorage.getItem('codec-voice')==='true'}catch(e){return false}})();
-function toggleVoiceReply(){_voiceOn=!_voiceOn;try{localStorage.setItem('codec-voice',_voiceOn)}catch(e){}updateVoiceIcon()}
+var _voiceOn=(function(){try{return _lsGet('codec-voice')==='true'}catch(e){return false}})();
+function toggleVoiceReply(){_voiceOn=!_voiceOn;try{_lsSet('codec-voice',_voiceOn)}catch(e){}updateVoiceIcon()}
 function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#d97757'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
 updateVoiceIcon();
 // Theme
@@ -289,7 +307,7 @@ updateVoiceIcon();
 var _SUN_SVG='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/></svg>';
 var _MOON_SVG='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>';
 var _AUTO_SVG='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 000 18z" fill="currentColor" stroke="none"/></svg>';
-function _themePref(){var v=null;try{v=localStorage.getItem('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
+function _themePref(){var v=null;try{v=_lsGet('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
 function _themeResolved(pref){
   if(pref==='light'||pref==='dark')return pref;
   try{return (window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches)?'light':'dark'}catch(e){return 'dark'}
@@ -306,7 +324,7 @@ function applyCortexTheme(){
 }
 function toggleCortexTheme(){
   var order=['system','light','dark'],next=order[(order.indexOf(_themePref())+1)%3];
-  try{localStorage.setItem('codec-theme',next)}catch(e){}
+  try{_lsSet('codec-theme',next)}catch(e){}
   applyCortexTheme();
 }
 (function(){

--- a/codec_dashboard.html
+++ b/codec_dashboard.html
@@ -856,6 +856,24 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
 <div class="toast" id="toast"></div>
 
 <script>
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
+<script>
 // Side panel open/close
 function openSidePanel(){document.getElementById('sidePanel').classList.add('open');document.getElementById('sidePanelOverlay').classList.add('open');if(typeof refreshWakeState==='function')refreshWakeState()}
 function closeSidePanel(){document.getElementById('sidePanel').classList.remove('open');document.getElementById('sidePanelOverlay').classList.remove('open')}
@@ -863,7 +881,7 @@ function closeSidePanel(){document.getElementById('sidePanel').classList.remove(
 // On mobile (Android Chrome), cookies may not persist — fallback to sessionStorage
 (function(){
 var _f=window.fetch;
-function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||sessionStorage.getItem('codec_session')||''}
+function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||_ssGet('codec_session')||''}
 function _injectSession(url){var s=_getSession();if(!s)return url;var sep=url.indexOf('?')>=0?'&':'?';return url+sep+'s='+s}
 window.fetch=function(u,o){
   o=o||{};
@@ -881,11 +899,11 @@ window.fetch=function(u,o){
 // E2E encryption layer — AES-256-GCM via ECDH key exchange
 var _e2eKey=null;
 (function(){var _f2=window.fetch;function _b64(buf){var bytes=new Uint8Array(buf),CHUNK=8192,str='';for(var i=0;i<bytes.length;i+=CHUNK){str+=String.fromCharCode.apply(null,bytes.subarray(i,i+CHUNK))}return btoa(str)}function _unb64(s){var b=atob(s),a=new Uint8Array(b.length);for(var i=0;i<b.length;i++)a[i]=b.charCodeAt(i);return a}
-window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;sessionStorage.setItem('_e2eReady','1');var eb=document.getElementById('e2eBadge');if(eb)eb.style.display=''})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
+window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;_ssSet('_e2eReady','1');var eb=document.getElementById('e2eBadge');if(eb)eb.style.display=''})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
 var _e2eRetrying=false;
 window.fetch=function(u,o){o=o||{};var _origBody=o.body;if(!_e2eKey)return _f2.call(this,u,o);var method=(o.method||'GET').toUpperCase();if(method!=='GET'&&o.body){var iv=crypto.getRandomValues(new Uint8Array(12));return crypto.subtle.encrypt({name:'AES-GCM',iv:iv},_e2eKey,new TextEncoder().encode(o.body)).then(function(ct){o.body=JSON.stringify({iv:_b64(iv),ct:_b64(ct)});o.headers=o.headers||{};if(o.headers instanceof Headers){o.headers.set('x-e2e','1');o.headers.set('Content-Type','application/json')}else{o.headers['x-e2e']='1';o.headers['Content-Type']='application/json'}return _f2.call(this,u,o)}.bind(this)).then(function(r){if(r.status===428&&!_e2eRetrying){_e2eRetrying=true;_e2eKey=null;return window._e2eNegotiate().then(function(){_e2eRetrying=false;o.body=_origBody;delete o.headers['x-e2e'];return window.fetch(u,o)}).catch(function(){_e2eRetrying=false;return r})}return _decResp(r)})}return _f2.call(this,u,o).then(_decResp)};
 function _decResp(r){if(!_e2eKey||r.headers.get('x-e2e')!=='1')return r;return r.clone().json().then(function(d){if(!d.iv||!d.ct)return r;var iv=_unb64(d.iv),ct=_unb64(d.ct);return crypto.subtle.decrypt({name:'AES-GCM',iv:iv},_e2eKey,ct).then(function(pt){var txt=new TextDecoder().decode(pt);return new Response(txt,{status:r.status,headers:r.headers})})}).catch(function(){return r})}
-if(sessionStorage.getItem('_e2eReady'))window._e2eNegotiate();
+if(_ssGet('_e2eReady'))window._e2eNegotiate();
 })();
 // ── State ──
 var currentTab = 'chat';
@@ -989,7 +1007,7 @@ function copyText(text, btn) {
 // rule keeps working untouched. An explicit light/dark choice pins it.
 function _themePref() {
   var v = null;
-  try { v = localStorage.getItem('codec-theme'); } catch (e) {}
+  try { v = _lsGet('codec-theme'); } catch (e) {}
   return (v === 'light' || v === 'dark' || v === 'system') ? v : 'system';
 }
 function _themeResolved(pref) {
@@ -1013,7 +1031,7 @@ function applyTheme() {
 // for any other caller and for keyboard users.
 function setThemePref(v) {
   if (v !== 'system' && v !== 'light' && v !== 'dark') return;
-  try { localStorage.setItem('codec-theme', v); } catch (e) {}
+  try { _lsSet('codec-theme', v); } catch (e) {}
   applyTheme();
   if (typeof showToast === 'function') {
     showToast(v === 'system' ? 'Theme follows your system' : 'Theme: ' + v);
@@ -1022,7 +1040,7 @@ function setThemePref(v) {
 function toggleTheme() {
   var order = ['system', 'light', 'dark'];
   var next = order[(order.indexOf(_themePref()) + 1) % 3];
-  try{localStorage.setItem('codec-theme',next)}catch(e){}
+  try{_lsSet('codec-theme',next)}catch(e){}
   applyTheme();
   if (typeof showToast === 'function') {
     showToast(next === 'system' ? 'Theme follows your system' : 'Theme: ' + next);
@@ -2164,10 +2182,10 @@ var _uiFeatures = {
 };
 
 function _getUIPrefs() {
-  try { return JSON.parse(localStorage.getItem('codec-ui-prefs') || '{}'); } catch(e) { return {}; }
+  try { return JSON.parse(_lsGet('codec-ui-prefs') || '{}'); } catch(e) { return {}; }
 }
 function _saveUIPrefs(prefs) {
-  localStorage.setItem('codec-ui-prefs', JSON.stringify(prefs));
+  _lsSet('codec-ui-prefs', JSON.stringify(prefs));
   // Also save to server for cross-device sync
   fetch('/api/config', { method: 'PUT', headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({ ui_prefs: prefs }) }).catch(function(){});
@@ -2317,10 +2335,10 @@ function fmtTime(ts) {
 }
 
 // ── Voice Replies ──
-var voiceEnabled = localStorage.getItem('codec-voice') === 'true';
+var voiceEnabled = _lsGet('codec-voice') === 'true';
 function toggleVoice() {
   voiceEnabled = !voiceEnabled;
-  localStorage.setItem('codec-voice', voiceEnabled);
+  _lsSet('codec-voice', voiceEnabled);
   updateVoiceIcon();
   if (!voiceEnabled) stopPlayback();
 }
@@ -2934,7 +2952,7 @@ window.addEventListener('beforeinstallprompt', function(e) { deferredPrompt = e;
 // ── Sparkle-compatible update banner ──────────────────────────────────────────
 var _updateInfo = null;
 async function checkForUpdate(){
-  if (sessionStorage.getItem('codec-update-dismissed') === '1') return;
+  if (_ssGet('codec-update-dismissed') === '1') return;
   try{
     var r = await fetch('/api/update/check');
     if(!r.ok) return;
@@ -2969,7 +2987,7 @@ async function downloadUpdate(){
 }
 function dismissUpdate(e){
   if(e) e.preventDefault();
-  try{ sessionStorage.setItem('codec-update-dismissed','1'); }catch(_){}
+  try{ _ssSet('codec-update-dismissed','1'); }catch(_){}
   var b = document.getElementById('updateBanner'); if(b) b.style.display='none';
 }
 function escapeHtml(s){ return String(s==null?'':s).replace(/[&<>"']/g, function(c){

--- a/codec_tasks.html
+++ b/codec_tasks.html
@@ -427,13 +427,31 @@ a { color: var(--accent); text-decoration: none; }
 <div class="toast-container" id="toastContainer"></div>
 
 <script>
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
+<script>
 function openSidePanel(){document.getElementById('sidePanel').classList.add('open');document.getElementById('sidePanelOverlay').classList.add('open')}
 function closeSidePanel(){document.getElementById('sidePanel').classList.remove('open');document.getElementById('sidePanelOverlay').classList.remove('open')}
 // Auth + CSRF: inject session token and CSRF header on all requests
 // On mobile (Android Chrome), cookies may not persist — fallback to sessionStorage
 (function(){
 var _f=window.fetch;
-function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||sessionStorage.getItem('codec_session')||''}
+function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||_ssGet('codec_session')||''}
 function _injectSession(url){var s=_getSession();if(!s)return url;var sep=url.indexOf('?')>=0?'&':'?';return url+sep+'s='+s}
 window.fetch=function(u,o){
   o=o||{};
@@ -444,18 +462,18 @@ window.fetch=function(u,o){
 // E2E encryption layer — AES-256-GCM via ECDH key exchange
 var _e2eKey=null;
 (function(){var _f2=window.fetch;function _b64(buf){var bytes=new Uint8Array(buf),CHUNK=8192,str='';for(var i=0;i<bytes.length;i+=CHUNK){str+=String.fromCharCode.apply(null,bytes.subarray(i,i+CHUNK))}return btoa(str)}function _unb64(s){var b=atob(s),a=new Uint8Array(b.length);for(var i=0;i<b.length;i++)a[i]=b.charCodeAt(i);return a}
-window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;sessionStorage.setItem('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
+window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;_ssSet('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
 var _e2eRetrying=false;
 window.fetch=function(u,o){o=o||{};var _origBody=o.body;if(!_e2eKey)return _f2.call(this,u,o);var method=(o.method||'GET').toUpperCase();if(method!=='GET'&&o.body){var iv=crypto.getRandomValues(new Uint8Array(12));return crypto.subtle.encrypt({name:'AES-GCM',iv:iv},_e2eKey,new TextEncoder().encode(o.body)).then(function(ct){o.body=JSON.stringify({iv:_b64(iv),ct:_b64(ct)});o.headers=o.headers||{};if(o.headers instanceof Headers){o.headers.set('x-e2e','1');o.headers.set('Content-Type','application/json')}else{o.headers['x-e2e']='1';o.headers['Content-Type']='application/json'}return _f2.call(this,u,o)}.bind(this)).then(function(r){if(r.status===428&&!_e2eRetrying){_e2eRetrying=true;_e2eKey=null;return window._e2eNegotiate().then(function(){_e2eRetrying=false;o.body=_origBody;delete o.headers['x-e2e'];return window.fetch(u,o)}).catch(function(){_e2eRetrying=false;return r})}return _decResp(r)})}return _f2.call(this,u,o).then(_decResp)};
 function _decResp(r){if(!_e2eKey||r.headers.get('x-e2e')!=='1')return r;return r.clone().json().then(function(d){if(!d.iv||!d.ct)return r;var iv=_unb64(d.iv),ct=_unb64(d.ct);return crypto.subtle.decrypt({name:'AES-GCM',iv:iv},_e2eKey,ct).then(function(pt){var txt=new TextDecoder().decode(pt);return new Response(txt,{status:r.status,headers:r.headers})})}).catch(function(){return r})}
-if(sessionStorage.getItem('_e2eReady'))window._e2eNegotiate();
+if(_ssGet('_e2eReady'))window._e2eNegotiate();
 })();
 /* ── Theme ── */
-function toggleTheme(){var t=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',t);localStorage.setItem('codec-theme',t);updateThemeIcon(t)}
+function toggleTheme(){var t=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',t);_lsSet('codec-theme',t);updateThemeIcon(t)}
 function updateThemeIcon(t){var ico=document.getElementById('themeIco');if(t==='light'){ico.innerHTML='<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>'}else{ico.innerHTML='<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}}
 function lockSession(){fetch('/api/auth/logout',{method:'POST'}).then(function(){document.cookie='codec_session=;path=/;max-age=0;SameSite=Lax'+(location.protocol==='https:'?';Secure':'');window.location.href='/auth'})}
-var _voiceOn=localStorage.getItem('codec-voice')==='true';
-function toggleVoiceReply(){_voiceOn=!_voiceOn;localStorage.setItem('codec-voice',_voiceOn);updateVoiceIcon()}
+var _voiceOn=_lsGet('codec-voice')==='true';
+function toggleVoiceReply(){_voiceOn=!_voiceOn;_lsSet('codec-voice',_voiceOn);updateVoiceIcon()}
 function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#E8711A'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
 updateVoiceIcon();
 // ── Screenshot (shows preview) ──
@@ -572,7 +590,7 @@ function savePipFrame() {
 })();
 function pollStatus(){fetch('/api/health').then(function(r){return r.json()}).then(function(d){var dot=document.getElementById('statusDot');if(dot){dot.classList.toggle('on',!!d.ok)}}).catch(function(){var dot=document.getElementById('statusDot');if(dot)dot.classList.remove('on')})}
 pollStatus();setInterval(pollStatus,15000);
-(function(){var s=localStorage.getItem('codec-theme');if(s==='light'){document.documentElement.setAttribute('data-theme','light');updateThemeIcon('light')}})();
+(function(){var s=_lsGet('codec-theme');if(s==='light'){document.documentElement.setAttribute('data-theme','light');updateThemeIcon('light')}})();
 
 /* ── Tabs: showTab is defined once, canonically, lower in this file
       (tab switch + reports load). ── */
@@ -1063,7 +1081,7 @@ function showTab(name) {
 }
 
 // Apply UI preferences from dashboard settings
-(function(){try{var p=JSON.parse(localStorage.getItem('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn','tasks_heartbeat':'#tab-heartbeat','tasks_reports':'#tab-reports'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
+(function(){try{var p=JSON.parse(_lsGet('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn','tasks_heartbeat':'#tab-heartbeat','tasks_reports':'#tab-reports'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
 </script>
 <!-- Preview Modal (screenshot + webcam photo) -->
 <div class="preview-modal" id="previewModal" onclick="closePreview(event)">

--- a/codec_vibe.html
+++ b/codec_vibe.html
@@ -13,6 +13,24 @@
      the upstream files to mint the pinned hashes. Until then, browsers
      still validate the TLS chain to cdnjs.cloudflare.com itself. -->
 <link rel="stylesheet" crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.45.0/min/vs/editor/editor.main.min.css">
+<script>
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
 <script crossorigin="anonymous" src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.8/purify.min.js"></script>
 <style>
 :root {
@@ -280,7 +298,7 @@ function closeSidePanel(){document.getElementById('sidePanel').classList.remove(
 // On mobile (Android Chrome), cookies may not persist — fallback to sessionStorage
 (function(){
 var _f=window.fetch;
-function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||sessionStorage.getItem('codec_session')||''}
+function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||_ssGet('codec_session')||''}
 function _injectSession(url){var s=_getSession();if(!s)return url;var sep=url.indexOf('?')>=0?'&':'?';return url+sep+'s='+s}
 window.fetch=function(u,o){
   o=o||{};
@@ -291,17 +309,17 @@ window.fetch=function(u,o){
 // E2E encryption layer — AES-256-GCM via ECDH key exchange
 var _e2eKey=null;
 (function(){var _f2=window.fetch;function _b64(buf){var bytes=new Uint8Array(buf),CHUNK=8192,str='';for(var i=0;i<bytes.length;i+=CHUNK){str+=String.fromCharCode.apply(null,bytes.subarray(i,i+CHUNK))}return btoa(str)}function _unb64(s){var b=atob(s),a=new Uint8Array(b.length);for(var i=0;i<b.length;i++)a[i]=b.charCodeAt(i);return a}
-window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;sessionStorage.setItem('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
+window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;_ssSet('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
 var _e2eRetrying=false;
 window.fetch=function(u,o){o=o||{};var _origBody=o.body;if(!_e2eKey)return _f2.call(this,u,o);var method=(o.method||'GET').toUpperCase();if(method!=='GET'&&o.body){var iv=crypto.getRandomValues(new Uint8Array(12));return crypto.subtle.encrypt({name:'AES-GCM',iv:iv},_e2eKey,new TextEncoder().encode(o.body)).then(function(ct){o.body=JSON.stringify({iv:_b64(iv),ct:_b64(ct)});o.headers=o.headers||{};if(o.headers instanceof Headers){o.headers.set('x-e2e','1');o.headers.set('Content-Type','application/json')}else{o.headers['x-e2e']='1';o.headers['Content-Type']='application/json'}return _f2.call(this,u,o)}.bind(this)).then(function(r){if(r.status===428&&!_e2eRetrying){_e2eRetrying=true;_e2eKey=null;return window._e2eNegotiate().then(function(){_e2eRetrying=false;o.body=_origBody;delete o.headers['x-e2e'];return window.fetch(u,o)}).catch(function(){_e2eRetrying=false;return r})}return _decResp(r)})}return _f2.call(this,u,o).then(_decResp)};
 function _decResp(r){if(!_e2eKey||r.headers.get('x-e2e')!=='1')return r;return r.clone().json().then(function(d){if(!d.iv||!d.ct)return r;var iv=_unb64(d.iv),ct=_unb64(d.ct);return crypto.subtle.decrypt({name:'AES-GCM',iv:iv},_e2eKey,ct).then(function(pt){var txt=new TextDecoder().decode(pt);return new Response(txt,{status:r.status,headers:r.headers})})}).catch(function(){return r})}
-if(sessionStorage.getItem('_e2eReady'))window._e2eNegotiate();
+if(_ssGet('_e2eReady'))window._e2eNegotiate();
 })();
 // ── Theme: system / light / dark ──────────────────────────────────────────
 // 'system' is the DEFAULT and follows the OS day-night setting live. The
 // resolved value is stamped on data-theme (so existing [data-theme="light"]
 // rules work untouched) AND pushed into Monaco, which has its own theme.
-function _themePref(){var v=null;try{v=localStorage.getItem('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
+function _themePref(){var v=null;try{v=_lsGet('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
 function _themeResolved(pref){
   if(pref==='light'||pref==='dark')return pref;
   try{return (window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches)?'light':'dark'}catch(e){return 'dark'}
@@ -314,14 +332,14 @@ function applyTheme(){
 }
 function toggleTheme(){
   var order=['system','light','dark'],next=order[(order.indexOf(_themePref())+1)%3];
-  try{localStorage.setItem('codec-theme',next)}catch(e){}applyTheme();
+  try{_lsSet('codec-theme',next)}catch(e){}applyTheme();
 }
 try{if(window.matchMedia){matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if(_themePref()==='system')applyTheme()})}}catch(e){}
 window.addEventListener('storage',function(e){if(e.key==='codec-theme')applyTheme()});
 function updateThemeIcon(t){var ico=document.getElementById('themeIco');if(t==='light'){ico.innerHTML='<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>'}else{ico.innerHTML='<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}}
 function lockSession(){fetch('/api/auth/logout',{method:'POST'}).then(function(){document.cookie='codec_session=;path=/;max-age=0;SameSite=Lax'+(location.protocol==='https:'?';Secure':'');window.location.href='/auth'})}
-var _voiceOn=localStorage.getItem('codec-voice')==='true';
-function toggleVoiceReply(){_voiceOn=!_voiceOn;localStorage.setItem('codec-voice',_voiceOn);updateVoiceIcon()}
+var _voiceOn=_lsGet('codec-voice')==='true';
+function toggleVoiceReply(){_voiceOn=!_voiceOn;_lsSet('codec-voice',_voiceOn);updateVoiceIcon()}
 function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#d97757'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
 updateVoiceIcon();
 function takeScreenshot(){fetch('/api/screenshot',{method:'POST'}).then(function(r){return r.json()}).then(function(d){if(d.path)alert('Screenshot saved: '+d.path)}).catch(function(){})}
@@ -564,7 +582,7 @@ function doStop() {
 
 // Working folder allocated to this Vibe session (like a working directory),
 // sent with every message so file operations scope to it. Persists per-browser.
-var _workdir = localStorage.getItem('codec_workdir') || '';
+var _workdir = _lsGet('codec_workdir') || '';
 function _renderVibeWorkdir() {
   var chip = document.getElementById('vibeWorkdirChip');
   if (!_workdir) { if (chip) chip.style.display = 'none'; return; }
@@ -582,11 +600,11 @@ function _renderVibeWorkdir() {
 }
 function pickWorkingFolder() {
   fetch('/api/pick-folder', {method: 'POST'}).then(function(r){return r.json()}).then(function(j){
-    if (j && j.ok && j.path) { _workdir = j.path; localStorage.setItem('codec_workdir', _workdir); _renderVibeWorkdir(); }
+    if (j && j.ok && j.path) { _workdir = j.path; _lsSet('codec_workdir', _workdir); _renderVibeWorkdir(); }
     else if (!(j && j.cancelled)) { alert((j && j.error) || 'Could not open folder picker'); }
   }).catch(function(){ alert('Folder picker unavailable'); });
 }
-function clearWorkingFolder() { _workdir = ''; localStorage.removeItem('codec_workdir'); _renderVibeWorkdir(); }
+function clearWorkingFolder() { _workdir = ''; _lsDel('codec_workdir'); _renderVibeWorkdir(); }
 
 function doSend() {
   var inp = document.getElementById('vi');
@@ -1231,7 +1249,7 @@ document.getElementById('vi').addEventListener('input', function() {
   });
 })();
 // Apply UI preferences from dashboard settings
-(function(){try{var p=JSON.parse(localStorage.getItem('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
+(function(){try{var p=JSON.parse(_lsGet('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
 </script>
 <div class="webcam-pip" id="webcamPip">
   <img id="pipVideo" alt="Mac Webcam" onclick="expandPip()" style="cursor:pointer" />

--- a/codec_voice.html
+++ b/codec_voice.html
@@ -569,13 +569,31 @@
     </div>
 
     <script>
+/* Safe storage accessors — use these, never localStorage/sessionStorage directly.
+
+   Storage access THROWS when blocked; it does not return null. Safari private
+   mode, a hardened profile, and an iframe whose third-party storage is blocked
+   all raise on the FIRST touch. An unguarded read at the top level of a script
+   therefore kills that entire script: every statement after it, theme init
+   included, silently never runs, and the page looks fine while being half-dead.
+   That is exactly what happened to cortex, which the dashboard embeds in an
+   iframe. Reads degrade to null, writes to no-ops — a page with no persisted
+   preferences beats a page with no JavaScript. */
+function _lsGet(k){try{return localStorage.getItem(k)}catch(e){return null}}
+function _lsSet(k,v){try{localStorage.setItem(k,v)}catch(e){}}
+function _lsDel(k){try{localStorage.removeItem(k)}catch(e){}}
+function _ssGet(k){try{return sessionStorage.getItem(k)}catch(e){return null}}
+function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
+function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
+</script>
+<script>
     function openSidePanel(){document.getElementById('sidePanel').classList.add('open');document.getElementById('sidePanelOverlay').classList.add('open')}
     function closeSidePanel(){document.getElementById('sidePanel').classList.remove('open');document.getElementById('sidePanelOverlay').classList.remove('open')}
     // Auth + CSRF: inject session token and CSRF header on all requests
     // On mobile (Android Chrome), cookies may not persist — fallback to sessionStorage
     (function(){
     var _f=window.fetch;
-    function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||sessionStorage.getItem('codec_session')||''}
+    function _getSession(){return document.cookie.match(/codec_session=([^;]+)/)?.[1]||_ssGet('codec_session')||''}
     function _injectSession(url){var s=_getSession();if(!s)return url;var sep=url.indexOf('?')>=0?'&':'?';return url+sep+'s='+s}
     window.fetch=function(u,o){
       o=o||{};
@@ -586,11 +604,11 @@
     // E2E encryption layer — AES-256-GCM via ECDH key exchange
     var _e2eKey=null;
     (function(){var _f2=window.fetch;function _b64(buf){var bytes=new Uint8Array(buf),CHUNK=8192,str='';for(var i=0;i<bytes.length;i+=CHUNK){str+=String.fromCharCode.apply(null,bytes.subarray(i,i+CHUNK))}return btoa(str)}function _unb64(s){var b=atob(s),a=new Uint8Array(b.length);for(var i=0;i<b.length;i++)a[i]=b.charCodeAt(i);return a}
-    window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;sessionStorage.setItem('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
+    window._e2eNegotiate=function(){return crypto.subtle.generateKey({name:'ECDH',namedCurve:'P-256'},true,['deriveBits']).then(function(kp){return crypto.subtle.exportKey('raw',kp.publicKey).then(function(pub){return _f2('/api/auth/keyexchange',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:_b64(pub)})}).then(function(r){return r.json()}).then(function(d){var srvPub=_unb64(d.pub);return crypto.subtle.importKey('raw',srvPub,{name:'ECDH',namedCurve:'P-256'},false,[]).then(function(srvKey){return crypto.subtle.deriveBits({name:'ECDH',public:srvKey},kp.privateKey,256)}).then(function(bits){return crypto.subtle.importKey('raw',bits,{name:'HKDF'},false,['deriveKey'])}).then(function(hkdfKey){return crypto.subtle.deriveKey({name:'HKDF',hash:'SHA-256',salt:new Uint8Array(0),info:new TextEncoder().encode('codec-e2e')},hkdfKey,{name:'AES-GCM',length:256},false,['encrypt','decrypt'])}).then(function(k){_e2eKey=k;_ssSet('_e2eReady','1')})})})}).catch(function(e){console.warn('E2E negotiation failed:',e)})};
     var _e2eRetrying=false;
 window.fetch=function(u,o){o=o||{};var _origBody=o.body;if(!_e2eKey)return _f2.call(this,u,o);var method=(o.method||'GET').toUpperCase();if(method!=='GET'&&o.body){var iv=crypto.getRandomValues(new Uint8Array(12));return crypto.subtle.encrypt({name:'AES-GCM',iv:iv},_e2eKey,new TextEncoder().encode(o.body)).then(function(ct){o.body=JSON.stringify({iv:_b64(iv),ct:_b64(ct)});o.headers=o.headers||{};if(o.headers instanceof Headers){o.headers.set('x-e2e','1');o.headers.set('Content-Type','application/json')}else{o.headers['x-e2e']='1';o.headers['Content-Type']='application/json'}return _f2.call(this,u,o)}.bind(this)).then(function(r){if(r.status===428&&!_e2eRetrying){_e2eRetrying=true;_e2eKey=null;return window._e2eNegotiate().then(function(){_e2eRetrying=false;o.body=_origBody;delete o.headers['x-e2e'];return window.fetch(u,o)}).catch(function(){_e2eRetrying=false;return r})}return _decResp(r)})}return _f2.call(this,u,o).then(_decResp)};
     function _decResp(r){if(!_e2eKey||r.headers.get('x-e2e')!=='1')return r;return r.clone().json().then(function(d){if(!d.iv||!d.ct)return r;var iv=_unb64(d.iv),ct=_unb64(d.ct);return crypto.subtle.decrypt({name:'AES-GCM',iv:iv},_e2eKey,ct).then(function(pt){var txt=new TextDecoder().decode(pt);return new Response(txt,{status:r.status,headers:r.headers})})}).catch(function(){return r})}
-    if(sessionStorage.getItem('_e2eReady'))window._e2eNegotiate();
+    if(_ssGet('_e2eReady'))window._e2eNegotiate();
     })();
     /* ── Theme support ── */
     // ── Theme: system / light / dark ──────────────────────────────────────────
@@ -598,7 +616,7 @@ window.fetch=function(u,o){o=o||{};var _origBody=o.body;if(!_e2eKey)return _f2.c
 // darkens with macOS at sunset without anyone touching a toggle. The resolved
 // value is always stamped on data-theme, so every existing [data-theme="light"]
 // rule keeps working untouched. An explicit light/dark choice pins it.
-function _themePref(){var v=null;try{v=localStorage.getItem('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
+function _themePref(){var v=null;try{v=_lsGet('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
 function _themeResolved(pref){
   if(pref==='light'||pref==='dark')return pref;
   try{return (window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches)?'light':'dark'}catch(e){return 'dark'}
@@ -610,15 +628,15 @@ function applyTheme(){
 }
 function toggleTheme(){
   var order=['system','light','dark'],next=order[(order.indexOf(_themePref())+1)%3];
-  try{localStorage.setItem('codec-theme',next)}catch(e){}applyTheme();
+  try{_lsSet('codec-theme',next)}catch(e){}applyTheme();
   if(typeof showToast==='function')showToast(next==='system'?'Theme follows your system':'Theme: '+next);
 }
 try{if(window.matchMedia){matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if(_themePref()==='system')applyTheme()})}}catch(e){}
 window.addEventListener('storage',function(e){if(e.key==='codec-theme')applyTheme()});
     function updateThemeIcon(t){var ico=document.getElementById('themeIco');if(t==='light'){ico.innerHTML='<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>'}else{ico.innerHTML='<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}}
     function lockSession(){fetch('/api/auth/logout',{method:'POST'}).then(function(){document.cookie='codec_session=;path=/;max-age=0;SameSite=Lax'+(location.protocol==='https:'?';Secure':'');window.location.href='/auth'})}
-    var _voiceOn=localStorage.getItem('codec-voice')==='true';
-    function toggleVoiceReply(){_voiceOn=!_voiceOn;localStorage.setItem('codec-voice',_voiceOn);updateVoiceIcon()}
+    var _voiceOn=_lsGet('codec-voice')==='true';
+    function toggleVoiceReply(){_voiceOn=!_voiceOn;_lsSet('codec-voice',_voiceOn);updateVoiceIcon()}
     function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#d97757'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
     updateVoiceIcon();
     function takeScreenshot(){fetch('/api/screenshot',{method:'POST'}).then(function(r){return r.json()}).then(function(d){if(d.path)alert('Screenshot saved: '+d.path)}).catch(function(){})}
@@ -1221,7 +1239,7 @@ window.addEventListener('storage',function(e){if(e.key==='codec-theme')applyThem
       });
     })();
     // Apply UI preferences from dashboard settings
-    (function(){try{var p=JSON.parse(localStorage.getItem('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn','voice_transcript':'.transcript-wrap','voice_actions':'#actionRow'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
+    (function(){try{var p=JSON.parse(_lsGet('codec-ui-prefs')||'{}'),m={'screenshot_btn':'#screenBtn','photo_btn':'#photoBtn','webcam_pip_btn':'#camBtn','voice_btn':'#voiceBtn','notif_bell':'#notifBellBtn','mic_btn':'#micBtn','voice_transcript':'.transcript-wrap','voice_actions':'#actionRow'};Object.keys(m).forEach(function(k){if(p[k]===false)m[k].split(',').forEach(function(s){document.querySelectorAll(s.trim()).forEach(function(el){el.style.display='none'})})})}catch(e){}})();
     </script>
 <div class="webcam-pip" id="webcamPip">
   <img id="pipVideo" alt="Mac Webcam" onclick="expandPip()" style="cursor:pointer" />

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -184,3 +184,32 @@ regenerate `skills/.manifest.json`, or delete both files.
 (May 13) living in `~/.codec/skills/`, not repo files. Moved to
 `~/.codec/pilot_archive/` — recordings preserved, skills dir clean,
 `tests/test_skills.py` fully green (160/160).
+
+## Auth routes write unsigned plaintext into the HMAC-signed audit log (2026-08-21)
+
+`routes/_shared._audit_write` appends raw strings straight to `~/.codec/audit.log`,
+bypassing `codec_audit.audit()` and therefore the whole PR-2E envelope — no HMAC,
+no secret redaction, no JSON. Nine call sites in `routes/auth.py`, all
+security-relevant, several carrying client IPs:
+
+    [2026-08-21T12:15:12.532832] TOTP_SETUP: 2FA enabled
+
+Three consequences, in order of severity:
+
+1. **`audit_verify` reports the operator's log as tampered, permanently.**
+   Measured on the live log: `total_lines 599, signed 597, broken 2,
+   integrity_ok False` — and both broken lines are these auth writes. The
+   tamper-detection feature built in PR-2E currently cries wolf at CODEC's own
+   auth route, which trains the operator to ignore it.
+2. **The events most worth signing are the only unsigned ones.** AUTH_SUCCESS /
+   AUTH_FAILED / TOTP_* are exactly what an intruder would want to edit, and
+   they are the lines with no HMAC over them.
+3. **No redaction pass**, so anything that ends up interpolated into these
+   f-strings lands in the log verbatim.
+
+Found 2026-08-21 while measuring test pollution of the audit log; out of that
+PR's scope. Fix: replace `_audit_write` with `codec_audit.audit()` calls using
+proper event names (`auth_success`, `auth_failed`, `totp_enabled`, ...), then
+re-run `verify_audit_log()` to confirm `integrity_ok` goes true. The two
+existing broken lines stay — §6 forbids hand-editing the log, and per-line HMAC
+cannot detect a deletion anyway.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ so it applies session-wide instead of per-test.
 """
 import sys
 import os
+import tempfile
 import types
 from pathlib import Path
 
@@ -28,6 +29,37 @@ _WORKTREE_REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, os.path.expanduser("~/codec-repo"))
 sys.path.insert(0, os.path.expanduser("~/.codec/skills"))
 sys.path.insert(0, str(_WORKTREE_REPO))
+
+
+def _isolate_audit_log() -> None:
+    """Point the audit log at a throwaway file for the whole test session.
+
+    `codec_audit._AUDIT_DIR` is a module constant of `~/.codec`, so an unmocked
+    `audit()` anywhere in the suite appends to the OPERATOR'S real, HMAC-signed
+    audit log. Measured: 315 lines per full run, from 12 sources — including
+    `file_write_blocked`, `python_exec_blocked` and `plugin_allowlist_migrated`.
+    Those are indistinguishable from genuine security events after the fact, so
+    the log a forensic review depends on is seeded with fiction by `pytest`.
+
+    Done at conftest IMPORT time rather than in an autouse fixture: a fixture
+    runs after test modules are imported, and module-scope audit emits during
+    collection would already have landed in the real log.
+
+    Tests that assert on audit output monkeypatch `_AUDIT_LOG` per-test as
+    before; this only changes where the unmocked writes go. Existing polluted
+    lines are deliberately left alone — hand-editing an HMAC-signed log is
+    exactly what §6 of AGENTS.md forbids.
+    """
+    try:
+        import codec_audit
+    except Exception:
+        return  # audit unavailable in this environment; nothing to isolate
+    tmp = Path(tempfile.mkdtemp(prefix="codec-test-audit-"))
+    codec_audit._AUDIT_DIR = tmp
+    codec_audit._AUDIT_LOG = tmp / "audit.log"
+
+
+_isolate_audit_log()
 
 
 def _install_pynput_stub_if_needed() -> None:

--- a/tests/test_storage_guards.py
+++ b/tests/test_storage_guards.py
@@ -1,0 +1,110 @@
+"""Every PWA surface must reach storage through the guarded shim.
+
+Storage access THROWS when blocked — Safari private mode, a hardened profile,
+an iframe whose third-party storage is blocked — it does not return null. An
+unguarded read at the top level of a script kills that ENTIRE script: every
+statement after it silently never runs and the page looks fine while being
+half-dead. That is what happened to cortex, which the dashboard embeds in an
+iframe, and it cost a debugging session because the symptom (theme not applying)
+pointed nowhere near the cause.
+
+This is a lint, not a behaviour test: it pins the property that no future edit
+reintroduces a bare `localStorage.getItem` on a page.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SURFACES = sorted(REPO.glob("codec_*.html"))
+
+# The shim's own bodies are the only place bare storage may appear.
+_SHIM_BODIES = re.compile(
+    r"function _(?:ls|ss)(?:Get|Set|Del)\(k(?:,v)?\)\{try\{"
+    r"(?:return )?(?:local|session)Storage\.(?:get|set|remove)Item\([^)]*\)\}catch\(e\)\{[^}]*\}\}"
+)
+_BARE_ACCESS = re.compile(r"(?:local|session)Storage\.(?:get|set|remove)Item\s*\(")
+_ACCESSORS = ("_lsGet", "_lsSet", "_lsDel", "_ssGet", "_ssSet", "_ssDel")
+
+
+def _strip_shim(text: str) -> str:
+    return _SHIM_BODIES.sub("", text)
+
+
+def test_surfaces_are_discovered():
+    """Guard the guard: a bad glob would make every test below vacuously pass."""
+    assert len(SURFACES) >= 7, f"expected the PWA surfaces, found {SURFACES}"
+
+
+@pytest.mark.parametrize("path", SURFACES, ids=lambda p: p.name)
+def test_no_bare_storage_access(path: Path):
+    leftovers = _BARE_ACCESS.findall(_strip_shim(path.read_text()))
+    assert not leftovers, (
+        f"{path.name} touches storage directly {len(leftovers)}x — use "
+        f"_lsGet/_lsSet/_lsDel/_ssGet/_ssSet/_ssDel, which cannot throw"
+    )
+
+
+@pytest.mark.parametrize("path", SURFACES, ids=lambda p: p.name)
+def test_shim_is_defined_before_first_use(path: Path):
+    """Function declarations hoist only within their own script block, so the
+    shim has to be defined in an EARLIER block than any caller."""
+    text = path.read_text()
+    if "function _lsGet(" not in text:
+        pytest.skip(f"{path.name} does not touch storage")
+    checked = 0
+    for accessor in _ACCESSORS:
+        definition = text.find(f"function {accessor}(")
+        if definition < 0:
+            continue
+        calls = [m.start() for m in re.finditer(rf"(?<!function ){accessor}\(", text)]
+        if not calls:
+            continue  # shim exports the whole set; not every page uses every one
+        checked += 1
+        assert definition < min(calls), (
+            f"{path.name}: {accessor} is called before it is defined"
+        )
+    assert checked, f"{path.name} defines the shim but never calls it"
+
+
+@pytest.mark.parametrize("path", SURFACES, ids=lambda p: p.name)
+def test_reads_have_a_fallback_and_writes_do_not(path: Path):
+    """The read shims must return null on failure, not undefined — call sites
+    do `_lsGet(k)||''` and `=== 'true'`, which undefined would also satisfy,
+    but an explicit null keeps the contract identical to the real API."""
+    text = path.read_text()
+    if "function _lsGet(" not in text:
+        pytest.skip(f"{path.name} does not touch storage")
+    for getter in ("_lsGet", "_ssGet"):
+        body = text[text.index(f"function {getter}("):]
+        assert "return null" in body[:160], f"{path.name}: {getter} must fall back to null"
+
+
+def test_suite_does_not_write_to_the_real_audit_log():
+    """The suite must never append to ~/.codec/audit.log.
+
+    An unmocked `audit()` used to write there — 315 lines per full run, seeding
+    an HMAC-signed forensic log with events that read as real security findings.
+    conftest redirects the module constants at import time; this pins it.
+    """
+    import codec_audit
+    real = Path(os.path.expanduser("~/.codec/audit.log"))
+    assert Path(codec_audit._AUDIT_LOG) != real, "audit log is NOT isolated"
+    assert Path(codec_audit._AUDIT_DIR) != real.parent, "audit dir is NOT isolated"
+
+    # Prove it end to end, not just by inspecting the constants. Look for OUR
+    # probe rather than diffing the file: on a live machine the real log is
+    # being appended to by codec-observer while this runs, so a whole-content
+    # comparison would fail on the daemon's writes, not on ours.
+    probe = "test_isolation_probe_a4be465"
+    codec_audit.audit(event=probe, source="pytest", outcome="ok",
+                      message="must not reach the real log")
+    assert probe in Path(codec_audit._AUDIT_LOG).read_text(), \
+        "the probe did not reach the isolated log either — check the redirect"
+    if real.exists():
+        assert probe not in real.read_text(), \
+            "audit() reached the operator's real log"


### PR DESCRIPTION
## Why

Storage access **throws** when blocked — Safari private mode, a hardened profile, an iframe whose third-party storage is blocked. It does not return null. An unguarded read at the top level of a script kills that **entire script**: every statement after it silently never runs, and the page looks fine while being half-dead.

That already happened to cortex, which the dashboard embeds in an iframe. The symptom was "theme doesn't apply" and it pointed nowhere near the cause.

Proof, running the real shim against a storage that throws on every touch:

```
unguarded:  THREW: SecurityError — everything after this line would not run
shimmed:    {"workdir":"","voiceOn":false,"sessionRead":null,"script_survived":true}
```

## Scope — wider than the three surfaces named

| surface | call sites |
|---|---|
| codec_chat.html | 19 |
| codec_dashboard.html | 12 |
| codec_vibe.html | 11 |
| codec_voice.html | 8 |
| codec_tasks.html | 8 |
| codec_audit.html | 5 |
| **codec_auth.html** | 4 |
| codec_cortex.html | 4 |

chat / dashboard / vibe were the known ones. voice, tasks, audit, auth and cortex carry the identical top-level pattern — and `codec_auth.html` is the worst, because a storage exception there kills the script on the **login page**. Fixing three and leaving the front door broken made no sense.

The shim gets its own script block ahead of every other one: function declarations hoist within a block, not across them, so a later definition would not cover an earlier caller. A test pins that ordering.

## Also: the test suite was writing to the operator's real audit log

`codec_audit._AUDIT_DIR` is a module constant of `~/.codec`, so any unmocked `audit()` in the suite appended to the real, HMAC-signed log. Measured on a full run:

```
315 lines, 12 sources — incl. file_write_blocked, python_exec_blocked,
plugin_allowlist_migrated, keychain_set, model_switched
```

Those read as genuine security events after the fact. The log a forensic review depends on was being seeded with fiction by `pytest`.

`conftest` now redirects the constants at **import time**, not via an autouse fixture — a fixture runs after test modules are imported, so module-scope emits during collection would already have landed. Verified: a full run now adds **0** pytest lines (the 3 that appeared were `codec-observer` doing its job).

Existing polluted lines are deliberately left alone — hand-editing an HMAC-signed log is what §6 of AGENTS.md forbids.

## Tests

26 new: a lint that no surface reaches storage directly, that the shim precedes its first caller, and that reads fall back to null; plus an end-to-end check that `audit()` cannot reach the real log. That last one looks for its own probe rather than diffing the file — on a live machine `codec-observer` appends while the suite runs, so a content diff would fail on the daemon's writes, not ours.

`2794 passed, 78 skipped`; ruff clean; every inline script block re-checked with `node --check`.

## Found and NOT fixed here

`routes/_shared._audit_write` appends unsigned plaintext straight into the signed audit log from 9 auth call sites. It is why `verify_audit_log()` reports `integrity_ok: False` on the live machine right now (`599 lines, 597 signed, 2 broken`) — the tamper detector is crying wolf at CODEC's own auth route. Logged in `docs/known-issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)