### PR TITLE
fix(skills): regenerate the trusted manifest — chrome_open was dead at runtime

### DIFF
--- a/skills/.manifest.json
+++ b/skills/.manifest.json
@@ -19,7 +19,7 @@
     "chrome_close.py": "9c62736a5030ba1c511f6a0b198e2e7cf1c7b64714cf5b4df198cc20b5043b75",
     "chrome_extract.py": "749072240f2ee55f2a6d473c0be23f15c28dae00f2cc6608889d05e381a0b57c",
     "chrome_fill.py": "3fa2ba14ab88a33bc59faf3032c09a03a114d59cd71dd1ea2c9dd20360ed06ea",
-    "chrome_open.py": "a5702a049f44baeb53f8176d053091350c09c3dee86e2a7d593ef423735b4c72",
+    "chrome_open.py": "10dc7189c18eeb55e8fbeb836d4deb637c554ef705c0c67c710483157fecc875",
     "chrome_read.py": "5dcc846a6a56d6910edce0fe60e39cc7a9f20b1b854e5efd3bb54733c56fae12",
     "chrome_scroll.py": "4c79653c9a43f642d03d855621fe89c3ba95824ea08fe5647ab82cb76b72b5a3",
     "chrome_search.py": "20830e6da2a055ba6c1308d4df3d6e5df2191e5f2633cea227e1e4262cce13f8",

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -369,3 +369,50 @@ def test_load_no_manifest_treats_dir_as_untrusted(tmp_path):
 
     assert result is None
     assert _was_block_event_emitted(mock_log_event)
+
+
+# ── D-1 gate: every built-in skill must actually LOAD ─────────────────────────
+
+def test_every_builtin_skill_loads_under_the_manifest_gate():
+    """A stale manifest does not just fail CI — it kills the skill at runtime.
+
+    On 2026-08-26 `skills/chrome_open.py` was edited and pushed to main without
+    regenerating `skills/.manifest.json`. Its hash no longer matched, so
+    `SkillRegistry.load` fell through to the AST gate, which refused it for
+    `import subprocess`. chrome_open was dead on the live machine while the only
+    signal was a red CI step named "Trusted-skill manifest is current".
+
+    `generate_skill_manifest.py --check` catches the drift. This catches the
+    CONSEQUENCE, in the normal suite, so it also fires for anyone who runs
+    pytest without the bespoke CI step — including on a branch that never
+    opened a PR, which is exactly how that break reached main.
+    """
+    import codec_skill_registry
+
+    skills_dir = REPO / "skills"
+    registry = codec_skill_registry.SkillRegistry(str(skills_dir))
+    try:
+        registry.scan()
+    except Exception:
+        pass
+
+    # Iterate the REGISTRY, not the filenames: a skill's registered name comes
+    # from its SKILL_NAME, which is not always the file stem (time_date.py
+    # registers as "time"). Keying on the stem would report healthy skills as
+    # missing and make this test lie in both directions.
+    names = registry.names()
+    assert names, "registry scanned no skills — the test would pass vacuously"
+
+    refused = []
+    for name in sorted(names):
+        try:
+            if registry.load(name) is None:
+                refused.append(name)
+        except Exception as exc:  # a raising skill is also a broken skill
+            refused.append(f"{name} ({type(exc).__name__})")
+
+    assert not refused, (
+        "these built-in skills are refused at load time and are DEAD at runtime: "
+        f"{refused}. If you edited a skill, run "
+        "`python3 tools/generate_skill_manifest.py --write` and commit the diff."
+    )


### PR DESCRIPTION
## The break

`skills/chrome_open.py` was edited in 10adf17 without regenerating `skills/.manifest.json`. Its hash stopped matching the trusted manifest, so `SkillRegistry.load` fell through to the AST gate, which refused it:

```
Skill 'chrome_open' refused at load time (not in trusted manifest): Dangerous import: subprocess
chrome_open loads: NO
calculator (control) loads: YES
```

**chrome_open was dead on the live machine** — "open chrome" did nothing — and it's a demo skill. The only signal was a CI step named "Trusted-skill manifest is current", which reads like a bookkeeping nit rather than "a skill stopped working".

Regenerating the manifest is a one-line diff (the new hash) and restores it.

## Why it got past CI

`10adf17` and `aca9270` are single-parent commits pushed **straight to main**. No PR, so no CI ran before the break landed — the first red run was post-merge.

## The test

Rather than duplicate the `--check` drift detection, this loads every skill the registry knows and fails naming any that are refused. It catches the consequence, in the normal suite, so it also fires for a branch that never opens a PR.

It iterates the **registry**, not filenames — a skill's registered name comes from `SKILL_NAME` and isn't always the file stem (`time_date.py` registers as `time`). Keying on the stem made the first version report five healthy skills as broken.

Mutation-checked:

```
corrupted hash -> FAILS (good)
  AssertionError: these built-in skills are refused at load time and are DEAD
  at runtime: ['chrome_open']
```

It also asserts the registry is non-empty, so it can't pass vacuously.

`2830 passed, 78 skipped`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)