### PR TITLE
feat(app): CODEC owns a native window — the dashboard renders in the app, not in Chrome

### DIFF
--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -21,8 +21,14 @@
          launched through `open`/LaunchServices the runtime call left the app
          in the Dock with no status item (observed 2026-09-04: System Events
          reported background-only=false and no menu bar 2). -->
-    <key>LSUIElement</key>
-    <true/>
+    <!-- The dashboard is served over plain http on loopback; ATS blocks that
+         by default and the WKWebView would show a blank window. Scoped to
+         localhost only — no general cleartext exemption. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleExecutable</key>

--- a/packaging/macos/build_app.sh
+++ b/packaging/macos/build_app.sh
@@ -88,9 +88,12 @@ printf 'APPL????' > "$CONTENTS/PkgInfo"
 # ZERO entitlements, and therefore no way to ever be granted a microphone.
 # See launcher/codec_launcher.swift for the full account.
 LAUNCHER_SWIFT="$PKG_DIR/launcher/codec_launcher.swift"
+# Every .swift in launcher/ is compiled into the one binary — the window lives
+# in DashboardWindow.swift, and omitting it would silently drop the app's UI.
+LAUNCHER_SOURCES=("$PKG_DIR/launcher"/*.swift)
 if [ -f "$LAUNCHER_SWIFT" ]; then
     echo "==> compiling Mach-O launcher"
-    SWIFTC_ARGS=(-O -o "$CONTENTS/MacOS/codec" "$LAUNCHER_SWIFT")
+    SWIFTC_ARGS=(-O -o "$CONTENTS/MacOS/codec" "${LAUNCHER_SOURCES[@]}")
     [ -n "${ARCH:-}" ] && case "$ARCH" in
         aarch64) SWIFTC_ARGS=(-target arm64-apple-macos13.0 "${SWIFTC_ARGS[@]}") ;;
         x86_64)  SWIFTC_ARGS=(-target x86_64-apple-macos13.0 "${SWIFTC_ARGS[@]}") ;;

--- a/packaging/macos/launcher/DashboardWindow.swift
+++ b/packaging/macos/launcher/DashboardWindow.swift
@@ -1,0 +1,132 @@
+// The CODEC app window.
+//
+// WHY (2026-09-04): CODEC's UI is a FastAPI-served dashboard on :8090. The
+// launcher used to `NSWorkspace.open` that URL, so "the Mac app" was a website
+// in the user's default browser with an app icon in front of it. Reported, and
+// fairly: "it running inside google chrome!!! what the whole point? aint we
+// building a app???"
+//
+// So the dashboard now renders inside the app itself: a real NSWindow, real
+// title bar, CODEC's icon in the Dock, no address bar, no tabs, no other
+// browser's cookies or extensions. Same server, same page — but the app IS the
+// product rather than a shortcut to one.
+//
+// It is a WKWebView pointed at localhost, NOT an embedded browser: navigation
+// away from the local origin is refused and handed to the real browser, so a
+// link in a chat reply opens in Safari/Chrome rather than turning this window
+// into a rogue browser with no address bar.
+
+import AppKit
+import WebKit
+
+final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationDelegate, WKUIDelegate {
+    private var window: NSWindow?
+    private var webView: WKWebView?
+    private let url: URL
+    /// Everything the app is allowed to render in-window. Anything else is a
+    /// link out, and belongs in the user's browser.
+    private let allowedHosts: Set<String> = ["127.0.0.1", "localhost", "::1"]
+
+    init(url: URL) {
+        self.url = url
+        super.init()
+    }
+
+    /// Bring the window up, creating it on first use. Safe to call repeatedly —
+    /// the menu item and the dock icon both route here.
+    func show() {
+        if let w = window {
+            w.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let config = WKWebViewConfiguration()
+        // The dashboard stores its theme + prefs in localStorage; a non-persistent
+        // store would silently reset them on every launch.
+        config.websiteDataStore = .default()
+
+        let web = WKWebView(frame: .zero, configuration: config)
+        web.navigationDelegate = self
+        web.uiDelegate = self
+        web.allowsBackForwardNavigationGestures = false
+        web.setValue(false, forKey: "drawsBackground")   // no white flash before the dark page paints
+        web.load(URLRequest(url: url))
+        webView = web
+
+        let w = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1180, height: 800),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered, defer: false
+        )
+        w.title = "CODEC"
+        w.titlebarAppearsTransparent = true
+        w.titleVisibility = .hidden
+        w.isReleasedWhenClosed = false          // closing must not destroy the agent
+        w.minSize = NSSize(width: 900, height: 600)
+        w.delegate = self
+        w.contentView = web
+        w.center()
+        w.setFrameAutosaveName("CODECDashboardWindow")   // remember size/position
+        window = w
+
+        w.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func reload() { webView?.reload() }
+
+    /// Closing the window leaves the agent running in the menu bar — the fleet
+    /// must not stop because someone closed a window. Reopened from the menu.
+    func windowWillClose(_ notification: Notification) {
+        window = nil
+        webView = nil
+    }
+
+    // MARK: - Navigation policy
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let target = navigationAction.request.url else { return decisionHandler(.allow) }
+        if let host = target.host, allowedHosts.contains(host) {
+            return decisionHandler(.allow)
+        }
+        // An outbound link (a source in a web_search reply, a Google Doc) belongs
+        // in the real browser, with its address bar and the user's session.
+        if target.scheme == "http" || target.scheme == "https" || target.scheme == "mailto" {
+            NSWorkspace.shared.open(target)
+        }
+        decisionHandler(.cancel)
+    }
+
+    /// target="_blank" has no window to open into here; send it out too.
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
+                 for navigationAction: WKNavigationAction,
+                 windowFeatures: WKWindowFeatures) -> WKWebView? {
+        if let target = navigationAction.request.url { NSWorkspace.shared.open(target) }
+        return nil
+    }
+
+    /// The dashboard is served by a fleet that may still be binding its port when
+    /// the window opens. Retry briefly rather than showing a dead page.
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        retryLoad()
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        retryLoad()
+    }
+
+    private var retries = 0
+    private func retryLoad() {
+        guard retries < 15 else { return }   // ~30s, then leave the error visible
+        retries += 1
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            guard let self else { return }
+            self.webView?.load(URLRequest(url: self.url))
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { retries = 0 }
+}

--- a/packaging/macos/launcher/codec_launcher.swift
+++ b/packaging/macos/launcher/codec_launcher.swift
@@ -132,6 +132,10 @@ func startFleet() -> StartResult {
 final class Launcher: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private var result: StartResult?
+    // The dashboard renders INSIDE the app now. Handing the URL to the user's
+    // browser made "the Mac app" a website with an app icon in front of it.
+    private lazy var dashboard = DashboardWindowController(
+        url: URL(string: "http://127.0.0.1:8090/")!)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         log("CODEC launched from \(bundleURL.path)")
@@ -143,8 +147,7 @@ final class Launcher: NSObject, NSApplicationDelegate {
         }
         statusItem = item
         if item.button == nil {
-            log("status bar refused a status item — falling back to a Dock presence")
-            NSApp.setActivationPolicy(.regular)
+            log("status bar refused a status item — the Dock icon remains the way back in")
         }
         rebuildMenu(status: "Starting…", enabled: false)
 
@@ -166,6 +169,8 @@ final class Launcher: NSObject, NSApplicationDelegate {
                                      action: #selector(openDashboard), keyEquivalent: "")
         dashboard.target = self
         dashboard.isEnabled = enabled
+        let reload = menu.addItem(withTitle: "Reload", action: #selector(reloadDashboard), keyEquivalent: "r")
+        reload.target = self
         let logs = menu.addItem(withTitle: "Show Logs", action: #selector(openLogs), keyEquivalent: "")
         logs.target = self
         menu.addItem(.separator())
@@ -178,10 +183,10 @@ final class Launcher: NSObject, NSApplicationDelegate {
     /// gets a modal the user has to dismiss, and a success only updates the menu.
     private func announce(_ outcome: StartResult) {
         guard !outcome.ok else {
-            // The product's only UI is the dashboard. A successful start that
-            // shows nothing is indistinguishable from a broken one, so open it
-            // once, after the fleet has had a moment to bind its port.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in self?.openDashboard() }
+            // A successful start that shows nothing is indistinguishable from a
+            // broken one. The window retries its own load while the fleet binds
+            // its port, so it can open immediately.
+            DispatchQueue.main.async { [weak self] in self?.openDashboard() }
             return
         }
         let alert = NSAlert()
@@ -193,9 +198,16 @@ final class Launcher: NSObject, NSApplicationDelegate {
         if alert.runModal() == .alertFirstButtonReturn { openLogs() }
     }
 
-    @objc private func openDashboard() {
-        NSWorkspace.shared.open(URL(string: "http://127.0.0.1:8090/")!)
+    @objc private func openDashboard() { dashboard.show() }
+
+    /// Clicking the Dock icon with no window open must bring CODEC back, or the
+    /// app looks dead after the window is closed.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag { dashboard.show() }
+        return true
     }
+
+    @objc private func reloadDashboard() { dashboard.reload() }
 
     @objc private func openLogs() {
         let logs = FileManager.default.homeDirectoryForCurrentUser
@@ -205,10 +217,3 @@ final class Launcher: NSObject, NSApplicationDelegate {
 
     @objc private func quit() { NSApp.terminate(nil) }
 }
-
-let app = NSApplication.shared
-let delegate = Launcher()
-app.delegate = delegate
-// .accessory: menu-bar presence with no Dock icon bouncing for a background agent.
-app.setActivationPolicy(.accessory)
-app.run()

--- a/packaging/macos/launcher/main.swift
+++ b/packaging/macos/launcher/main.swift
@@ -1,0 +1,14 @@
+// Entry point. Swift permits top-level expressions ONLY in a file named
+// main.swift, and the launcher became multi-file when the app gained a real
+// window (DashboardWindow.swift), so the bootstrap moved here.
+
+import AppKit
+
+let app = NSApplication.shared
+let delegate = Launcher()
+app.delegate = delegate
+// .regular now: CODEC owns a real window, so it belongs in the Dock and the
+// app switcher like any Mac app. The menu-bar item stays as the always-there
+// handle for an agent that keeps running after the window is closed.
+app.setActivationPolicy(.regular)
+app.run()

--- a/packaging/macos/verify/feedback.mjs
+++ b/packaging/macos/verify/feedback.mjs
@@ -19,10 +19,24 @@ if (!/Open CODEC Dashboard/.test(s)) fail.push("no route to the dashboard, so a 
 if (!/terminationStatus != 0/.test(s)) fail.push("child exit status is never checked");
 if (!/Show Logs/.test(s)) fail.push("no way to reach the logs from the failure alert");
 if (!/openDashboard\(\)/.test(s.split("guard !outcome.ok else {")[1] || "")) fail.push("a successful start opens nothing");
-// LSUIElement in the SHIPPED plist: runtime setActivationPolicy alone left the
-// app in the Dock with no status item when launched via `open`.
-const plist = join(dirname(pkg), "macos/Info.plist");
-if (!/<key>LSUIElement<\/key>\s*<true\/>/.test(readFileSync(plist, "utf8"))) fail.push("Info.plist lacks LSUIElement=true");
+// The app owns a real window now, so it must NOT be LSUIElement (that hides it
+// from the Dock and app switcher) and must declare the localhost ATS exemption,
+// without which the WKWebView renders a blank window over plain-http loopback.
+const plist = readFileSync(join(dirname(pkg), "macos/Info.plist"), "utf8");
+if (/<key>LSUIElement<\/key>\s*<true\/>/.test(plist))
+  fail.push("LSUIElement=true hides a windowed app from the Dock");
+if (!/NSAllowsLocalNetworking/.test(plist))
+  fail.push("no ATS localhost exemption — the dashboard window would be blank");
+// The dashboard must render IN the app, not be handed to a browser.
+const win = join(pkg, "launcher/DashboardWindow.swift");
+if (!existsSync(win)) fail.push("no DashboardWindow.swift — the UI would still be a browser tab");
+else {
+  const w = readFileSync(win, "utf8");
+  if (!/WKWebView/.test(w)) fail.push("dashboard window does not embed a web view");
+  if (!/decidePolicyFor/.test(w)) fail.push("no navigation policy — the window would act as an open browser");
+}
+if (/NSWorkspace\.shared\.open\(URL\(string: "http:\/\/127\.0\.0\.1:8090/.test(s))
+  fail.push("still opens the dashboard in an external browser");
 
 if (fail.length) { console.error("G5 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }
 console.log("UNLAZY-G5-PASS");

--- a/packaging/macos/verify/feedback.mjs
+++ b/packaging/macos/verify/feedback.mjs
@@ -1,7 +1,7 @@
 // G5: launching must never be silent.
 // "when I click it nothing happened It just nothing happened." The launcher
 // started the fleet and exited: no window, no menu-bar item, no notification.
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -9,11 +9,16 @@ const pkg = dirname(dirname(fileURLToPath(import.meta.url)));
 const src = join(pkg, "launcher/codec_launcher.swift");
 const fail = [];
 if (!existsSync(src)) { console.error("G5 FAILED: no launcher source"); process.exit(1); }
-const s = readFileSync(src, "utf8");
+// The launcher is multi-file now: declarations in codec_launcher.swift, the
+// bootstrap (and activation policy) in main.swift, the window in
+// DashboardWindow.swift. Read them all, or a check on one file goes stale the
+// moment code moves — which is exactly what happened here.
+const s = readdirSync(join(pkg, "launcher")).filter(f => f.endsWith(".swift"))
+  .map(f => readFileSync(join(pkg, "launcher", f), "utf8")).join("\n");
 
 if (!/NSStatusBar\.system\.statusItem/.test(s)) fail.push("no menu-bar item — the app is invisible once started");
 if (!/NSAlert\(\)/.test(s)) fail.push("failures are not surfaced to the user");
-if (!/setActivationPolicy\(\.accessory\)/.test(s)) fail.push("activation policy not set — presence is undefined");
+if (!/setActivationPolicy\(\.regular\)/.test(s)) fail.push("activation policy is not .regular — a windowed app belongs in the Dock and ⌘-Tab");
 if (!/Open CODEC Dashboard/.test(s)) fail.push("no route to the dashboard, so a running agent has nowhere to go");
 // A failure must name a cause, not just say something went wrong.
 if (!/terminationStatus != 0/.test(s)) fail.push("child exit status is never checked");


### PR DESCRIPTION
"it running inside google chrome!!! what the whole point? aint we building
a app???" Fair. The launcher handed localhost:8090 to the default browser,
so "the Mac app" was a website with an icon in front of it.

DashboardWindow.swift: a WKWebView inside a real NSWindow — own title bar,
CODEC's icon in the Dock and ⌘-Tab, no address bar, no tabs, no other
browser's cookies or extensions. Remembers size and position. Closing the
window leaves the agent running in the menu bar; the Dock icon brings it
back (applicationShouldHandleReopen).

It is a window onto localhost, NOT an embedded browser: decidePolicyFor
refuses any host that is not loopback and hands the URL to the real browser,
so a source link in a chat reply opens in Safari/Chrome rather than turning
a window with no address bar into a rogue browser. target=_blank goes out
the same way. The load retries for ~30s while the fleet binds its port.

Activation policy is .regular now (a window app belongs in the Dock);
LSUIElement is removed and NSAllowsLocalNetworking added — without the ATS
exemption the WKWebView shows a blank window over plain-http loopback.
Top-level bootstrap moved to main.swift, the only file Swift allows it in
once the launcher became multi-file; build_app.sh compiles every launcher
source so the window cannot be silently dropped.

Verified via System Events on the installed app: windows: 1, background
only: false, window title: CODEC, 1180x800, dashboard content rendered.

G5 updated: asserts DashboardWindow.swift with a WKWebView and a navigation
policy, no LSUIElement, ATS exemption present, and no external-browser open
of the dashboard URL.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
