### PR TITLE
fix(ux): notifications link lands on Reports, system theme everywhere, menu-bar launcher

### DIFF
--- a/codec_audit.html
+++ b/codec_audit.html
@@ -360,27 +360,23 @@ function init() {
   renderPills();
   bindTimeButtons();
   bindSearch();
-  loadTheme();
   fetchStats();
   fetchEvents();
   statsInterval = setInterval(fetchStats, 10000);
 }
 
 // --- Theme ---
-function loadTheme() {
-  const saved = _lsGet('codec-theme');
-  if (saved === 'light') document.documentElement.setAttribute('data-theme', 'light');
-}
-document.getElementById('themeToggle').onclick = function() {
-  const isLight = document.documentElement.getAttribute('data-theme') === 'light';
-  if (isLight) {
-    document.documentElement.removeAttribute('data-theme');
-    _lsSet('codec-theme', 'dark');
-  } else {
-    document.documentElement.setAttribute('data-theme', 'light');
-    _lsSet('codec-theme', 'light');
-  }
-};
+// Theme: system / light / dark (ported from chat). "system" follows the OS and
+// switches live at sunset; an explicit choice pins it until you cycle back.
+function _themePref(){var v=null;try{v=_lsGet('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
+function _themeResolved(pref){if(pref==='light'||pref==='dark')return pref;try{return (window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches)?'light':'dark'}catch(e){return 'dark'}}
+function applyTheme(){var pref=_themePref(),eff=_themeResolved(pref);if(eff==='light'){document.documentElement.setAttribute('data-theme','light')}else{document.documentElement.setAttribute('data-theme','dark')}updateThemeIcon(pref,eff)}
+function toggleTheme(){var order=['system','light','dark'],next=order[(order.indexOf(_themePref())+1)%3];try{_lsSet('codec-theme',next)}catch(e){}applyTheme();if(typeof showToast==='function')showToast(next==='system'?'Theme follows your system':'Theme: '+next)}
+try{if(window.matchMedia){matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if(_themePref()==='system')applyTheme()})}}catch(e){}
+window.addEventListener('storage',function(e){if(e.key==='codec-theme')applyTheme()});
+function updateThemeIcon(pref,eff){var ico=document.getElementById('themeIco');if(!ico)return;var theme=(pref==='system')?'system':(eff||pref);var btn=ico.parentNode;if(theme==='system'){ico.innerHTML='<circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 000 18z" fill="currentColor" stroke="none"/>';btn&&btn.setAttribute('title','Theme: follows your system — click to pin light');return}btn&&btn.setAttribute('title','Theme: '+theme+' — click to change');if(theme==='light'){ico.innerHTML='<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>'}else{ico.innerHTML='<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}}
+applyTheme();
+document.getElementById('themeToggle').onclick = toggleTheme;
 
 // --- Pills ---
 function renderPills() {

--- a/codec_auth.html
+++ b/codec_auth.html
@@ -222,10 +222,16 @@ function _ssSet(k,v){try{sessionStorage.setItem(k,v)}catch(e){}}
 function _ssDel(k){try{sessionStorage.removeItem(k)}catch(e){}}
 </script>
 <script>
-function toggleTheme(){var t=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',t);_lsSet('codec-theme',t);updateThemeIcon(t)}
-function updateThemeIcon(t){document.getElementById('themeIco').innerHTML=t==='light'?'<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>':'<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}
-(function(){var s=_lsGet('codec-theme');if(s==='light'){document.documentElement.setAttribute('data-theme','light');updateThemeIcon('light')}})();
-
+// Theme: system / light / dark (ported from chat). "system" follows the OS and
+// switches live at sunset; an explicit choice pins it until you cycle back.
+function _themePref(){var v=null;try{v=_lsGet('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
+function _themeResolved(pref){if(pref==='light'||pref==='dark')return pref;try{return (window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches)?'light':'dark'}catch(e){return 'dark'}}
+function applyTheme(){var pref=_themePref(),eff=_themeResolved(pref);if(eff==='light'){document.documentElement.setAttribute('data-theme','light')}else{document.documentElement.setAttribute('data-theme','dark')}updateThemeIcon(pref,eff)}
+function toggleTheme(){var order=['system','light','dark'],next=order[(order.indexOf(_themePref())+1)%3];try{_lsSet('codec-theme',next)}catch(e){}applyTheme();if(typeof showToast==='function')showToast(next==='system'?'Theme follows your system':'Theme: '+next)}
+try{if(window.matchMedia){matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if(_themePref()==='system')applyTheme()})}}catch(e){}
+window.addEventListener('storage',function(e){if(e.key==='codec-theme')applyTheme()});
+function updateThemeIcon(pref,eff){var ico=document.getElementById('themeIco');if(!ico)return;var theme=(pref==='system')?'system':(eff||pref);var btn=ico.parentNode;if(theme==='system'){ico.innerHTML='<circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 000 18z" fill="currentColor" stroke="none"/>';btn&&btn.setAttribute('title','Theme: follows your system — click to pin light');return}btn&&btn.setAttribute('title','Theme: '+theme+' — click to change');if(theme==='light'){ico.innerHTML='<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>'}else{ico.innerHTML='<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}}
+applyTheme();
 var isRemote = location.hostname !== 'localhost' && location.hostname !== '127.0.0.1';
 if (isRemote) {
     document.getElementById('remoteNote').style.display = 'block';

--- a/codec_tasks.html
+++ b/codec_tasks.html
@@ -469,8 +469,16 @@ function _decResp(r){if(!_e2eKey||r.headers.get('x-e2e')!=='1')return r;return r
 if(_ssGet('_e2eReady'))window._e2eNegotiate();
 })();
 /* ── Theme ── */
-function toggleTheme(){var t=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',t);_lsSet('codec-theme',t);updateThemeIcon(t)}
-function updateThemeIcon(t){var ico=document.getElementById('themeIco');if(t==='light'){ico.innerHTML='<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>'}else{ico.innerHTML='<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}}
+// Theme: system / light / dark (ported from chat). "system" follows the OS and
+// switches live at sunset; an explicit choice pins it until you cycle back.
+function _themePref(){var v=null;try{v=_lsGet('codec-theme')}catch(e){}return (v==='light'||v==='dark'||v==='system')?v:'system'}
+function _themeResolved(pref){if(pref==='light'||pref==='dark')return pref;try{return (window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches)?'light':'dark'}catch(e){return 'dark'}}
+function applyTheme(){var pref=_themePref(),eff=_themeResolved(pref);if(eff==='light'){document.documentElement.setAttribute('data-theme','light')}else{document.documentElement.setAttribute('data-theme','dark')}updateThemeIcon(pref,eff)}
+function toggleTheme(){var order=['system','light','dark'],next=order[(order.indexOf(_themePref())+1)%3];try{_lsSet('codec-theme',next)}catch(e){}applyTheme();if(typeof showToast==='function')showToast(next==='system'?'Theme follows your system':'Theme: '+next)}
+try{if(window.matchMedia){matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if(_themePref()==='system')applyTheme()})}}catch(e){}
+window.addEventListener('storage',function(e){if(e.key==='codec-theme')applyTheme()});
+function updateThemeIcon(pref,eff){var ico=document.getElementById('themeIco');if(!ico)return;var theme=(pref==='system')?'system':(eff||pref);var btn=ico.parentNode;if(theme==='system'){ico.innerHTML='<circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 000 18z" fill="currentColor" stroke="none"/>';btn&&btn.setAttribute('title','Theme: follows your system — click to pin light');return}btn&&btn.setAttribute('title','Theme: '+theme+' — click to change');if(theme==='light'){ico.innerHTML='<path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>'}else{ico.innerHTML='<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'}}
+applyTheme();
 function lockSession(){fetch('/api/auth/logout',{method:'POST'}).then(function(){document.cookie='codec_session=;path=/;max-age=0;SameSite=Lax'+(location.protocol==='https:'?';Secure':'');window.location.href='/auth'})}
 var _voiceOn=_lsGet('codec-voice')==='true';
 function toggleVoiceReply(){_voiceOn=!_voiceOn;_lsSet('codec-voice',_voiceOn);updateVoiceIcon()}
@@ -590,8 +598,6 @@ function savePipFrame() {
 })();
 function pollStatus(){fetch('/api/health').then(function(r){return r.json()}).then(function(d){var dot=document.getElementById('statusDot');if(dot){dot.classList.toggle('on',!!d.ok)}}).catch(function(){var dot=document.getElementById('statusDot');if(dot)dot.classList.remove('on')})}
 pollStatus();setInterval(pollStatus,15000);
-(function(){var s=_lsGet('codec-theme');if(s==='light'){document.documentElement.setAttribute('data-theme','light');updateThemeIcon('light')}})();
-
 /* ── Tabs: showTab is defined once, canonically, lower in this file
       (tab switch + reports load). ── */
 
@@ -1053,6 +1059,12 @@ document.addEventListener('DOMContentLoaded', function() {
   loadHeartbeat();
   loadAlerts();
   loadHistory();
+  // The dashboard's Notifications item links to /tasks#reports, but nothing
+  // read the hash on arrival, so it landed on the default tab and looked like
+  // the notifications page did not exist. Honour it, and follow later changes.
+  function _tabFromHash(){var h=(location.hash||'').replace('#','');if(h&&document.getElementById('tab-'+h))showTab(h)}
+  _tabFromHash();
+  window.addEventListener('hashchange',_tabFromHash);
   pollNotifCount();
   setInterval(pollNotifCount, 30000);
   var bell=document.getElementById('notifBellBtn');

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -16,6 +16,13 @@
     <!-- Names the .icns that build_app.sh copies into Resources. Declaring it
          is not enough on its own: the file must actually be in the bundle, or
          the Dock shows a blank tile with no error. -->
+    <!-- Menu-bar agent: no Dock icon, no app switcher entry. Declared here
+         rather than only via setActivationPolicy(.accessory) at runtime — when
+         launched through `open`/LaunchServices the runtime call left the app
+         in the Dock with no status item (observed 2026-09-04: System Events
+         reported background-only=false and no menu bar 2). -->
+    <key>LSUIElement</key>
+    <true/>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleExecutable</key>

--- a/packaging/macos/launcher/codec_launcher.swift
+++ b/packaging/macos/launcher/codec_launcher.swift
@@ -138,6 +138,10 @@ final class Launcher: NSObject, NSApplicationDelegate {
             button.image?.isTemplate = true
         }
         statusItem = item
+        if item.button == nil {
+            log("status bar refused a status item — falling back to a Dock presence")
+            NSApp.setActivationPolicy(.regular)
+        }
         rebuildMenu(status: "Starting…", enabled: false)
 
         DispatchQueue.global().async { [weak self] in
@@ -169,7 +173,13 @@ final class Launcher: NSObject, NSApplicationDelegate {
     /// A failure must be impossible to miss; a success must not nag. So an error
     /// gets a modal the user has to dismiss, and a success only updates the menu.
     private func announce(_ outcome: StartResult) {
-        guard !outcome.ok else { return }
+        guard !outcome.ok else {
+            // The product's only UI is the dashboard. A successful start that
+            // shows nothing is indistinguishable from a broken one, so open it
+            // once, after the fleet has had a moment to bind its port.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in self?.openDashboard() }
+            return
+        }
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = outcome.summary

--- a/packaging/macos/verify/feedback.mjs
+++ b/packaging/macos/verify/feedback.mjs
@@ -18,6 +18,11 @@ if (!/Open CODEC Dashboard/.test(s)) fail.push("no route to the dashboard, so a 
 // A failure must name a cause, not just say something went wrong.
 if (!/terminationStatus != 0/.test(s)) fail.push("child exit status is never checked");
 if (!/Show Logs/.test(s)) fail.push("no way to reach the logs from the failure alert");
+if (!/openDashboard\(\)/.test(s.split("guard !outcome.ok else {")[1] || "")) fail.push("a successful start opens nothing");
+// LSUIElement in the SHIPPED plist: runtime setActivationPolicy alone left the
+// app in the Dock with no status item when launched via `open`.
+const plist = join(dirname(pkg), "macos/Info.plist");
+if (!/<key>LSUIElement<\/key>\s*<true\/>/.test(readFileSync(plist, "utf8"))) fail.push("Info.plist lacks LSUIElement=true");
 
 if (fail.length) { console.error("G5 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }
 console.log("UNLAZY-G5-PASS");


### PR DESCRIPTION
Three reports from the same first-run, 2026-09-04.

"Notifications doesn't open the notification page." The dashboard's
Notifications item links to /tasks#reports, but codec_tasks.html never read
location.hash — showTab('reports') only fired after runNow(). So the link
navigated and landed on the default tab, which reads as "the page does not
exist". The tasks page now honours the hash on arrival and on hashchange.

"No system option for light/dark." tasks, auth and audit still had the
pre-#324 two-state toggle. Ported chat's three-state block (system / light /
dark, live sunset switching, cross-tab sync). audit's bespoke loadTheme() is
gone; its themeToggle calls the shared toggleTheme.

"When I click it nothing opens; the logo shows in the Dock." The launcher's
runtime setActivationPolicy(.accessory) was not honoured when launched via
`open`: System Events reported background-only=false and no menu bar 2 — the
app sat in the Dock with no status item, indistinguishable from broken.
LSUIElement=true in Info.plist is the canonical declaration and is applied by
LaunchServices before the process exists. A successful fleet start now opens
the dashboard once (the product's only UI), and if the status bar refuses an
item the launcher falls back to a Dock presence rather than vanishing. G5
verifies LSUIElement in the shipped plist and the open-on-success path.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
