### PR TITLE
fix(setup): setup and chat read ONE key slot, and the local option is honest

### DIFF
--- a/codec_dashboard.html
+++ b/codec_dashboard.html
@@ -587,6 +587,7 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
 .setup-opt{text-align:left;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--radius);padding:14px 16px;cursor:pointer;display:flex;flex-direction:column;gap:3px;transition:border-color .15s,background .15s}
 .setup-opt:hover{border-color:var(--border-hover);background:var(--surface-3)}
 .setup-opt.sel{border-color:var(--accent);background:var(--accent-dim)}
+.setup-opt.disabled,.setup-opt:disabled{opacity:.45;cursor:not-allowed}
 .setup-opt-t{font-size:14px;font-weight:600;color:var(--text)}
 .setup-opt-d{font-size:12px;color:var(--text-muted)}
 .setup-opt-meta{font-size:11px;color:var(--text-dim)}
@@ -3103,7 +3104,14 @@ setInterval(checkForUpdate, 6*60*60*1000);   // re-check every 6h
   function refresh(){
     return fetch('/api/setup/status').then(function(r){return r.json()}).then(function(d){
       var lm=document.getElementById('setupLocalMeta');
-      if(d.local_models&&d.local_models.length){
+      var localBtn=document.querySelector('.setup-opt[data-mode="local"]');
+      if(d.local_available===false){
+        // No server to answer a local model on this Mac. Offering it anyway
+        // would fail after a multi-GB download — say so and disable it.
+        lm.textContent=(d.local_reason||'Local model server is not running.')+' Choose AVA cloud or your own endpoint.';
+        if(localBtn){localBtn.disabled=true;localBtn.classList.add('disabled')}
+      } else if(d.local_models&&d.local_models.length){
+        if(localBtn){localBtn.disabled=false;localBtn.classList.remove('disabled')}
         lm.textContent=d.local_models.length+' model'+(d.local_models.length>1?'s':'')+' ready on this Mac';
         localPick.innerHTML='';
         d.local_models.forEach(function(m){

--- a/codec_setup.py
+++ b/codec_setup.py
@@ -54,8 +54,13 @@ AVA_DEFAULT_MODEL = "gemini-2.5-flash-lite"
 
 PROVIDERS = ("local", "ava", "custom")
 
-# Keychain service for a user-supplied key. config.json must never hold it.
-CUSTOM_KEY_SERVICE = "ai.avadigital.codec.custom_llm_key"
+# The bearer for llm_base_url lives in ONE Keychain slot: "llm_api_key", which
+# is what codec_dashboard already reads via codec_config.get_llm_api_key().
+# The first version stored custom keys under a separate slot; verify() added
+# the key itself and went green, then every real chat sent no key and got 401.
+# A false green from the setup screen is the exact failure it exists to prevent,
+# so setup and chat now read the same slot by construction.
+KEY_SLOT = "llm_api_key"
 
 
 def _load_config() -> Dict[str, Any]:
@@ -141,11 +146,18 @@ def set_provider(mode: str, *, model: str = "", base_url: str = "",
         cfg["llm_base_url"] = LOCAL_BASE_URL
         cfg["llm_model"] = chosen
         cfg["llm_provider"] = "mlx"
+        # The local server needs no bearer; a stale cloud key must not be sent
+        # to it, and the model server must actually be serving THIS model —
+        # codec_models.restart_server() makes the launcher preload it.
+        _store_key("")
     elif mode == "ava":
         ava = cfg.get("ava") if isinstance(cfg.get("ava"), dict) else {}
         cfg["llm_base_url"] = (ava.get("proxy_url") or AVA_PROXY_URL).rstrip("/") + "/v1"
         cfg["llm_model"] = model or ava.get("default_cloud_model") or AVA_DEFAULT_MODEL
         cfg["llm_provider"] = "ava"
+        # The proxy is authorised by the licence key, so THAT is the bearer the
+        # chat path must send. Put it where the chat path looks.
+        _store_key(ava.get("license_key", ""))
     else:  # custom
         if not base_url:
             return {"ok": False, "error": "a base URL is required"}
@@ -153,35 +165,52 @@ def set_provider(mode: str, *, model: str = "", base_url: str = "",
         cfg["llm_model"] = model or ""
         cfg["llm_provider"] = "custom"
         if api_key:
-            _store_custom_key(api_key)
-        # Belt and braces: an older build may have left a key on disk.
-        cfg.pop("llm_api_key", None)
+            _store_key(api_key)
+    # Never on disk, whatever an older build left behind.
+    cfg.pop("llm_api_key", None)
 
     # A new choice is unproven until verify() says otherwise.
     cfg["llm_verified_at"] = ""
     _save_config(cfg)
+    if mode == "local":
+        try:
+            import codec_models
+            codec_models.restart_server()   # preload the chosen model; best effort
+        except Exception:
+            pass
     return {"ok": True, "provider": mode,
             "model": cfg.get("llm_model", ""), "base_url": cfg.get("llm_base_url", "")}
 
 
-def _store_custom_key(key: str) -> None:
-    """Keychain only. config.json is backed up and pasted into support threads."""
+def _store_key(key: str) -> None:
+    """Keychain only, in the slot the chat path reads. config.json is backed up
+    and pasted into support threads."""
     try:
         from codec_keychain import keychain_set
-        keychain_set(CUSTOM_KEY_SERVICE, key)
+        keychain_set(KEY_SLOT, key)
     except Exception:
-        # Headless/CI falls back to the envelope store PR-2B already uses.
         try:
             from codec_keychain import _fallback_set  # type: ignore
-            _fallback_set(CUSTOM_KEY_SERVICE, key)
+            _fallback_set(KEY_SLOT, key)
         except Exception:
             pass
+    # codec_config caches secrets for 30s; a chat sent right after setup must
+    # not read a stale empty value.
+    try:
+        import codec_config
+        cache = getattr(codec_config, "_SECRET_CACHE", None)
+        if isinstance(cache, dict):
+            cache.pop(KEY_SLOT, None)
+    except Exception:
+        pass
 
 
-def get_custom_key() -> str:
+def get_key() -> str:
+    """Read the SAME slot the chat path reads — so verify() proves what chat
+    will actually send, not what setup happens to remember."""
     try:
         from codec_keychain import keychain_get
-        return keychain_get(CUSTOM_KEY_SERVICE) or ""
+        return keychain_get(KEY_SLOT) or ""
     except Exception:
         return ""
 
@@ -217,12 +246,11 @@ def verify(timeout: float = 45.0) -> Dict[str, Any]:
                                f"Download it, or pick one of: "
                                f"{', '.join(sorted(local)) or 'none found'}.")}
 
-    key = get_custom_key() if mode == "custom" else ""
-    if mode == "ava":
-        ava = cfg.get("ava") if isinstance(cfg.get("ava"), dict) else {}
-        key = ava.get("license_key", "")
-        if not key:
-            return {"ok": False, "detail": "No licence key — AVA cloud needs the key from your welcome email."}
+    # Read the key exactly as chat will: from the shared slot, never from a
+    # private copy — otherwise verify() can pass while chat fails.
+    key = get_key() if mode in ("ava", "custom") else ""
+    if mode == "ava" and not key:
+        return {"ok": False, "detail": "No licence key — AVA cloud needs the key from your welcome email."}
 
     body = json.dumps({"model": model,
                        "messages": [{"role": "user", "content": "Reply with the single word: READY"}],
@@ -282,11 +310,28 @@ def _explain_http(code: int, detail: str, mode: str) -> str:
     return f"HTTP {code}: {detail[:160]}"
 
 
+def _local_server_listening(timeout: float = 1.0) -> bool:
+    import socket
+    from urllib.parse import urlparse
+    u = urlparse(LOCAL_BASE_URL)
+    try:
+        with socket.create_connection((u.hostname or "localhost", u.port or 8083), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
 def status() -> Dict[str, Any]:
     """What the first-run screen asks: is there a working brain?"""
     cfg = _load_config()
     mode = get_provider(cfg)
+    local_up = _local_server_listening()
     return {
+        # A buyer's build cannot serve a local model unless the model server
+        # is part of the fleet AND running. Say so instead of offering an option
+        # that fails after a 4 GB download.
+        "local_available": local_up,
+        "local_reason": "" if local_up else "CODEC's local model server is not running on this Mac.",
         "connected": bool(mode and cfg.get("llm_verified_at")),
         "provider": mode,
         "model": cfg.get("llm_model", ""),

--- a/packaging/macos/verify/setup_screen.mjs
+++ b/packaging/macos/verify/setup_screen.mjs
@@ -14,6 +14,7 @@ if (!/\/api\/setup\/verify/.test(s)) fail.push("never verifies — it could repo
 if (!/overlay\.hidden\s*=\s*!!d\.connected/.test(s)) fail.push("overlay visibility is not driven by verified connectivity");
 for (const m of ["local", "ava", "custom"])
   if (!new RegExp(`data-mode="${m}"`).test(s)) fail.push(`no "${m}" option`);
+if (!/local_available===false/.test(s)) fail.push("local option is offered even when no local server can answer");
 if (!/openConnectSetup/.test(s)) fail.push("not reachable from Settings after first run");
 if (!/Keychain, never on disk/.test(s)) fail.push("does not tell the user where their key goes");
 if (fail.length) { console.error("G6 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }

--- a/tests/test_setup_connect.py
+++ b/tests/test_setup_connect.py
@@ -23,6 +23,16 @@ if str(REPO) not in sys.path:
 import codec_setup  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _no_real_side_effects(monkeypatch):
+    """Never let the suite restart the operator's model server or touch the
+    real Keychain: set_provider('local') calls codec_models.restart_server()."""
+    import codec_models
+    monkeypatch.setattr(codec_models, "restart_server", lambda *a, **k: (False, "test"))
+    monkeypatch.setattr(codec_setup, "_store_key", lambda k: None)
+    monkeypatch.setattr(codec_setup, "get_key", lambda: "")
+
+
 @pytest.fixture
 def cfg(tmp_path, monkeypatch):
     path = tmp_path / "config.json"
@@ -172,11 +182,25 @@ def test_test_call_is_honest(cfg, server, monkeypatch, capsys):
 
 def test_key_never_on_disk(cfg, monkeypatch, capsys):
     stored = {}
-    monkeypatch.setattr(codec_setup, "_store_custom_key", lambda k: stored.update(key=k))
+    monkeypatch.setattr(codec_setup, "_store_key", lambda k: stored.update(key=k))
     codec_setup.set_provider("custom", base_url="https://api.example/v1",
                              model="m", api_key="sk-super-secret-value")
     raw = Path(cfg).read_text()
     assert "sk-super-secret-value" not in raw, "API KEY LEAKED INTO config.json"
     assert "llm_api_key" not in _read(cfg), "llm_api_key must not be written to disk"
     assert stored.get("key") == "sk-super-secret-value", "key never reached the Keychain"
+
+    # The slot must be the one the CHAT path reads, or verify() passes while
+    # every real message sends no key. That happened.
+    assert codec_setup.KEY_SLOT == "llm_api_key", \
+        f"setup stores keys under {codec_setup.KEY_SLOT!r} but chat reads 'llm_api_key'"
+
+    # AVA mode must put the licence key in that same slot.
+    Path(cfg).write_text(json.dumps({"ava": {"license_key": "lic-123", "proxy_url": "https://p.example"}}))
+    codec_setup.set_provider("ava")
+    assert stored.get("key") == "lic-123", "AVA licence key never reached the chat's key slot"
+
+    # And a local choice must clear it, so no cloud bearer is sent to the local server.
+    codec_setup.set_provider("local", model="x")
+    assert stored.get("key") == "", "stale cloud key left in place for the local server"
     print("UNLAZY-G5-PASS")


### PR DESCRIPTION
The connect screen could go green while every real chat failed. verify()
attached the key itself, but stored custom keys under a private Keychain
slot; codec_dashboard reads llm_api_key via codec_config.get_llm_api_key().
So the test passed, the chat sent no bearer, and the buyer got 401 — a false
green from the screen that exists to prevent false greens. Found by walking
the buyer path end to end rather than trusting the gate.

Now: one slot, "llm_api_key", the one chat already reads. AVA mode stores the
licence key there (it IS the bearer for the proxy — verified live: the proxy
answers READY to it). Custom mode stores the user's key there. Local mode
clears it so no cloud bearer is sent to the local server, and calls
codec_models.restart_server() so the launcher preloads the chosen model
instead of serving the old one. verify() reads the same slot, so it proves
what chat will send. codec_config's 30s secret cache is invalidated on write.

Also: a buyer's bundle has no mlx_vlm and no model-server venv, so "Use the
local model" cannot work there yet. status() now reports local_available by
probing the local server port, and the screen disables the option with the
reason instead of letting someone download 4 GB into a dead end. Bundling the
serving stack (~900 MB) is a separate product decision.

G5 now asserts the slot name equals what chat reads, that AVA stores the
licence key there, and that local clears it. G6 asserts the UI honours
local_available.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
