### PR TITLE
design(pwa): finish the 2026 refresh on the three surfaces it missed

### DIFF
--- a/codec_audit.html
+++ b/codec_audit.html
@@ -5,25 +5,26 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>AUDIT STREAM — CODEC</title>
 <link rel="icon" href="/favicon.png">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 :root {
-  --bg: #121215; --surface: #1a1a1d; --surface-2: #212125; --surface-3: #2a2a2e;
-  --border: #303035; --border-hover: #424248;
+  --bg: #121215; --surface: #18181b; --surface-2: #1f1f22; --surface-3: #27272a;
+  --border: #2a2a2f; --border-hover: #3a3a40;
   --text: #ececec; --text-muted: #9a9aa0; --dim: #6a6a70;
-  --accent: #E8711A; --accent-hover: #f07d2a; --accent-dim: rgba(232,113,26,0.10);
+  /* 2026 refresh: keep CODEC orange identity but warmer + calmer (was pure #E8711A) */
+  --accent: #d97757; --accent-hover: #e08766; --accent-dim: rgba(217,119,87,0.10);
   --green: #22c55e; --red: #ef4444; --yellow: #ffd740; --blue: #448aff;
   --purple: #b388ff; --cyan: #26c6da; --pink: #f06292; --teal: #26a69a;
   --amber: #ffab00; --slate: #78909c; --red-orange: #ff6e40;
-  --font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --mono: 'JetBrains Mono', 'SF Mono', monospace;
+  --font: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: 'IBM Plex Mono', 'SF Mono', monospace;
   --radius-sm: 6px; --radius: 10px; --radius-lg: 14px;
 }
 [data-theme="light"] {
-  --bg: #f7f5f2; --surface: #ffffff; --surface-2: #f0ece6; --surface-3: #e8e4de;
-  --border: #d5d0ca; --border-hover: #bbb;
-  --text: #1a1a1a; --text-muted: #555; --dim: #777;
-  --accent-dim: rgba(232,113,26,0.08);
+  --bg: #faf8f5; --surface: #ffffff; --surface-2: #f2eee8; --surface-3: #ebe6df;
+  --border: #e2ddd5; --border-hover: #c8c2b8;
+  --text: #18181b; --text-muted: #52525b; --dim: #71717a;
+  --accent: #b85a3a; --accent-hover: #a04d31; --accent-dim: rgba(184,90,58,0.08);
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 html, body { font-family: var(--font); background: var(--bg); color: var(--text); height: 100%; }
@@ -124,7 +125,7 @@ body { display: flex; flex-direction: column; overflow: hidden; }
 }
 .pill.active { opacity: 1; }
 .pill[data-cat="command"]  { color: var(--accent); border-color: var(--accent); }
-.pill[data-cat="command"].active  { background: rgba(232,113,26,0.15); }
+.pill[data-cat="command"].active  { background: rgba(217,119,87,0.15); }
 .pill[data-cat="skill"]    { color: var(--green); border-color: var(--green); }
 .pill[data-cat="skill"].active    { background: rgba(34,197,94,0.15); }
 .pill[data-cat="llm"]      { color: var(--blue); border-color: var(--blue); }
@@ -238,7 +239,8 @@ body { display: flex; flex-direction: column; overflow: hidden; }
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   padding: 80px 20px; color: var(--dim);
 }
-.empty-state .empty-icon { font-size: 36px; margin-bottom: 12px; opacity: 0.3; }
+.empty-state .empty-icon { margin-bottom: 12px; opacity: 0.3; }
+.empty-state .empty-icon svg { width: 36px; height: 36px; stroke: currentColor; fill: none; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
 .empty-state h3 { font-size: 14px; font-weight: 500; margin-bottom: 6px; color: var(--text-muted); }
 .empty-state p { font-size: 12px; }
 
@@ -336,7 +338,7 @@ function openSidePanel(){document.getElementById('sidePanel').classList.add('ope
 function closeSidePanel(){document.getElementById('sidePanel').classList.remove('open');document.getElementById('sidePanelOverlay').classList.remove('open')}
 var _voiceOn=_lsGet('codec-voice')==='true';
 function toggleVoiceReply(){_voiceOn=!_voiceOn;_lsSet('codec-voice',_voiceOn);updateVoiceIcon()}
-function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#E8711A'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
+function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#d97757'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
 updateVoiceIcon();
 const CATEGORIES = [
   'command','skill','llm','auth','error','scheduled',
@@ -505,7 +507,7 @@ function renderTimeline(evts) {
   if (!evts.length) {
     container.innerHTML = `
       <div class="empty-state">
-        <div class="empty-icon">&#128269;</div>
+        <div class="empty-icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></div>
         <h3>No events found</h3>
         <p>Try adjusting your filters, time range, or search query.</p>
       </div>`;

--- a/codec_auth.html
+++ b/codec_auth.html
@@ -5,21 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>CODEC — Authenticate</title>
     <link rel="icon" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
         :root {
-            --bg: #121215; --surface: #1a1a1d; --surface-2: #212125; --border: #303035; --border-hover: #424248;
+            --bg: #121215; --surface: #18181b; --surface-2: #1f1f22; --surface-3: #27272a;
+            --border: #2a2a2f; --border-hover: #3a3a40;
             --text: #ececec; --text-muted: #9a9aa0; --text-dim: #6a6a70;
-            --accent: #E8711A; --accent-hover: #f07d2a;
-            --danger: #ef4444; --success: #22c55e;
-            --font: 'Inter', -apple-system, sans-serif;
-            --mono: 'JetBrains Mono', monospace;
-            --radius-sm: 6px; --radius: 10px;
+            /* 2026 refresh: keep CODEC orange identity but warmer + calmer (was pure #E8711A) */
+            --accent: #d97757; --accent-hover: #e08766; --accent-dim: rgba(217,119,87,0.10);
+            --danger: #ef4444; --success: #22c55e; --info: #3b82f6;
+            --font: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+            --mono: 'IBM Plex Mono', 'SF Mono', monospace;
+            --radius-sm: 6px; --radius: 10px; --radius-lg: 14px;
         }
         [data-theme="light"] {
-            --bg: #f7f5f2; --surface: #fff; --surface-2: #f0ece6; --border: #d5d0ca; --border-hover: #bbb;
-            --text: #1a1a1a; --text-muted: #555; --text-dim: #777;
+            --bg: #faf8f5; --surface: #fff; --surface-2: #f2eee8; --surface-3: #ebe6df;
+            --border: #e2ddd5; --border-hover: #c8c2b8;
+            --text: #18181b; --text-muted: #52525b; --text-dim: #71717a;
+            --accent: #b85a3a; --accent-hover: #a04d31; --accent-dim: rgba(184,90,58,0.08);
         }
+        /* Line-SVG icon base — no emoji anywhere in CODEC UI. */
+        .ico { width: 18px; height: 18px; stroke: currentColor; fill: none;
+               stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+               flex-shrink: 0; vertical-align: -3px; }
         * { margin:0; padding:0; box-sizing:border-box; }
         body {
             font-family: var(--font);
@@ -30,7 +38,7 @@
         .auth-container {
             text-align: center; max-width: 360px; width: 100%; padding: 32px;
         }
-        .logo { width: 68px; height: 68px; margin: 0 auto 16px; filter: drop-shadow(0 0 18px rgba(232,113,26,0.35)); }
+        .logo { width: 68px; height: 68px; margin: 0 auto 16px; filter: drop-shadow(0 0 18px rgba(217,119,87,0.35)); }
         .title { font-family: var(--mono); font-size: 24px; font-weight: 700; color: var(--text); letter-spacing: 2px; margin-bottom: 6px; }
         .subtitle { font-size: 13px; color: var(--text-dim); margin-bottom: 32px; }
 
@@ -48,11 +56,12 @@
         [data-theme="light"] .fingerprint-ring.success { background: #eaf7ee; }
         [data-theme="light"] .fingerprint-ring.error { background: #fdeaea; }
         [data-theme="light"] .fingerprint-ring.waiting { background: var(--surface); }
-        .fingerprint-icon { font-size: 40px; }
+        .fingerprint-icon { display:flex; }
+        .fingerprint-icon .ico { width: 40px; height: 40px; stroke-width: 1.5; }
 
         @keyframes pulse {
-            0%, 100% { box-shadow: 0 0 0 0 rgba(232,113,26,0.3); }
-            50% { box-shadow: 0 0 0 16px rgba(232,113,26,0); }
+            0%, 100% { box-shadow: 0 0 0 0 rgba(217,119,87,0.3); }
+            50% { box-shadow: 0 0 0 16px rgba(217,119,87,0); }
         }
 
         .auth-btn {
@@ -84,7 +93,7 @@
             border-radius: 8px; outline: none;
             transition: border-color 0.15s; font-family: var(--mono);
         }
-        .pin-digit:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(232,113,26,0.1); }
+        .pin-digit:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(217,119,87,0.1); }
         .pin-digit.filled { border-color: var(--accent); }
 
         .status { font-size: 13px; color: var(--text-dim); min-height: 20px; margin-top: 16px; }
@@ -109,7 +118,7 @@
           .pin-input-row { gap: 6px; }
           .pin-digit { width: 44px; height: 50px; font-size: 20px; }
           .fingerprint-ring { width: 100px; height: 100px; }
-          .fingerprint-icon { font-size: 34px; }
+          .fingerprint-icon .ico { width: 34px; height: 34px; }
         }
     </style>
 </head>
@@ -126,7 +135,7 @@
         <!-- Touch ID section -->
         <div id="touchidSection">
             <div class="fingerprint-ring" id="fpRing" onclick="authenticate()">
-                <span class="fingerprint-icon" id="fpIcon">&#128274;</span>
+                <span class="fingerprint-icon" id="fpIcon"><svg viewBox="0 0 24 24" class="ico"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span>
             </div>
             <button class="auth-btn" id="authBtn" onclick="authenticate()">Authenticate with Touch ID</button>
         </div>
@@ -185,11 +194,11 @@
 
         <!-- Setup 2FA link (shown when TOTP not yet configured) -->
         <div id="setup2faLink" style="display:none;margin-top:12px">
-            <a href="#" onclick="startTotpSetup();return false" style="font-size:12px;color:var(--accent);text-decoration:none;opacity:0.7">&#128272; Setup 2FA (Authenticator App)</a>
+            <a href="#" onclick="startTotpSetup();return false" style="font-size:12px;color:var(--accent);text-decoration:none;opacity:0.7"><svg viewBox="0 0 24 24" class="ico"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg> Setup 2FA (Authenticator App)</a>
         </div>
 
         <div class="remote-note" id="remoteNote" style="display:none;">
-            &#128241; Remote access detected. Touch ID will prompt on your Mac.
+            <svg viewBox="0 0 24 24" class="ico"><rect x="6" y="2" width="12" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18"/></svg> Remote access detected. Touch ID will prompt on your Mac.
             Keep the Mac awake and nearby.
         </div>
     </div>
@@ -327,6 +336,11 @@ function clearPin() {
 }
 
 // ── Touch ID auth ──
+// Icon states for the auth ring. Line SVG, never emoji — see AGENTS.md §9.
+var ICO_LOCK  = '<svg viewBox="0 0 24 24" class="ico"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>';
+var ICO_PRINT = '<svg viewBox="0 0 24 24" class="ico"><path d="M12 10a2 2 0 0 1 2 2c0 2.5-.4 4.6-1 6.5"/><path d="M8.5 12a3.5 3.5 0 0 1 7 0c0 3-.6 5.6-1.6 7.8"/><path d="M5 12a7 7 0 0 1 14 0c0 1.6-.2 3.2-.6 4.7"/><path d="M12 5a7 7 0 0 0-5 2"/></svg>';
+var ICO_CHECK = '<svg viewBox="0 0 24 24" class="ico"><polyline points="20 6 9 17 4 12"/></svg>';
+
 async function authenticate() {
     var ring = document.getElementById('fpRing');
     var icon = document.getElementById('fpIcon');
@@ -334,7 +348,7 @@ async function authenticate() {
     var status = document.getElementById('status');
 
     ring.className = 'fingerprint-ring waiting';
-    icon.innerHTML = '&#128070;';
+    icon.innerHTML = ICO_PRINT;
     btn.disabled = true;
     btn.textContent = isRemote ? 'Waiting for Touch ID on Mac...' : 'Touch the sensor...';
     status.textContent = 'Authenticating...';
@@ -346,10 +360,10 @@ async function authenticate() {
         if (data.authenticated) {
             onSuccess(data);
             ring.className = 'fingerprint-ring success';
-            icon.innerHTML = '&#9989;';
+            icon.innerHTML = ICO_CHECK;
         } else {
             ring.className = 'fingerprint-ring error';
-            icon.innerHTML = '&#128274;';
+            icon.innerHTML = ICO_LOCK;
             status.textContent = data.error || 'Authentication failed';
             status.className = 'status error';
             btn.disabled = false;
@@ -357,7 +371,7 @@ async function authenticate() {
         }
     } catch(e) {
         ring.className = 'fingerprint-ring error';
-        icon.innerHTML = '&#128274;';
+        icon.innerHTML = ICO_LOCK;
         status.textContent = 'Connection error: ' + e.message;
         status.className = 'status error';
         btn.disabled = false;

--- a/codec_tasks.html
+++ b/codec_tasks.html
@@ -6,7 +6,7 @@
 <title>CODEC — Tasks</title>
 <link rel="icon" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 :root {
   --bg: #121215; --surface: #18181b; --surface-2: #1f1f22; --surface-3: #27272a;
@@ -15,8 +15,8 @@
   /* 2026 refresh: calmer brand orange (was pure #E8711A) */
   --accent: #d97757; --accent-hover: #e08766; --accent-dim: rgba(217,119,87,0.10);
   --danger: #ef4444; --success: #22c55e; --info: #3b82f6;
-  --font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --mono: 'JetBrains Mono', 'SF Mono', monospace;
+  --font: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: 'IBM Plex Mono', 'SF Mono', monospace;
   --radius-sm: 6px; --radius: 10px;
 }
 [data-theme="light"] {
@@ -474,7 +474,7 @@ function updateThemeIcon(t){var ico=document.getElementById('themeIco');if(t==='
 function lockSession(){fetch('/api/auth/logout',{method:'POST'}).then(function(){document.cookie='codec_session=;path=/;max-age=0;SameSite=Lax'+(location.protocol==='https:'?';Secure':'');window.location.href='/auth'})}
 var _voiceOn=_lsGet('codec-voice')==='true';
 function toggleVoiceReply(){_voiceOn=!_voiceOn;_lsSet('codec-voice',_voiceOn);updateVoiceIcon()}
-function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#E8711A'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
+function updateVoiceIcon(){var m1=document.getElementById('muteX1'),m2=document.getElementById('muteX2'),st=document.getElementById('voiceState');if(_voiceOn){if(m1)m1.style.display='none';if(m2)m2.style.display='none';if(st){st.textContent='ON';st.style.color='#0a0a0a';st.style.background='#d97757'}}else{if(m1)m1.style.display='';if(m2)m2.style.display='';if(st){st.textContent='OFF';st.style.color='#888';st.style.background='#2a2a2a'}}}
 updateVoiceIcon();
 // ── Screenshot (shows preview) ──
 function takeScreenshot(){
@@ -854,10 +854,15 @@ function renderAlerts() {
     el.innerHTML = '<div style="font-size:13px;color:var(--text-dim);padding:8px 0;">No alerts configured. Add them in <code>~/.codec/config.json</code> under <code>heartbeat_alerts</code>.</div>';
     return;
   }
-  var icons = { price: '💰', email_check: '📧', disk_usage: '💾' };
+  // Line SVG, never emoji — see AGENTS.md §9.
+  var icons = {
+    price:       '<svg viewBox="0 0 24 24" class="ico"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>',
+    email_check: '<svg viewBox="0 0 24 24" class="ico"><path d="M4 4h16v12H4z"/><polyline points="4 6 12 12 20 6"/></svg>',
+    disk_usage:  '<svg viewBox="0 0 24 24" class="ico"><rect x="2" y="7" width="20" height="10" rx="2"/><line x1="6" y1="12" x2="6" y2="12"/><line x1="10" y1="12" x2="18" y2="12"/></svg>'
+  };
   var html = '';
   hbAlerts.forEach(function(alert, i) {
-    var icon = icons[alert.type] || '🔔';
+    var icon = icons[alert.type] || '<svg viewBox="0 0 24 24" class="ico"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.7 21a2 2 0 0 1-3.4 0"/></svg>';
     var enabled = alert.enabled !== false;
     var meta = alert.type;
     if (alert.type === 'price') meta += ' | ' + (alert.asset || 'bitcoin') + ' | ' + (alert.threshold_pct || 5) + '% ' + (alert.direction || 'any');
@@ -985,6 +990,9 @@ function renderReports() {
     }
     if (r.body || r.message) {
       var bodyText = escHtml(r.body || r.message);
+      // The emoji here is CONTENT, not UI: shift_report emits this marker in the
+      // report body and this strips it. Replacing it would break the strip and
+      // the marker would render — the no-emoji rule is why it must stay.
       bodyText = bodyText.replace(/📄\s*\[View Full Report\]\([^)]+\)\n*/g, '');
       if (bodyText.trim()) {
         html += '<div class="report-body">' + bodyText.substring(0, 500) + (bodyText.length > 500 ? '...' : '') + '</div>';

--- a/codec_vibe.html
+++ b/codec_vibe.html
@@ -46,8 +46,8 @@ function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
   --fg: #ececec; --fg2: #9a9aa0; --fg3: #6a6a70;
   --ac: #d97757; --bd: #303035;
   --tx: #ececec; --tx2: #9a9aa0;
-  --ft: 'Inter', -apple-system, sans-serif;
-  --mn: 'JetBrains Mono', monospace;
+  --ft: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --mn: 'IBM Plex Mono', 'SF Mono', monospace;
   --dn: #ef4444;
   --accent2: #ff9a4d; --accent-bg: rgba(217,119,87,0.10);
   --safe-top: env(safe-area-inset-top, 0px);

--- a/codec_voice.html
+++ b/codec_voice.html
@@ -23,8 +23,8 @@
           --fg: #ececec; --fg2: #9a9aa0; --fg3: #6a6a70;
           --ac: #d97757; --bd: #303035;
           --tx: #ececec; --tx2: #9a9aa0;
-          --ft: 'Inter', -apple-system, sans-serif;
-          --mn: 'JetBrains Mono', monospace;
+          --ft: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+          --mn: 'IBM Plex Mono', 'SF Mono', monospace;
           --dn: #ef4444;
           --accent2: #ff9a4d; --accent-bg: rgba(217,119,87,0.10);
           --safe-top: env(safe-area-inset-top, 0px);

--- a/tests/test_design_system.py
+++ b/tests/test_design_system.py
@@ -1,0 +1,88 @@
+"""Every PWA surface runs one design system.
+
+Three surfaces (auth, audit, tasks) were missed by the #318-#324 refresh and
+kept serving the pre-2026 orange, Inter/JetBrains Mono, and emoji. The login
+page — the first screen of the demo — was one of them.
+
+Two lessons from that refresh are encoded here:
+
+- Replacing the hex alone is not enough. The first pass on chat swapped only the
+  `rgba()` spelling and the live page kept serving five `#E8711A` values, so both
+  spellings are checked.
+- A source grep is not proof that the SERVED page is clean, but it IS the cheap
+  regression guard. The served check happens at deploy; this stops the drift
+  from being reintroduced in the first place.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SURFACES = sorted(REPO.glob("codec_*.html"))
+
+NEW_ACCENT = "#d97757"
+NEW_ACCENT_LIGHT = "#b85a3a"
+_OLD_HEX = re.compile(r"#E8711A", re.I)
+_OLD_RGBA = re.compile(r"rgba\(\s*232\s*,\s*113\s*,\s*26")
+_ACCENT_DECL = re.compile(r"--accent:\s*([^;}]+)")
+
+# Smartphone emoji only. Geometric glyphs (✓ ✕ ● ▸ ⚠) are typography, not emoji,
+# and are used deliberately across the surfaces.
+_EMOJI = re.compile(r"[\U0001F300-\U0001FAFF]")
+_EMOJI_ENTITY = re.compile(r"&#(1[0-9]{5});")
+
+# `codec_tasks.html` strips a marker that `shift_report` puts in the report BODY.
+# The emoji is content produced elsewhere, not UI chrome — editing it would break
+# the strip and the marker would start rendering.
+_CONTENT_EMOJI_EXEMPT = {"codec_tasks.html": 1}
+
+
+def test_surfaces_are_discovered():
+    assert len(SURFACES) >= 7, f"expected the PWA surfaces, found {SURFACES}"
+
+
+@pytest.mark.parametrize("path", SURFACES, ids=lambda p: p.name)
+def test_no_old_accent_in_either_spelling(path: Path):
+    text = path.read_text()
+    # The token comment documents what the value replaced; that mention is fine.
+    live = "\n".join(l for l in text.splitlines() if "was pure #E8711A" not in l)
+    assert not _OLD_HEX.search(live), f"{path.name} still hardcodes the pre-2026 orange"
+    assert not _OLD_RGBA.search(live), (
+        f"{path.name} still has the OLD accent in rgba() form — replacing the hex "
+        f"alone is what let five values survive the first chat pass"
+    )
+
+
+@pytest.mark.parametrize("path", SURFACES, ids=lambda p: p.name)
+def test_accent_token_is_the_shared_value(path: Path):
+    declared = {m.strip() for m in _ACCENT_DECL.findall(path.read_text())}
+    if not declared:
+        pytest.skip(f"{path.name} declares no --accent")
+    assert declared <= {NEW_ACCENT, NEW_ACCENT_LIGHT}, (
+        f"{path.name} declares off-system accents: {declared - {NEW_ACCENT, NEW_ACCENT_LIGHT}}"
+    )
+
+
+@pytest.mark.parametrize("path", SURFACES, ids=lambda p: p.name)
+def test_typeface_is_ibm_plex(path: Path):
+    text = path.read_text()
+    if "fonts.googleapis.com" not in text:
+        pytest.skip(f"{path.name} loads no webfont")
+    assert "IBM+Plex" in text, f"{path.name} still loads the pre-refresh typeface"
+    assert "'Inter'" not in text and "'JetBrains Mono'" not in text, (
+        f"{path.name} still names Inter/JetBrains Mono in a font stack"
+    )
+
+
+@pytest.mark.parametrize("path", SURFACES, ids=lambda p: p.name)
+def test_no_emoji_in_ui(path: Path):
+    text = path.read_text()
+    found = _EMOJI.findall(text) + [chr(int(c)) for c in _EMOJI_ENTITY.findall(text)]
+    allowed = _CONTENT_EMOJI_EXEMPT.get(path.name, 0)
+    assert len(found) <= allowed, (
+        f"{path.name} has {len(found)} emoji ({''.join(found)}) but only {allowed} "
+        f"content exemption(s) — CODEC UI uses line SVG or plain text"
+    )


### PR DESCRIPTION
## Why

`auth`, `audit` and `tasks` were never migrated by #318-#324. They kept serving the pre-2026 orange, Inter/JetBrains Mono, and emoji — and **`codec_auth.html` is the login page**, the first screen of the demo.

Confirmed on the served page by computed style, not by grep:

```
touchIdBg:   rgb(232, 113, 26)
accentToken: #E8711A
emoji:       🔒  🔐 Setup 2FA (Authenticator App)  📱 Remote access detected
```

## Emoji → line SVG

| surface | replaced |
|---|---|
| auth | lock (3 ring states), fingerprint, check, shield, smartphone |
| audit | search, in the empty state |
| tasks | dollar, mail, drive, bell, for the heartbeat alert types |

One stays, in `codec_tasks.html`, now commented: it is the marker `shift_report` writes into a report **body**, and that line strips it. Content produced elsewhere, not UI chrome — editing it would break the strip and the marker would start rendering. The lint carries a named exemption.

Geometric glyphs (`✓ ✕ ● ▸ ⚠`) are left alone. The rule is about smartphone emoji, not typography.

## Two things the new lint caught that I had already called clean

**1. `updateVoiceIcon` hardcodes `'#E8711A'` inline — in audit AND tasks.** `tasks`' `--accent` token was already correct, which is precisely why a token-level check missed it. Same lesson as #318-#324: one spelling replaced, another left serving the old value. I reported tasks as needing an accent migration, then corrected myself to say it didn't; both were half right — the token was fine, the inline literal was not.

**2. `vibe` and `voice` load IBM Plex but never used it.** Their `--ft`/`--mn` tokens still named `'Inter'`/`'JetBrains Mono'`, which are not loaded, so they fell through to `-apple-system`. Those two surfaces rendered in the system font while the rest rendered IBM Plex. Nothing looked broken, which is why it survived the refresh.

## Tests

33 new, across every surface: both accent spellings, the shared token value, the typeface, and emoji.

The `rgba()` check exists specifically because the first chat pass replaced only the hex and the live page kept serving five old values. A source lint is not proof about the served page — that check happens at deploy — but it is what stops the drift being reintroduced.

`2827 passed, 78 skipped`; ruff clean; every inline script block re-checked with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)