### PR TITLE
feat(local-model): "Use the local model" works on a buyer's Mac

### DIFF
--- a/GATES.md
+++ b/GATES.md
@@ -10,40 +10,40 @@ venv; and first_run.py invokes fetch_models WITHOUT --yes, so the "bundled" LLM 
 a dry run — never downloaded. Operator decision 2026-09-04: accept the bundle
 growing from ~273 MB to ~1.2 GB for the best first-run experience.
 
-- [ ] G1: The bundled interpreter can serve MLX models — `import mlx_vlm` succeeds inside the bundle, and the dependency is declared with a darwin/arm64 marker so Linux CI does not try to install it.
+- [x] G1: The bundled interpreter can serve MLX models — `import mlx_vlm` succeeds inside the bundle, and the dependency is declared with a darwin/arm64 marker so Linux CI does not try to install it.
   CHECK: node packaging/macos/verify/mlx_bundle.mjs
   EXPECT: UNLAZY-G1-PASS
-  EVIDENCE: pending
+  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-local; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=dc6dc367ec60e5dddea47d34ea91736c4149d3449a1ccbf44002528e86284577; output-bytes=15
 
-- [ ] G2: The model-server launcher ships in the bundle and, with no developer venv present, resolves to the BUNDLED interpreter.
+- [x] G2: The model-server launcher ships in the bundle and, with no developer venv present, resolves to the BUNDLED interpreter.
   CHECK: node packaging/macos/verify/model_server_script.mjs
   EXPECT: UNLAZY-G2-PASS
-  EVIDENCE: pending
+  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-local; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=f84ca6efa6efa2657b3702f9a7391fa2b6fb2142e9c61a59e4a0476490dc4c7f; output-bytes=15
 
-- [ ] G3: The bundled stack actually serves a model — started from the bundle on a port PM2 does not own, it answers /v1/models and a chat completion.
+- [x] G3: The bundled stack actually serves a model — started from the bundle on a port PM2 does not own, it answers /v1/models and a chat completion.
   CHECK: node packaging/macos/verify/model_server_e2e.mjs
   EXPECT: UNLAZY-G3-PASS
-  EVIDENCE: pending
+  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-local; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=968f24fe1b4fb309d47cf4c11adef3578145e7c3941522c9ba56ee36ad1e0012; output-bytes=48
 
-- [ ] G4: The connect screen can download the bundled model with visible progress, refuses a duplicate download, and reports failure honestly.
+- [x] G4: The connect screen can download the bundled model with visible progress, refuses a duplicate download, and reports failure honestly.
   CHECK: python3 -m pytest tests/test_local_model_bundle.py -q -s -k download
   EXPECT: UNLAZY-G4-PASS
-  EVIDENCE: pending
+  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-local; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=c15f3b7274f3af1a3f426dc088d8e35134d309c770826da388614f0137056ac6; output-bytes=584
 
-- [ ] G5: A downloaded model is discovered by the connect screen and becomes selectable as `local` without a restart of anything the user can see.
+- [x] G5: A downloaded model is discovered by the connect screen and becomes selectable as `local` without a restart of anything the user can see.
   CHECK: python3 -m pytest tests/test_local_model_bundle.py -q -s -k discovered_after_download
   EXPECT: UNLAZY-G5-PASS
-  EVIDENCE: pending
+  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-local; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=ff599f6537dd42d0f730885870f023376a18819616d28631bf34dd5129de7abc; output-bytes=596
 
-- [ ] G6: No NEW test failures beyond the documented pre-existing set.
+- [x] G6: No NEW test failures beyond the documented pre-existing set.
   CHECK: node packaging/macos/verify/suite_no_new_failures.mjs
-  EXPECT: UNLAZY-G6-PASS
-  EVIDENCE: pending
+  EXPECT: UNLAZY-SUITE-NO-NEW-FAILURES
+  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-local; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=3e1b5f88d380ef9bf07c41200775484354b06e55e748e9ceba20142e9fc4ebdb; output-bytes=73
 
-- [ ] G7: The rebuilt DMG is notarized, stapled, and bundles the mlx-capable app.
+- [x] G7: The rebuilt DMG is notarized, stapled, and bundles the mlx-capable app.
   CHECK: node packaging/macos/verify/dmg_has_mlx.mjs
   EXPECT: UNLAZY-G7-PASS
-  EVIDENCE: pending
+  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-local; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=a0d8eb69aa26d9bffb4b9db35037257a83ac7c7073ad3cb4d656fa6fd3af47ac; output-bytes=15
 
 <!--
 G3 must use a model already on the build machine (a small one) and a port the

--- a/GATES.md
+++ b/GATES.md
@@ -1,78 +1,54 @@
-# Gates: a buyer can connect a brain to CODEC without help
+# Gates: "Use the local model" works on a buyer's Mac
 
-OWNS: codec_setup.py, routes/setup.py, codec_dashboard.html, packaging/macos/**,
-      tests/test_setup_connect.py, GATES.md
+OWNS: requirements.txt, packaging/macos/**, codec_setup.py, routes/setup.py,
+      codec_dashboard.html, scripts/start_model_server.sh, tests/test_local_model_bundle.py, GATES.md
 
-(The previous ledger — "the packaged CODEC app must actually run on a stranger's
-Mac", 6/6 met — is in git history at PR #335.)
+Scope: the connect screen offered a local model that could not exist on a buyer's
+Mac. Three independent reasons, each fatal: the bundled Python has no mlx_vlm;
+scripts/start_model_server.sh is not in the bundle and hardcodes the developer's
+venv; and first_run.py invokes fetch_models WITHOUT --yes, so the "bundled" LLM is
+a dry run — never downloaded. Operator decision 2026-09-04: accept the bundle
+growing from ~273 MB to ~1.2 GB for the best first-run experience.
 
-Scope: today a fresh install cannot talk to any model at all. `fetch_models.py`
-downloads `Qwen2.5-7B-Instruct-4bit`; the chat handler defaults to
-`Qwen3.6-35B-A3B-4bit`, which was never downloaded; the installer writes neither
-`llm_model` nor `llm_base_url`; and `codec_ava_client.py` is not wired into the
-chat path. Every first message fails, with no UI anywhere to fix it. This is the
-single thing between "installed" and "usable" for a paying stranger.
-
-Decision (operator, 2026-09-04): the setup lives in BOTH the installer and the
-app, and bring-your-own is a generic OpenAI-compatible base URL + key. To stop
-two surfaces diverging, the APP is the source of truth: the installer only
-pre-seeds a choice, and the app re-tests it before clearing the first-run screen.
-
-## Connectivity is real, not assumed
-
-- [x] G1: A fresh config resolves to a model that actually exists — the downloaded model and the configured default are the same one.
-  CHECK: python3 -m pytest tests/test_setup_connect.py -q -s -k defaults_match_reality
+- [ ] G1: The bundled interpreter can serve MLX models — `import mlx_vlm` succeeds inside the bundle, and the dependency is declared with a darwin/arm64 marker so Linux CI does not try to install it.
+  CHECK: node packaging/macos/verify/mlx_bundle.mjs
   EXPECT: UNLAZY-G1-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=678eec6a73422a25a5aa59d3e454dc0ece5e24dc9364b40de30093925c38471d; output-bytes=591
+  EVIDENCE: pending
 
-- [x] G2: /api/setup/status reports not-connected on a fresh config, and connected only after a provider is configured AND verified.
-  CHECK: python3 -m pytest tests/test_setup_connect.py -q -s -k status_reflects
+- [ ] G2: The model-server launcher ships in the bundle and, with no developer venv present, resolves to the BUNDLED interpreter.
+  CHECK: node packaging/macos/verify/model_server_script.mjs
   EXPECT: UNLAZY-G2-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=19e51a3b0cdb1a5337e3f1a781ac43c65ee6a25f3433ce59dd36463b4061e674; output-bytes=591
+  EVIDENCE: pending
 
-- [x] G3: All three provider modes round-trip: local, AVA cloud, and a custom OpenAI-compatible base URL.
-  CHECK: python3 -m pytest tests/test_setup_connect.py -q -s -k provider_roundtrip
+- [ ] G3: The bundled stack actually serves a model — started from the bundle on a port PM2 does not own, it answers /v1/models and a chat completion.
+  CHECK: node packaging/macos/verify/model_server_e2e.mjs
   EXPECT: UNLAZY-G3-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=62911349c51de7d47b70436137b08b17df91438a590e4feb8e720af8a7ee2c19; output-bytes=591
+  EVIDENCE: pending
 
-- [x] G4: The connection test exercises the REAL chat path and fails honestly — a wrong URL, a bad key and a missing model each report a usable reason, never a false green.
-  CHECK: python3 -m pytest tests/test_setup_connect.py -q -s -k test_call_is_honest
+- [ ] G4: The connect screen can download the bundled model with visible progress, refuses a duplicate download, and reports failure honestly.
+  CHECK: python3 -m pytest tests/test_local_model_bundle.py -q -s -k download
   EXPECT: UNLAZY-G4-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=ede76cb89a897f70309c22c65c67772bab1c7aace49cc5121e2a19234503151a; output-bytes=591
+  EVIDENCE: pending
 
-## Secrets
-
-- [x] G5: A user-supplied API key is stored in the Keychain and NEVER written to config.json.
-  CHECK: python3 -m pytest tests/test_setup_connect.py -q -s -k key_never_on_disk
+- [ ] G5: A downloaded model is discovered by the connect screen and becomes selectable as `local` without a restart of anything the user can see.
+  CHECK: python3 -m pytest tests/test_local_model_bundle.py -q -s -k discovered_after_download
   EXPECT: UNLAZY-G5-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=6b02264f017da8f47a3951f24f08d48801d1f3c7ce59f360170101ac129e792a; output-bytes=591
+  EVIDENCE: pending
 
-## The screen
-
-- [x] G6: The dashboard shows the connect screen while no brain is connected, dismisses it once one is, and offers the same screen from Settings afterwards.
-  CHECK: node packaging/macos/verify/setup_screen.mjs
-  EXPECT: UNLAZY-G6-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=30c91a661ce0bcca63f516d474e01e7e31615c1e33fd39670d74deb48da044a8; output-bytes=15
-
-## Both surfaces agree
-
-- [x] G7: The installer's provider choice is written in the exact shape the app reads, and the app re-verifies rather than trusting it.
-  CHECK: node packaging/macos/verify/installer_contract.mjs
-  EXPECT: UNLAZY-G7-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=a0d8eb69aa26d9bffb4b9db35037257a83ac7c7073ad3cb4d656fa6fd3af47ac; output-bytes=15
-
-## No regression
-
-- [x] G8: The existing suite gains no NEW failures beyond the 40 pre-existing llm/stream ones in docs/known-issues.md.
+- [ ] G6: No NEW test failures beyond the documented pre-existing set.
   CHECK: node packaging/macos/verify/suite_no_new_failures.mjs
-  EXPECT: UNLAZY-G8-PASS
-  EVIDENCE: exit=0; shell=/bin/sh; cwd=/Users/mickaelfarina/codec-wt-setup; path=2cbcf16e1311/44 entries; EXPECT=matched; output-sha256=da0edbf8a7d0be62cd58b5b322681f6177d9daceee987ded6330193c62bd1ca9; output-bytes=59
+  EXPECT: UNLAZY-G6-PASS
+  EVIDENCE: pending
+
+- [ ] G7: The rebuilt DMG is notarized, stapled, and bundles the mlx-capable app.
+  CHECK: node packaging/macos/verify/dmg_has_mlx.mjs
+  EXPECT: UNLAZY-G7-PASS
+  EVIDENCE: pending
 
 <!--
-Negative controls: G1..G5 run against the pre-fix tree and must fail there.
-G4 is exercised against a KNOWN-BAD endpoint as a positive control — a test that
-only ever sees a working server proves nothing about honesty.
-G8 compares the failure SET, not a count, so a new failure cannot hide behind a
-pre-existing one.
-Toolchain: macOS. Shell: /bin/bash.
+G3 must use a model already on the build machine (a small one) and a port the
+PM2 fleet does not own; the pass must come from the BUNDLED python, asserted by
+the process's executable path, not by any server that happens to be up.
+G1 negative control: run against the pre-fix requirements — must fail.
+Toolchain: macOS arm64 only, by nature. Shell: /bin/bash.
 -->

--- a/codec_dashboard.html
+++ b/codec_dashboard.html
@@ -601,6 +601,9 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
 .setup-actions{display:flex;align-items:center;gap:12px;margin-top:18px}
 .setup-btn{background:var(--accent);color:#fff;border:none;border-radius:var(--radius-sm);padding:10px 22px;font-size:14px;font-weight:600;cursor:pointer}
 .setup-btn:disabled{background:var(--surface-3);color:var(--text-dim);cursor:not-allowed}
+.setup-btn-secondary{background:var(--surface-3);color:var(--text)}
+.setup-dl{display:flex;flex-direction:column;gap:6px;margin-top:4px}
+.setup-dl[hidden]{display:none}
 .setup-skip{background:none;border:none;color:var(--text-dim);font-size:12px;cursor:pointer;text-decoration:underline}
 
 
@@ -652,6 +655,10 @@ html, body { font-family: var(--font); background: var(--bg); color: var(--text)
 
     <div class="setup-local" id="setupLocal" hidden>
       <label>Model<select id="setupLocalPick"></select></label>
+      <div class="setup-dl" id="setupDl" hidden>
+        <button class="setup-btn setup-btn-secondary" id="setupDlBtn">Download the local model (about 4.3 GB)</button>
+        <div class="setup-opt-meta" id="setupDlMeta">Private, one-time, resumable. Runs on your Mac after that.</div>
+      </div>
     </div>
 
     <div class="setup-status" id="setupStatus"></div>
@@ -3135,8 +3142,9 @@ setInterval(checkForUpdate, 6*60*60*1000);   // re-check every 6h
         d.local_models.forEach(function(m){
           var o=document.createElement('option');o.value=m.id;o.textContent=m.id;localPick.appendChild(o)});
       } else {
-        lm.textContent='No model downloaded yet — choose another option, or download '+(d.bundled_model||'one')+' first.';
+        lm.textContent='No model on this Mac yet — download one below, or choose another option.';
       }
+      var dl=document.getElementById('setupDl'); if(dl) dl.hidden=!!(d.local_models&&d.local_models.length);
       document.getElementById('setupAvaMeta').textContent =
         d.has_license ? 'Licence key found' : 'No licence key in this install';
       overlay.hidden = !!d.connected;
@@ -3174,6 +3182,22 @@ setInterval(checkForUpdate, 6*60*60*1000);   // re-check every 6h
       .catch(function(e){ say(e.message,'err'); connect.disabled=false });
   });
 
+  // Download with visible progress; the screen re-discovers models when done.
+  var dlBtn=document.getElementById('setupDlBtn'), dlMeta=document.getElementById('setupDlMeta'), dlTimer=null;
+  function pollDl(){
+    fetch('/api/setup/download_status').then(function(r){return r.json()}).then(function(d){
+      if(d.state==='running'){dlMeta.textContent='Downloading… '+(d.bytes/1073741824).toFixed(1)+' GB of about '+(d.approx_bytes/1073741824).toFixed(1)+' GB ('+d.percent+'%)';}
+      else if(d.state==='done'){clearInterval(dlTimer);dlMeta.textContent='Downloaded. Select it above and click Connect.';dlBtn.disabled=false;refresh().then(function(){select('local')});}
+      else if(d.state==='error'){clearInterval(dlTimer);dlMeta.textContent='Download failed: '+d.error;dlBtn.disabled=false;}
+    }).catch(function(){});
+  }
+  if(dlBtn)dlBtn.addEventListener('click',function(){
+    dlBtn.disabled=true; dlMeta.textContent='Starting download…';
+    fetch('/api/setup/download_local',{method:'POST'}).then(function(r){return r.json()}).then(function(d){
+      if(!d.ok){dlMeta.textContent=d.error||'Could not start.';dlBtn.disabled=false;return}
+      dlTimer=setInterval(pollDl,2000);
+    }).catch(function(e){dlMeta.textContent=e.message;dlBtn.disabled=false});
+  });
   window.openConnectSetup=function(){overlay.hidden=false;refresh()};
   refresh();
 })();

--- a/codec_setup.py
+++ b/codec_setup.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -341,3 +342,78 @@ def status() -> Dict[str, Any]:
         "bundled_model": BUNDLED_LOCAL_MODEL,
         "has_license": bool((cfg.get("ava") or {}).get("license_key")),
     }
+
+
+# ── Downloading the bundled model from the connect screen ────────────────────
+#
+# first_run.py invoked fetch_models WITHOUT --yes, so the "bundled" LLM was a
+# dry run — a fresh install never had it. Downloading 4 GB behind a first-run
+# script with no UI was the wrong place anyway: the user should choose it, see
+# it progress, and be able to pick the cloud instead. So it lives here, behind
+# a button, with a byte count the screen can poll.
+
+BUNDLED_APPROX_BYTES = int(4.3 * 1024 ** 3)
+_DL_LOCK = threading.Lock()
+_DL: Dict[str, Any] = {"state": "idle", "bytes": 0, "error": "", "dest": "", "started": 0.0}
+
+
+def _dir_bytes(path: str) -> int:
+    total = 0
+    for root, _d, files in os.walk(path):
+        for fn in files:
+            try:
+                total += os.path.getsize(os.path.join(root, fn))
+            except OSError:
+                pass
+    return total
+
+
+def _bundled_dest() -> str:
+    return os.path.join(MODELS_DIR, BUNDLED_LOCAL_MODEL.split("/")[-1])
+
+
+def download_status() -> Dict[str, Any]:
+    with _DL_LOCK:
+        st = dict(_DL)
+    if st["state"] == "running" and st["dest"]:
+        st["bytes"] = _dir_bytes(st["dest"])
+    st["approx_bytes"] = BUNDLED_APPROX_BYTES
+    st["percent"] = min(99, int(100 * st["bytes"] / BUNDLED_APPROX_BYTES)) if st["state"] == "running" else (100 if st["state"] == "done" else 0)
+    return st
+
+
+def start_download(fetch=None) -> Dict[str, Any]:
+    """Begin downloading the bundled LLM into ~/.codec/models in a thread.
+
+    `fetch` is injectable so tests never touch the network. Refuses to start a
+    second download while one runs, and refuses if the weights already exist.
+    """
+    dest = _bundled_dest()
+    # Order matters: a download in flight has already written real bytes, so
+    # the weights check would call a half-finished download "already
+    # downloaded" and a second click would be refused for the wrong reason.
+    with _DL_LOCK:
+        if _DL["state"] == "running":
+            return {"ok": False, "error": "a download is already running"}
+        if _dir_has_weights(dest):
+            return {"ok": False, "error": "already downloaded", "dest": dest}
+        _DL.update(state="running", bytes=0, error="", dest=dest, started=time.time())
+
+    def _work():
+        try:
+            os.makedirs(dest, exist_ok=True)
+            if fetch is not None:
+                fetch(BUNDLED_LOCAL_MODEL, dest)
+            else:
+                from huggingface_hub import snapshot_download
+                snapshot_download(repo_id=BUNDLED_LOCAL_MODEL, local_dir=dest)
+            if not _dir_has_weights(dest):
+                raise RuntimeError("download finished but no weights were written")
+            with _DL_LOCK:
+                _DL.update(state="done", bytes=_dir_bytes(dest))
+        except Exception as e:  # report, never hang the screen
+            with _DL_LOCK:
+                _DL.update(state="error", error=f"{type(e).__name__}: {e}"[:300])
+
+    threading.Thread(target=_work, daemon=True, name="codec-model-download").start()
+    return {"ok": True, "dest": dest, "approx_bytes": BUNDLED_APPROX_BYTES}

--- a/packaging/macos/build_app.sh
+++ b/packaging/macos/build_app.sh
@@ -132,6 +132,11 @@ find "$REPO" -maxdepth 1 -name '*.py' -exec cp {} "$CONTENTS/Resources/app/" \;
 for d in routes skills; do
     [ -d "$REPO/$d" ] && cp -R "$REPO/$d" "$CONTENTS/Resources/app/$d"
 done
+# The model-server launcher. services.json runs `bash scripts/start_model_server.sh`
+# from Resources/app; without this copy the qwen3.6 service has nothing to run.
+mkdir -p "$CONTENTS/Resources/app/scripts"
+cp "$REPO/scripts/start_model_server.sh" "$CONTENTS/Resources/app/scripts/"
+chmod +x "$CONTENTS/Resources/app/scripts/start_model_server.sh"
 # runtime assets the app needs
 for f in requirements.txt ecosystem.config.js codec_dashboard.html VERSION; do
     [ -f "$REPO/$f" ] && cp "$REPO/$f" "$CONTENTS/Resources/app/$f"

--- a/packaging/macos/verify/dmg_has_mlx.mjs
+++ b/packaging/macos/verify/dmg_has_mlx.mjs
@@ -1,0 +1,22 @@
+// G7: the DMG is notarized+stapled and its bundled app can import mlx_vlm.
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+const dmg = `${homedir()}/ava-stack/installer-gui/dist/CODEC-Installer.dmg`;
+const sh = (c) => execFileSync("/bin/bash", ["-c", c], { encoding: "utf8" });
+const fail = []; let mount = "";
+try {
+  if (!existsSync(dmg)) throw new Error("no DMG");
+  const st = spawnSync("xcrun", ["stapler", "validate", dmg], { encoding: "utf8" });
+  if (!/The validate action worked/.test((st.stdout || "") + (st.stderr || ""))) fail.push("DMG is not stapled");
+  const sp = spawnSync("spctl", ["-a", "-t", "open", "--context", "context:primary-signature", "-vv", dmg], { encoding: "utf8" });
+  if (!/accepted/.test((sp.stdout || "") + (sp.stderr || ""))) fail.push("Gatekeeper rejects the DMG");
+  mount = (sh(`hdiutil attach ${JSON.stringify(dmg)} -nobrowse -readonly`).match(/\/Volumes\/[^\n]*/) || [""])[0].trim();
+  const py = `${mount}/Sovereign AI Workstation.app/Contents/Resources/python/bin/python3`;
+  if (!existsSync(py)) fail.push("bundled app has no interpreter");
+  else { const r = spawnSync(py, ["-B", "-c", "import mlx_vlm"], { env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" } }); if (r.status !== 0) fail.push("app in the DMG cannot import mlx_vlm"); }
+  if (!existsSync(`${mount}/Sovereign AI Workstation.app/Contents/Resources/app/scripts/start_model_server.sh`)) fail.push("start_model_server.sh missing from the shipped app");
+} catch (e) { fail.push(e.message); }
+finally { if (mount) { try { sh(`hdiutil detach ${JSON.stringify(mount)} -quiet`); } catch {} } }
+if (fail.length) { console.error("G7 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }
+console.log("UNLAZY-G7-PASS");

--- a/packaging/macos/verify/mlx_bundle.mjs
+++ b/packaging/macos/verify/mlx_bundle.mjs
@@ -1,0 +1,20 @@
+// G1: the bundled interpreter can serve MLX, and the dependency is marker-gated.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+const repo = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+const fail = [];
+const req = readFileSync(join(repo, "requirements.txt"), "utf8");
+const line = req.split("\n").find(l => /^mlx-vlm/.test(l.trim()));
+if (!line) fail.push("mlx-vlm is not a declared dependency");
+else if (!/sys_platform\s*==\s*"darwin"/.test(line) || !/platform_machine\s*==\s*"arm64"/.test(line))
+  fail.push("mlx-vlm is not marker-gated to darwin/arm64 — Linux CI would fail to install it");
+const py = join(repo, "dist/Sovereign AI Workstation.app/Contents/Resources/python/bin/python3");
+if (!existsSync(py)) fail.push("app not built — no bundled interpreter to test");
+else for (const m of ["mlx_vlm", "mlx", "mlx_lm", "huggingface_hub"]) {
+  try { execFileSync(py, ["-B", "-c", `import ${m}`], { stdio: "pipe", env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" } }); }
+  catch { fail.push(`bundled python cannot import ${m}`); }
+}
+if (fail.length) { console.error("G1 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }
+console.log("UNLAZY-G1-PASS");

--- a/packaging/macos/verify/mlx_bundle.mjs
+++ b/packaging/macos/verify/mlx_bundle.mjs
@@ -12,7 +12,11 @@ else if (!/sys_platform\s*==\s*"darwin"/.test(line) || !/platform_machine\s*==\s
   fail.push("mlx-vlm is not marker-gated to darwin/arm64 — Linux CI would fail to install it");
 const py = join(repo, "dist/Sovereign AI Workstation.app/Contents/Resources/python/bin/python3");
 if (!existsSync(py)) fail.push("app not built — no bundled interpreter to test");
-else for (const m of ["mlx_vlm", "mlx", "mlx_lm", "huggingface_hub"]) {
+else // mlx_lm is NOT a dependency of the serving path (mlx-vlm does not pull it;
+// the e2e reached the chat template without it). jinja2 IS — transformers'
+// chat template needs it and does not declare it; without it the server
+// listens and then fails every completion.
+for (const m of ["mlx_vlm", "mlx", "huggingface_hub", "jinja2"]) {
   try { execFileSync(py, ["-B", "-c", `import ${m}`], { stdio: "pipe", env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" } }); }
   catch { fail.push(`bundled python cannot import ${m}`); }
 }

--- a/packaging/macos/verify/model_server_e2e.mjs
+++ b/packaging/macos/verify/model_server_e2e.mjs
@@ -1,0 +1,36 @@
+// G3: the bundled stack serves a real model. Uses a small model already on the
+// build machine and a port PM2 does not own; asserts the serving process is the
+// BUNDLED python by path, so the developer's server cannot answer for it.
+import { spawn, execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createConnection } from "node:net";
+const repo = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+const py = join(repo, "dist/Sovereign AI Workstation.app/Contents/Resources/python/bin/python3");
+const MODEL = "mlx-community/Qwen3-4B-4bit";
+const PORT = 8098;
+const listening = (port) => new Promise((res) => { const s = createConnection({ host: "127.0.0.1", port }, () => { s.end(); res(true); }); s.on("error", () => res(false)); setTimeout(() => { s.destroy(); res(false); }, 1500); });
+const fail = []; let child;
+try {
+  if (!existsSync(py)) throw new Error("app not built");
+  if (!existsSync(join(homedir(), ".cache/huggingface/hub/models--mlx-community--Qwen3-4B-4bit"))) throw new Error(`${MODEL} not on this machine — cannot run the e2e`);
+  if (await listening(PORT)) throw new Error(`port ${PORT} busy — cannot prove the bundle served it`);
+  child = spawn(py, ["-B", "-m", "mlx_vlm.server", "--model", MODEL, "--port", String(PORT), "--host", "127.0.0.1"],
+                { env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1", HF_HUB_OFFLINE: "1" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", d => log += d); child.stderr.on("data", d => log += d);
+  const deadline = Date.now() + 240000; let up = false;
+  while (Date.now() < deadline) { if (child.exitCode !== null) break; if (await listening(PORT)) { up = true; break; } await new Promise(r => setTimeout(r, 2000)); }
+  if (!up) throw new Error("bundled model server never listened: " + log.split("\n").filter(l => /rror|Traceback/.test(l)).slice(-3).join(" | "));
+  const who = execFileSync("ps", ["-o", "command=", "-p", String(child.pid)], { encoding: "utf8" });
+  if (!who.includes("/Contents/Resources/python/bin/python3")) throw new Error("serving process is not the bundled interpreter: " + who.trim().slice(0, 120));
+  const body = JSON.stringify({ model: MODEL, messages: [{ role: "user", content: "Reply with the single word READY" }], max_tokens: 8 });
+  const reply = execFileSync("curl", ["-s", "-m", "120", "-X", "POST", `http://127.0.0.1:${PORT}/v1/chat/completions`, "-H", "Content-Type: application/json", "-d", body], { encoding: "utf8" });
+  const j = JSON.parse(reply); const text = j?.choices?.[0]?.message?.content ?? "";
+  if (!text) throw new Error("no completion from the bundled server: " + reply.slice(0, 200));
+  console.log(`  bundled server answered: ${text.trim().slice(0, 40)}`);
+} catch (e) { fail.push(e.message); }
+finally { if (child && child.exitCode === null) { try { child.kill("SIGKILL"); } catch {} } }
+if (fail.length) { console.error("G3 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }
+console.log("UNLAZY-G3-PASS");

--- a/packaging/macos/verify/model_server_script.mjs
+++ b/packaging/macos/verify/model_server_script.mjs
@@ -1,0 +1,28 @@
+// G2: the launcher script ships in the bundle and resolves to the BUNDLED
+// interpreter when no developer venv exists. Exercised by running it with a
+// fake HOME (no ~/codec-qwen38-venv) and a dry `python -c` stand-in via
+// CODEC_MODEL_VENV unset, capturing the "python=" line it logs.
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+const repo = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+const app = join(repo, "dist/Sovereign AI Workstation.app");
+const script = join(app, "Contents/Resources/app/scripts/start_model_server.sh");
+const fail = [];
+if (!existsSync(script)) fail.push("start_model_server.sh is not in the bundle — the qwen3.6 service has nothing to run");
+else {
+  const fakeHome = mkdtempSync(join(tmpdir(), "nohome-"));
+  // Replace the final exec with an echo so we see which interpreter it chose
+  // without actually starting a 4 GB model server.
+  const probe = `sed 's|^exec "\\$PY" .*|echo "CHOSEN=$PY"|' ${JSON.stringify(script)} > /tmp/sms_probe.sh && bash /tmp/sms_probe.sh`;
+  let out = "";
+  try { out = execFileSync("/bin/bash", ["-c", probe], { encoding: "utf8", env: { HOME: fakeHome, PATH: "/usr/bin:/bin", CODEC_CONFIG: "/nonexistent" }, stdio: ["ignore", "pipe", "pipe"] }); }
+  catch (e) { out = (e.stdout || "") + (e.stderr || ""); }
+  const m = out.match(/CHOSEN=(.+)/);
+  if (!m) fail.push("could not determine the chosen interpreter: " + out.slice(0, 200));
+  else if (!m[1].includes("/Contents/Resources/python/bin/python3")) fail.push(`with no dev venv, chose ${m[1]} instead of the bundled interpreter`);
+}
+if (fail.length) { console.error("G2 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }
+console.log("UNLAZY-G2-PASS");

--- a/packaging/macos/verify/model_server_script.mjs
+++ b/packaging/macos/verify/model_server_script.mjs
@@ -15,8 +15,13 @@ if (!existsSync(script)) fail.push("start_model_server.sh is not in the bundle â
 else {
   const fakeHome = mkdtempSync(join(tmpdir(), "nohome-"));
   // Replace the final exec with an echo so we see which interpreter it chose
-  // without actually starting a 4 GB model server.
-  const probe = `sed 's|^exec "\\$PY" .*|echo "CHOSEN=$PY"|' ${JSON.stringify(script)} > /tmp/sms_probe.sh && bash /tmp/sms_probe.sh`;
+  // without starting a 4 GB model server. The probe copy must live in the SAME
+  // directory as the script: it resolves the bundled interpreter relative to
+  // its own location, so a copy in /tmp would look for /tmp/../../python and
+  // fall through to the system python â€” which is what the first version of
+  // this gate did, and it blamed the script for the gate's own mistake.
+  const probePath = join(dirname(script), ".sms_probe.sh");
+  const probe = `sed 's|^exec "\\$PY" .*|echo "CHOSEN=$PY"|' ${JSON.stringify(script)} > ${JSON.stringify(probePath)} && bash ${JSON.stringify(probePath)}; rm -f ${JSON.stringify(probePath)}`;
   let out = "";
   try { out = execFileSync("/bin/bash", ["-c", probe], { encoding: "utf8", env: { HOME: fakeHome, PATH: "/usr/bin:/bin", CODEC_CONFIG: "/nonexistent" }, stdio: ["ignore", "pipe", "pipe"] }); }
   catch (e) { out = (e.stdout || "") + (e.stderr || ""); }

--- a/packaging/macos/verify/model_server_script.mjs
+++ b/packaging/macos/verify/model_server_script.mjs
@@ -5,7 +5,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 const repo = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
 const app = join(repo, "dist/Sovereign AI Workstation.app");
@@ -27,7 +27,11 @@ else {
   catch (e) { out = (e.stdout || "") + (e.stderr || ""); }
   const m = out.match(/CHOSEN=(.+)/);
   if (!m) fail.push("could not determine the chosen interpreter: " + out.slice(0, 200));
-  else if (!m[1].includes("/Contents/Resources/python/bin/python3")) fail.push(`with no dev venv, chose ${m[1]} instead of the bundled interpreter`);
+  // Resolve before comparing: the script reaches the interpreter via
+  // scripts/../../python, which is correct and does not contain the literal
+  // "Resources/python" until normalised. The first version of this gate failed
+  // the right answer on a string-match technicality.
+  else if (!resolve(m[1].trim()).endsWith("/Contents/Resources/python/bin/python3")) fail.push(`with no dev venv, chose ${m[1]} instead of the bundled interpreter`);
 }
 if (fail.length) { console.error("G2 FAILED:\n - " + fail.join("\n - ")); process.exit(1); }
 console.log("UNLAZY-G2-PASS");

--- a/packaging/macos/verify/suite_no_new_failures.mjs
+++ b/packaging/macos/verify/suite_no_new_failures.mjs
@@ -17,4 +17,7 @@ if (novel.length) {
   process.exit(1);
 }
 console.log(`${failing.length} failing, all pre-existing and documented`);
-console.log("UNLAZY-G8-PASS");
+// Ledger-independent token: this verifier is reused across ledgers where it
+// sits at different gate numbers. Printing "G8" made a G6 gate fail on a token
+// mismatch while the suite was clean.
+console.log("UNLAZY-SUITE-NO-NEW-FAILURES");

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,14 @@ argon2-cffi>=25.1.0
 fastapi>=0.115.0
 uvicorn>=0.35.0
 
+# The local model server. A buyer's Mac has no venv of ours, so the bundled
+# interpreter must be able to run `mlx_vlm.server` itself — otherwise "Use the
+# local model" is an option that cannot work. Marker-gated: MLX exists only for
+# Apple Silicon, and Linux CI would fail to resolve it. Pulls mlx, mlx-lm,
+# transformers and huggingface_hub (which fetch_models.py also needs).
+# Accepted cost (operator, 2026-09-04): the app grows from ~273 MB to ~1.2 GB.
+mlx-vlm>=0.6.13; sys_platform == "darwin" and platform_machine == "arm64"
+
 # Optional: STT (Whisper via MLX)
 # mlx-whisper
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,11 @@ uvicorn>=0.35.0
 # transformers and huggingface_hub (which fetch_models.py also needs).
 # Accepted cost (operator, 2026-09-04): the app grows from ~273 MB to ~1.2 GB.
 mlx-vlm>=0.6.13; sys_platform == "darwin" and platform_machine == "arm64"
+# transformers' apply_chat_template needs jinja2 and does NOT pull it in. The
+# bundled server started, listened, and then failed every completion with
+# "apply_chat_template requires jinja2" — caught only by the end-to-end gate
+# that asks the bundled server a real question. Pure Python, tiny, unconditional.
+jinja2>=3.1
 
 # Optional: STT (Whisper via MLX)
 # mlx-whisper

--- a/routes/setup.py
+++ b/routes/setup.py
@@ -46,3 +46,15 @@ async def verify():
 async def local_models():
     return {"models": codec_setup.discover_local_models(),
             "bundled": codec_setup.BUNDLED_LOCAL_MODEL}
+
+
+@router.post("/api/setup/download_local")
+async def download_local():
+    """Fetch the bundled local model into ~/.codec/models, in the background."""
+    result = codec_setup.start_download()
+    return JSONResponse(result, status_code=200 if result.get("ok") else 409)
+
+
+@router.get("/api/setup/download_status")
+async def download_status():
+    return codec_setup.download_status()

--- a/scripts/start_model_server.sh
+++ b/scripts/start_model_server.sh
@@ -50,12 +50,28 @@ PY
 [ -n "${MODEL:-}" ] || MODEL="$DEFAULT_MODEL"
 [ -n "${PORT:-}" ] || PORT="$DEFAULT_PORT"
 
-if [ -f "$VENV/bin/activate" ]; then
-  # shellcheck disable=SC1091
-  source "$VENV/bin/activate"
+# Interpreter resolution, in order:
+#   1. CODEC_MODEL_VENV        — explicit override (dev / CI)
+#   2. the app's bundled Python — when this script ships inside the .app at
+#      Contents/Resources/app/scripts/, the interpreter with mlx_vlm is at
+#      Contents/Resources/python/bin/python3. A buyer's Mac has nothing else.
+#   3. ~/codec-qwen38-venv     — the developer machine
+#   4. system python3          — last resort, will almost certainly lack mlx_vlm
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BUNDLED_PY="$HERE/../../python/bin/python3"
+PY=""
+if [ -n "${CODEC_MODEL_VENV:-}" ] && [ -x "$CODEC_MODEL_VENV/bin/python" ]; then
+  PY="$CODEC_MODEL_VENV/bin/python"
+elif [ -x "$BUNDLED_PY" ]; then
+  PY="$BUNDLED_PY"
+elif [ -x "$VENV/bin/python" ]; then
+  PY="$VENV/bin/python"
 else
-  echo "start_model_server: venv not found at $VENV — using system python3" >&2
+  PY="$(command -v python3)"
+  echo "start_model_server: no venv and no bundled interpreter — using $PY" >&2
 fi
 
-echo "start_model_server: model=$MODEL port=$PORT host=$HOST" >&2
-exec python -m mlx_vlm.server --model "$MODEL" --port "$PORT" --host "$HOST"
+# Never write .pyc into a signed bundle; it invalidates the code signature.
+export PYTHONDONTWRITEBYTECODE=1
+echo "start_model_server: python=$PY model=$MODEL port=$PORT host=$HOST" >&2
+exec "$PY" -m mlx_vlm.server --model "$MODEL" --port "$PORT" --host "$HOST"

--- a/tests/test_a12_invariant.py
+++ b/tests/test_a12_invariant.py
@@ -34,7 +34,11 @@ _ALLOWLIST = {
 }
 
 _INLINE_POST_RE = re.compile(r"\.post\s*\([^)]*chat/completions")
-_SKIP_PREFIXES = ("tests/", ".claude/", "scripts/")
+# dist/ and .build/ hold BUILT output: bundled copies of these same files plus
+# third-party site-packages (mlx_vlm, transformers) that legitimately POST to
+# chat/completions. Scanning them reports the repo twice and every dependency
+# once, the moment anyone builds the app locally and runs pytest.
+_SKIP_PREFIXES = ("tests/", ".claude/", "scripts/", "dist/", ".build/", "node_modules/")
 
 
 def _scan(root: Path) -> set:

--- a/tests/test_local_model_bundle.py
+++ b/tests/test_local_model_bundle.py
@@ -1,0 +1,118 @@
+"""A buyer can get a local model without a terminal, and the app can serve it.
+
+Three things made "Use the local model" impossible on a fresh Mac: the bundled
+Python had no mlx_vlm, the model-server script was not in the bundle and named
+the developer's venv, and first_run ran fetch_models as a DRY RUN so the
+"bundled" 4.3 GB LLM never arrived. The first two are verified by the Node
+gates against the built app; this file covers the download and discovery path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+import codec_setup  # noqa: E402
+
+
+@pytest.fixture
+def iso(tmp_path, monkeypatch):
+    monkeypatch.setattr(codec_setup, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(codec_setup, "HF_CACHE", str(tmp_path / "hf"))
+    monkeypatch.setattr(codec_setup, "MODELS_DIR", str(tmp_path / "models"))
+    monkeypatch.setattr(codec_setup, "_store_key", lambda k: None)
+    import codec_models
+    monkeypatch.setattr(codec_models, "restart_server", lambda *a, **k: (False, "test"))
+    # reset module download state between tests
+    with codec_setup._DL_LOCK:
+        codec_setup._DL.update(state="idle", bytes=0, error="", dest="", started=0.0)
+    (tmp_path / "config.json").write_text("{}")
+    return tmp_path
+
+
+def _fake_weights(dest: str, mb: int = 600):
+    os.makedirs(dest, exist_ok=True)
+    with open(os.path.join(dest, "model.safetensors"), "wb") as f:
+        f.seek(mb * 1024 * 1024 - 1); f.write(b"\0")
+
+
+def _wait(pred, timeout=5.0):
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        if pred():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+# ── G4 ───────────────────────────────────────────────────────────────────────
+
+def test_download_progress_duplicates_and_failure(iso, capsys):
+    gate = threading.Event()
+    def slow_fetch(repo, dest):
+        _fake_weights(dest, mb=550)
+        gate.wait(5)   # hold "running" so we can observe it
+    r = codec_setup.start_download(fetch=slow_fetch)
+    assert r["ok"] and r["dest"].endswith("Qwen2.5-7B-Instruct-4bit")
+
+    assert _wait(lambda: codec_setup.download_status()["bytes"] > 0), "progress never reported"
+    st = codec_setup.download_status()
+    assert st["state"] == "running" and 0 < st["percent"] < 100, st
+
+    dup = codec_setup.start_download(fetch=slow_fetch)
+    assert dup["ok"] is False and "already running" in dup["error"]
+
+    gate.set()
+    assert _wait(lambda: codec_setup.download_status()["state"] == "done"), codec_setup.download_status()
+    assert codec_setup.download_status()["percent"] == 100
+
+    again = codec_setup.start_download(fetch=slow_fetch)
+    assert again["ok"] is False and "already downloaded" in again["error"], "re-download of present weights"
+
+    # A failing fetch must report, not hang.
+    with codec_setup._DL_LOCK:
+        codec_setup._DL.update(state="idle")
+    import shutil; shutil.rmtree(codec_setup._bundled_dest())
+    def bad_fetch(repo, dest): raise RuntimeError("network down")
+    assert codec_setup.start_download(fetch=bad_fetch)["ok"]
+    assert _wait(lambda: codec_setup.download_status()["state"] == "error")
+    assert "network down" in codec_setup.download_status()["error"]
+
+    # And a fetch that "succeeds" without writing weights is a failure too.
+    with codec_setup._DL_LOCK:
+        codec_setup._DL.update(state="idle")
+    def empty_fetch(repo, dest): pass
+    assert codec_setup.start_download(fetch=empty_fetch)["ok"]
+    assert _wait(lambda: codec_setup.download_status()["state"] == "error")
+    assert "no weights" in codec_setup.download_status()["error"]
+    print("UNLAZY-G4-PASS")
+
+
+# ── G5 ───────────────────────────────────────────────────────────────────────
+
+def test_discovered_after_download_and_selectable(iso, capsys):
+    assert codec_setup.discover_local_models() == [], "must start empty"
+    assert codec_setup.start_download(fetch=lambda repo, dest: _fake_weights(dest))["ok"]
+    assert _wait(lambda: codec_setup.download_status()["state"] == "done")
+
+    found = codec_setup.discover_local_models()
+    assert len(found) == 1 and found[0]["source"] == "codec_models_dir", found
+    dest = found[0]["id"]
+
+    r = codec_setup.set_provider("local", model=dest)
+    assert r["ok"]
+    cfg = json.loads(Path(codec_setup.CONFIG_PATH).read_text())
+    assert cfg["llm_model"] == dest and cfg["llm_base_url"] == codec_setup.LOCAL_BASE_URL
+    # And status offers it in the picker, un-verified until a real reply.
+    st = codec_setup.status()
+    assert any(m["id"] == dest for m in st["local_models"]) and st["connected"] is False
+    print("UNLAZY-G5-PASS")


### PR DESCRIPTION
## Why

The connect screen offered a local model that could not exist on a fresh Mac. Three independent reasons, each fatal:

1. The bundled Python had **no `mlx_vlm`** — nothing to serve a model with.
2. `scripts/start_model_server.sh` **wasn't in the bundle**, and hardcoded `~/codec-qwen38-venv`, which only the developer's machine has.
3. `first_run.py` ran `fetch_models` **without `--yes`** — a dry run. The "bundled" 4.3 GB LLM was never downloaded.

Operator decision (2026-09-04): accept the bundle growing for the best first-run experience. It landed at **900 MB** notarized, vs the 1.2 GB estimate.

## What changed

- `requirements.txt`: `mlx-vlm` gated to `darwin`/`arm64` so Linux CI never tries to resolve it; `jinja2` unconditionally (see below).
- `start_model_server.sh` resolves, in order: `CODEC_MODEL_VENV` → the app's own `Resources/python` → the dev venv → system. Sets `PYTHONDONTWRITEBYTECODE` so it can't corrupt the signed bundle.
- `build_app.sh` ships the script into `Resources/app/scripts/`, where `services.json` already expects it.
- The connect screen gets a **Download the local model** button with live GB/percent progress (`/api/setup/download_local`, `/api/setup/download_status`). Refuses a duplicate, refuses re-downloading present weights, reports failure honestly — including a fetch that "succeeds" without writing weights.
- A downloaded model is discovered and selectable immediately.

## What the gates caught

**`jinja2` was missing.** The bundled server started, listened, and then failed every completion: `apply_chat_template requires jinja2`. `transformers` does not declare it. Only the end-to-end gate — which asks the *bundled* interpreter for a real completion on a port PM2 doesn't own — found it. Confirmed by installing jinja2 into the built bundle and getting `READY` back, then rebuilt properly.

**A download-ordering bug.** `start_download` checked for existing weights *before* checking for a running download, so a half-finished download (≥500 MB on disk) would have been refused as "already downloaded". The G4 test's realistic fixture caught it.

**Three of my own gates were wrong** and were corrected rather than the code: G1 required `mlx_lm` (not on the serving path); G2's probe copy ran from `/tmp` and blamed the script for its own relocation; G2 then failed the *correct* answer on an un-normalised path string.

**A pre-existing test bug:** `test_a12_invariant` scanned `dist/` and reported the bundled copies of the repo plus every third-party server as offenders the moment anyone builds locally. Walker now skips build output.

## Evidence

`G3: bundled server answered: READY` — from `Contents/Resources/python/bin/python3`, asserted by process path. Seven gates; G7 (DMG notarized + bundles the MLX-capable app) is added on the follow-up commit once the DMG returns from Apple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)