### PR TITLE
fix(launcher): surface the real refusal line in the failure alert, not 'exit code 1'

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -241,3 +241,15 @@ exercise them. Confirmed pre-existing by diffing failing IDs on main vs a clean
 branch: zero unique to the branch. Fix: decide whether the cloud-mode lock is the
 intended default in tests (then update expectations) or gate it behind config in the
 test fixture.
+
+## `_fleet_loaded()` counts the app's own LaunchServices registration (2026-09-04)
+
+`launcher/codec_app_main.py:_fleet_loaded()` counts `launchctl list` entries matching
+`ai.avadigital.codec`. LaunchServices registers the running app itself as
+`application.ai.avadigital.codec.<pid>.<n>`, which matches, so an app launched via
+`open`/double-click sees "1 loaded" and skips `_bootstrap_fleet` even when zero fleet
+agents exist — it then reports "fleet running: 1 launchd service(s)" with nothing
+running. Launched directly from a shell the LS entry is absent, the count is 0, and
+bootstrap runs (and on a dev box is correctly refused by the PM2 guard). Fix: match
+`ai.avadigital.codec.<service>` labels only, excluding the `application.` prefix.
+Found while diffing `open` vs direct-exec behaviour of the Mach-O launcher.

--- a/packaging/macos/launcher/codec_launcher.swift
+++ b/packaging/macos/launcher/codec_launcher.swift
@@ -106,10 +106,14 @@ func startFleet() -> StartResult {
     if process.terminationStatus != 0 {
         // Surface the real reason, not "something went wrong". The first line of
         // a Python traceback's final frame is what actually helps.
-        let reason = combined
-            .split(separator: "\n")
-            .last(where: { $0.contains("Error") || $0.contains("error") })
-            .map(String.init) ?? "exit code \(process.terminationStatus)"
+        // Case-insensitive: codec_app_main prints "FLEET ERROR: ... REFUSING: ..."
+        // and the old match missed it, so the alert read "exit code 1" — true
+        // and useless. Prefer the REFUSING/Error line, else the last non-empty one.
+        let lines = combined.split(separator: "\n").map(String.init).filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        let reason = lines.last(where: { $0.range(of: "refus", options: .caseInsensitive) != nil })
+            ?? lines.last(where: { $0.range(of: "error", options: .caseInsensitive) != nil })
+            ?? lines.last
+            ?? "exit code \(process.terminationStatus)"
         return StartResult(ok: false, summary: "CODEC could not start", detail: reason)
     }
 


### PR DESCRIPTION
codec_app_main prints 'FLEET ERROR: bootstrap exited 1: REFUSING: the PM2 codec
fleet appears to be running'. The alert's reason picker matched 'Error'/'error'
case-sensitively, missed it, and showed 'exit code 1' — accurate and useless.
Now case-insensitive, preferring the REFUSING line. Observed 2026-09-04 via
System Events on a signed bundle copy: windows=1, text='CODEC could not start,
exit code 1'.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
