### PR TITLE
fix(audit): route-level events go through the signed envelope, never plaintext

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -33,7 +33,8 @@ restarted with both webhook guards live. Installed on this Mac from the notarize
 1. `_fleet_loaded()` counts the app's own LS registration; `_bootstrap_fleet` bypasses the
    ephemeral guard. On a buyer's Mac the first launch WILL install 14 LaunchAgents — untested
    end-to-end on clean hardware. **Mac Air test is the gate before the Buy button.**
-2. Auth route writes unsigned lines into the HMAC audit log (known-issues).
+2. ~~Auth route writes unsigned lines into the HMAC audit log~~ — RESOLVED 2026-09-05
+   (routes/_shared._audit_event; 10 call sites; legacy shim can no longer write plaintext).
 3. Demo narration script.
 
 ---

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -187,6 +187,12 @@ regenerate `skills/.manifest.json`, or delete both files.
 
 ## Auth routes write unsigned plaintext into the HMAC-signed audit log (2026-08-21)
 
+**RESOLVED 2026-09-05:** `routes/_shared._audit_event` routes every route-level audit
+through `codec_audit.audit()` (HMAC, redaction, JSON). All 10 call sites (auth 8, media,
+vision) converted; `_audit_write` survives only as a shim that converts a legacy string
+into an envelope line, so plaintext can never reach the log again. The live log had
+rotated by then: `verify_audit_log()` → integrity_ok=True.
+
 `routes/_shared._audit_write` appends raw strings straight to `~/.codec/audit.log`,
 bypassing `codec_audit.audit()` and therefore the whole PR-2E envelope — no HMAC,
 no secret redaction, no JSON. Nine call sites in `routes/auth.py`, all

--- a/routes/_shared.py
+++ b/routes/_shared.py
@@ -38,15 +38,41 @@ def _get_skills_dir():
         return os.path.join(DASHBOARD_DIR, "skills")
 
 
-def _audit_write(line: str):
-    """Append to audit log with restricted permissions."""
-    os.makedirs(os.path.dirname(AUDIT_LOG), exist_ok=True)
-    with open(AUDIT_LOG, "a") as f:
-        f.write(line)
+def _audit_event(event: str, *, outcome: str = "ok", level: str | None = None,
+                 message: str | None = None, **fields) -> None:
+    """Emit a structured, HMAC-signed audit line via codec_audit.
+
+    Routes used to append raw f-strings straight to ~/.codec/audit.log,
+    bypassing the PR-2E envelope — no HMAC, no secret redaction, not even JSON.
+    Nine auth events (AUTH_SUCCESS, AUTH_FAILED, TOTP_*), the ones an intruder
+    would most want to edit, were the only UNSIGNED lines in the log, and they
+    made `verify_audit_log()` report the operator's own log as tampered
+    (broken_lines=2, integrity_ok=False on 2026-08-27). This is the only writer
+    routes may use.
+    """
+    # `error` / `error_type` are reserved top-level envelope fields; codec_audit
+    # refuses to accept them via extra, so route them to the real slots.
+    error = fields.pop("error", None)
+    error_type = fields.pop("error_type", None)
     try:
-        os.chmod(AUDIT_LOG, 0o600)
-    except OSError:
-        pass
+        from codec_audit import audit
+        audit(event=event, source="codec-dashboard", outcome=outcome, level=level,
+              message=message, error=str(error) if error is not None else None,
+              error_type=error_type,
+              extra={k: v for k, v in fields.items() if v is not None} or None)
+    except Exception:
+        logging.getLogger("codec.routes").warning("audit emit failed for %s", event)
+
+
+def _audit_write(line: str) -> None:
+    """DEPRECATED shim: legacy `[ts] KIND: detail` strings become envelope
+    lines. Kept so a missed or third-party caller can never append plaintext
+    to the signed log again; every in-repo caller uses _audit_event directly.
+    """
+    text = (line or "").strip()
+    kind, _, detail = text.partition(": ")
+    kind = kind.split("] ", 1)[-1].strip().lower() or "legacy_audit_line"
+    _audit_event(kind, detail=detail or None, legacy=True)
 
 
 # ── Notification helpers ──

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -20,7 +20,7 @@ from routes._shared import (
     AUTH_ENABLED, AUTH_SESSION_HOURS, AUTH_BINARY, AUTH_PIN_HASH, AUTH_COOKIE_NAME,
     _auth_sessions, _auth_lock, _e2e_keys,
     _is_auth_compiled, _is_totp_enabled, _verify_biometric_session,
-    _save_sessions, _save_e2e_keys, _audit_write, _pin_attempts,
+    _save_sessions, _save_e2e_keys, _audit_event, _pin_attempts,
 )
 
 router = APIRouter()
@@ -73,9 +73,9 @@ async def auth_verify(request: Request):
 
             try:
                 if result.get("authenticated"):
-                    _audit_write(f"[{datetime.now().isoformat()}] AUTH_SUCCESS: method={result.get('method')} ip={client_ip}\n")
+                    _audit_event("auth_success", method=result.get("method"), ip=client_ip)
                 else:
-                    _audit_write(f"[{datetime.now().isoformat()}] AUTH_FAILED: error={result.get('error')} ip={client_ip}\n")
+                    _audit_event("auth_failed", outcome="error", level="warning", error=result.get("error"), ip=client_ip)
             except Exception:
                 pass
 
@@ -140,9 +140,9 @@ async def auth_pin(request: Request):
     pin_ok = verify_pin(pin, AUTH_PIN_HASH)
     try:
         if pin_ok:
-            _audit_write(f"[{datetime.now().isoformat()}] AUTH_SUCCESS: method=pin ip={client_ip}\n")
+            _audit_event("auth_success", method="pin", ip=client_ip)
         else:
-            _audit_write(f"[{datetime.now().isoformat()}] AUTH_FAILED: method=pin error=wrong_pin ip={client_ip}\n")
+            _audit_event("auth_failed", outcome="error", level="warning", method="pin", error="wrong_pin", ip=client_ip)
     except Exception:
         pass
 
@@ -253,7 +253,7 @@ async def totp_confirm(request: Request):
                 sess = _auth_sessions.get(token)
                 if sess:
                     sess.pop("pending_totp_secret", None)
-        _audit_write(f"[{datetime.now().isoformat()}] TOTP_SETUP: 2FA enabled\n")
+        _audit_event("totp_enabled")
         return {"verified": True, "enabled": True, "message": "2FA enabled successfully"}
     return {"verified": False, "error": "Invalid code. Try again."}
 
@@ -282,9 +282,9 @@ async def totp_verify(request: Request):
             if pending_token in _auth_sessions:
                 _auth_sessions[pending_token]["totp_verified"] = True
                 _save_sessions()
-        _audit_write(f"[{datetime.now().isoformat()}] TOTP_SUCCESS: ip={client_ip}\n")
+        _audit_event("totp_success", ip=client_ip)
         return {"verified": True, "token": pending_token}
-    _audit_write(f"[{datetime.now().isoformat()}] TOTP_FAILED: ip={client_ip}\n")
+    _audit_event("totp_failed", outcome="error", level="warning", ip=client_ip)
     return {"verified": False, "error": "Invalid code"}
 
 
@@ -327,7 +327,7 @@ async def totp_disable(request: Request):
             session.pop("totp_verified", None)
         _save_sessions()
     client_ip = request.client.host if request.client else "unknown"
-    _audit_write(f"[{datetime.now().isoformat()}] TOTP_DISABLED: 2FA disabled by ip={client_ip}\n")
+    _audit_event("totp_disabled", level="warning", ip=client_ip)
     return {"disabled": True}
 
 

--- a/routes/media.py
+++ b/routes/media.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from fastapi import APIRouter, Request
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
-from routes._shared import CONFIG_PATH, _audit_write
+from routes._shared import CONFIG_PATH, _audit_event
 
 router = APIRouter()
 
@@ -72,7 +72,7 @@ async def webcam_capture(request: Request):
                 result["model"] = vision_model
             except Exception as e:
                 result["analysis_error"] = str(e)
-        _audit_write(f"[{datetime.now().isoformat()}] WEBCAM: {filename} analyze={analyze}\n")
+        _audit_event("webcam_capture", filename=filename, analyze=analyze)
         return result
     except Exception as e:
         return JSONResponse({"error": str(e)}, status_code=500)

--- a/routes/vision.py
+++ b/routes/vision.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from codec_audit import log_event
-from routes._shared import CONFIG_PATH, _audit_write, get_db
+from routes._shared import CONFIG_PATH, _audit_event, get_db
 
 router = APIRouter()
 log = logging.getLogger("codec_dashboard")
@@ -66,7 +66,7 @@ async def vision_analyze(request: Request):
         r = rq.post(f"{vision_url}/chat/completions", json=payload, headers=headers, timeout=120)
         data = r.json()
         answer = data["choices"][0]["message"]["content"].strip()
-        _audit_write(f"[{datetime.now().isoformat()}] VISION: {prompt[:100]}\n")
+        _audit_event("vision_request", prompt_len=len(prompt), prompt_preview=prompt[:100])
         log_event("chat_vision", "codec-dashboard",
                   f"Vision analysis: {prompt[:60]}",
                   extra={"prompt_preview": prompt[:200]})

--- a/tests/test_auth_audit_envelope.py
+++ b/tests/test_auth_audit_envelope.py
@@ -1,0 +1,67 @@
+"""Route-level audit events go through the HMAC-signed envelope, never plaintext.
+
+`routes/_shared._audit_write` used to append raw f-strings to ~/.codec/audit.log.
+Nine auth events were the only UNSIGNED lines in the log — precisely the ones an
+intruder would want to edit — and they made `verify_audit_log()` report the
+operator's own log as tampered. conftest isolates the audit path, so these
+tests write to a throwaway log and verify it the way the operator would.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+import codec_audit  # noqa: E402
+from routes import _shared  # noqa: E402
+
+
+def _lines():
+    p = Path(codec_audit._AUDIT_LOG)
+    return p.read_text().splitlines() if p.exists() else []
+
+
+def test_structured_event_is_signed_json_and_verifies():
+    before = len(_lines())
+    _shared._audit_event("auth_failed", outcome="error", level="warning",
+                         method="pin", error="wrong_pin", ip="203.0.113.7")
+    new = _lines()[before:]
+    assert len(new) == 1, f"expected exactly one line, got {new}"
+    rec = json.loads(new[0])                      # JSON, not "[ts] AUTH_FAILED: ..."
+    assert rec["event"] == "auth_failed" and rec["source"] == "codec-dashboard"
+    assert rec["extra"]["ip"] == "203.0.113.7" and rec["error"] == "wrong_pin"   # error is a top-level envelope field
+    assert re.fullmatch(r"[0-9a-f]{64}", rec.get("hmac", "")), "line is not HMAC-signed"
+    r = codec_audit.verify_audit_log()
+    assert r["broken_lines"] == 0 and r["integrity_ok"] is True, r
+
+
+def test_legacy_shim_never_writes_plaintext():
+    """A caller still using the old string API must land in the envelope."""
+    before = len(_lines())
+    _shared._audit_write("[2026-09-05T09:00:00] TOTP_SETUP: 2FA enabled\n")
+    new = _lines()[before:]
+    assert len(new) == 1
+    rec = json.loads(new[0])                      # would raise on the old raw line
+    assert rec["event"] == "totp_setup" and rec["extra"]["legacy"] is True
+    assert rec["extra"]["detail"] == "2FA enabled"
+    assert "hmac" in rec
+
+
+def test_no_route_writes_the_audit_log_directly():
+    """Lint: codec_audit is the only module allowed to open the audit log."""
+    offenders = []
+    for path in sorted((REPO / "routes").glob("*.py")):
+        src = path.read_text()
+        # Reading the log (the /audit viewer) is fine; WRITING it is not.
+        if re.search(r"open\(\s*AUDIT_LOG\s*,\s*['\"][aw]", src):
+            offenders.append(f"{path.name}: writes AUDIT_LOG directly")
+        if re.search(r'_audit_write\(\s*f"\[', src):
+            offenders.append(f"{path.name}: legacy plaintext audit call")
+    assert not offenders, offenders
+    # Positive control for the lint: the pattern it hunts must be detectable.
+    assert re.search(r'_audit_write\(\s*f"\[', '_audit_write(f"[{now}] X: y")')


### PR DESCRIPTION
routes/_shared._audit_write appended raw f-strings straight to
~/.codec/audit.log, bypassing the PR-2E envelope: no HMAC, no secret
redaction, not even JSON. Nine auth events — AUTH_SUCCESS, AUTH_FAILED,
TOTP_* with client IPs, exactly the lines an intruder would want to edit —
were the only UNSIGNED lines in the log, and they made verify_audit_log()
report the operator's own log as tampered (broken_lines=2, 2026-08-27).
The tamper detector was crying wolf at CODEC's own auth route.

_audit_event(event, outcome, level, message, **fields) now routes through
codec_audit.audit(); `error`/`error_type` map to the envelope's reserved
top-level slots, everything else to extra. All 10 call sites converted
(auth 8, media 1, vision 1). _audit_write survives only as a shim that turns
a legacy "[ts] KIND: detail" string into an envelope line, so a missed or
third-party caller can never append plaintext again.

Tests: a structured event is JSON with a 64-hex hmac and verify_audit_log()
reports integrity_ok; the legacy shim yields JSON, not raw text; a lint
fails any route that opens AUDIT_LOG for writing (reading, as the /audit
viewer does, stays allowed) or still uses the plaintext call shape.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
